### PR TITLE
Revert "add ResponseError::FailedToStoreData"

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,6 @@ use std::fmt;
 pub enum ResponseError {
     NoData,
     InvalidRequest,
-    FailedToStoreData(Vec<u8>),
 }
 
 impl error::Error for ResponseError {
@@ -34,7 +33,6 @@ impl error::Error for ResponseError {
         match *self {
             ResponseError::NoData => "No Data",
             ResponseError::InvalidRequest => "Invalid request",
-            ResponseError::FailedToStoreData(_) => "Failed to store data",
         }
     }
     
@@ -48,7 +46,6 @@ impl fmt::Display for ResponseError {
         match *self {
             ResponseError::NoData => fmt::Display::fmt("ResponsError::NoData", f),
             ResponseError::InvalidRequest => fmt::Display::fmt("ResponsError::InvalidRequest", f),
-            ResponseError::FailedToStoreData(_) => fmt::Display::fmt("ResponsError::FailedToStoreData", f),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -451,7 +451,6 @@ impl Encodable for ResponseError {
         match *self {
             ResponseError::NoData => type_tag = "NoData",
             ResponseError::InvalidRequest => type_tag = "InvalidRequest",
-            ResponseError::FailedToStoreData(_) => type_tag = "FailedToStoreData",
         };
         CborTagEncode::new(5483_100, &(&type_tag)).encode(e)
     }


### PR DESCRIPTION
Reverts maidsafe/routing#284

The decoding and encoding of the error would lose the payload of the error message

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/286)
<!-- Reviewable:end -->
