### PR TITLE
Revert "Maid-1112 new put flow"

### DIFF
--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -251,13 +251,12 @@ impl Interface for TestNode {
         routing::node_interface::MethodCall::None
     }
     fn handle_put_response(&mut self, from_authority: Authority, from_address: NameType,
-                           response: Result<Vec<u8>, ResponseError>) -> MethodCall {
+                           response: Result<Vec<u8>, ResponseError>) {
         if response.is_ok() {
             println!("testing node shall not receive a put_response in case of success");
         } else {
             println!("testing node received error put_response from {}", from_address);
         }
-        MethodCall::None
     }
     fn handle_post_response(&mut self, from_authority: Authority, from_address: NameType,
                             response: Result<Vec<u8>, ResponseError>) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,6 @@ use std::fmt;
 pub enum ResponseError {
     NoData,
     InvalidRequest,
-    FailedToStoreData(Vec<u8>),
 }
 
 impl error::Error for ResponseError {
@@ -34,7 +33,6 @@ impl error::Error for ResponseError {
         match *self {
             ResponseError::NoData => "No Data",
             ResponseError::InvalidRequest => "Invalid request",
-            ResponseError::FailedToStoreData(_) => "Failed to store data",
         }
     }
     
@@ -48,7 +46,6 @@ impl fmt::Display for ResponseError {
         match *self {
             ResponseError::NoData => fmt::Display::fmt("ResponsError::NoData", f),
             ResponseError::InvalidRequest => fmt::Display::fmt("ResponsError::InvalidRequest", f),
-            ResponseError::FailedToStoreData(_) => fmt::Display::fmt("ResponsError::FailedToStoreData", f),
         }
     }
 }

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -28,7 +28,6 @@ pub enum MethodCall {
     Get { type_id: u64, name: NameType, },
     Post,
     Refresh { content: Box<Sendable>, },
-    SendOn { destination: NameType },
 }
 
 pub trait Interface : Sync + Send {
@@ -70,7 +69,7 @@ pub trait Interface : Sync + Send {
     fn handle_put_response(&mut self,
                            from_authority: Authority,
                            from_address: NameType,
-                           response: Result<Vec<u8>, ResponseError>) -> MethodCall;
+                           response: Result<Vec<u8>, ResponseError>);
 
     fn handle_post_response(&mut self,
                             from_authority: Authority,

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -409,8 +409,6 @@ impl<F> RoutingNode<F> where F: Interface {
                 node_interface::MethodCall::Refresh { content: x, } => self.refresh(x),
                 node_interface::MethodCall::Post => unimplemented!(),
                 node_interface::MethodCall::None => (),
-                // TODO
-                node_interface::MethodCall::SendOn { destination: _ } => unimplemented!(),
             }
         }
     }
@@ -876,7 +874,6 @@ impl<F> RoutingNode<F> where F: Interface {
         let put_data_response = try!(decode::<PutDataResponse>(&body));
         let from_authority = header.from_authority();
         let from = header.from();
-        // TODO: result verification
         self.mut_interface().handle_put_response(from_authority, from, put_data_response.data);
         Ok(())
     }
@@ -1219,7 +1216,7 @@ mod test {
             MethodCall::None
         }
         fn handle_put_response(&mut self, from_authority: Authority, from_address: NameType,
-                               response: Result<Vec<u8>, ResponseError>) -> MethodCall {
+                               response: Result<Vec<u8>, ResponseError>) {
             let stats = self.stats.clone();
             let mut stats_value = stats.lock().unwrap();
             stats_value.call_count += 1;
@@ -1227,7 +1224,6 @@ mod test {
                Ok(data) => data,
                 Err(_) => vec![]
             };
-            MethodCall::None
         }
         fn handle_post_response(&mut self, from_authority: Authority, from_address: NameType,
                                 response: Result<Vec<u8>, ResponseError>) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -451,7 +451,6 @@ impl Encodable for ResponseError {
         match *self {
             ResponseError::NoData => type_tag = "NoData",
             ResponseError::InvalidRequest => type_tag = "InvalidRequest",
-            ResponseError::FailedToStoreData(_) => type_tag = "FailedToStoreData",
         };
         CborTagEncode::new(5483_100, &(&type_tag)).encode(e)
     }


### PR DESCRIPTION
Reverts maidsafe/routing#284

The decoding and encoding of the error would lose the payload of the error message

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/285)
<!-- Reviewable:end -->
