### PR TITLE
documenting MethodCall, RoutingError, Interface traits

### DIFF
--- a/src/client_interface.rs
+++ b/src/client_interface.rs
@@ -18,11 +18,16 @@
 use types::MessageId;
 use error::ResponseError;
 
+#[deny(missing_docs)]
+/// The Interface trait introduces the methods expected to be implemented by the user
+/// of RoutingClient
 pub trait Interface : Sync + Send {
+    /// consumes data in response or handles the error
     fn handle_get_response(&mut self,
                            message_id: MessageId,
                            response: Result<Vec<u8>, ResponseError>);
 
+    /// handles the result of a put request
     fn handle_put_response(&mut self,
                            message_id: MessageId,
                            response: Result<Vec<u8>, ResponseError>);

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,20 +131,30 @@ impl fmt::Display for InterfaceError {
     }
 }
 
-
-
 //------------------------------------------------------------------------------
+#[deny(missing_docs)]
 #[derive(Debug)]
+/// Represents routing error types
 pub enum RoutingError {
+    /// invalid requester or handler authorities
     BadAuthority,
+    /// failure to connect to an already connected node
     AlreadyConnected,
+    /// received message having unknown type
     UnknownMessageType,
+    /// duplicate request received
     FilterCheckFailed,
+    /// failure to bootstrap off the provided endpoints
     FailedToBootstrap,
+    /// unexpected empty routing table
     RoutingTableEmpty,
+    /// interface error
     Interface(InterfaceError),
+    /// i/o error
     Io(io::Error),
+    /// serialisation error
     Cbor(CborError),
+    /// invalid response
     Response(ResponseError),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,10 +24,15 @@ use std::error;
 use std::fmt;
 
 //------------------------------------------------------------------------------
+#[deny(missing_docs)]
 #[derive(PartialEq, Eq, Clone, Debug)]
+/// represents response errors
 pub enum ResponseError {
+    /// data not found
     NoData,
+    /// invalid request
     InvalidRequest,
+    /// failure to store data
     FailedToStoreData(Vec<u8>)
 }
 

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -32,7 +32,7 @@ pub enum MethodCall {
     Get { type_id: u64, name: NameType, },
     /// request to post
     Post,
-    /// request to update
+    /// request to refresh
     Refresh { content: Box<Sendable>, },
     /// request to send on the request to destination
     SendOn { destination: NameType },

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -30,7 +30,7 @@ pub enum MethodCall {
     Put { destination: NameType, content: Box<Sendable>, },
     /// request to retreive data of particular type and name from network
     Get { type_id: u64, name: NameType, },
-    /// request to pot
+    /// request to post
     Post,
     /// request to update
     Refresh { content: Box<Sendable>, },

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -58,7 +58,7 @@ pub trait Interface : Sync + Send {
                   from_authority: Authority,
                   from_address: NameType) -> Result<MessageAction, InterfaceError>;
 
-    /// on success stores data or sends on request
+    /// success indicates store is done, or an address to store data is provided
     fn handle_put(&mut self,
                   our_authority: Authority,
                   from_authority: Authority,

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -54,7 +54,7 @@ pub trait Interface : Sync + Send {
 
     /// depending on our_authority and from_authority, data or address of the node
     /// potentially storing data with specified name and type_id is returned, on success.
-    /// failure to provide data or an address is indicated as an InterfaceError..
+    /// failure to provide data or an address is indicated as an InterfaceError.
     fn handle_get(&mut self,
                   type_id: u64,
                   name: NameType,

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -26,7 +26,7 @@ use error::{InterfaceError, ResponseError};
 pub enum MethodCall {
     /// request for no action
     None,
-    /// request to have `destination` NAE to handle put for the `content`
+    /// request to have `destination` to handle put for the `content`
     Put { destination: NameType, content: Box<Sendable>, },
     /// request to retreive data of particular type and name from network
     Get { type_id: u64, name: NameType, },
@@ -58,7 +58,7 @@ pub trait Interface : Sync + Send {
                   from_authority: Authority,
                   from_address: NameType) -> Result<MessageAction, InterfaceError>;
 
-    /// attempts to store data. The return value can contain the original data
+    /// on success stores data or sends on request
     fn handle_put(&mut self,
                   our_authority: Authority,
                   from_authority: Authority,

--- a/src/node_interface.rs
+++ b/src/node_interface.rs
@@ -113,7 +113,8 @@ pub trait Interface : Sync + Send {
                         from_authority: Authority,
                         from_address: NameType) -> Result<MessageAction, InterfaceError>;
 
-    /// attempts to store data in cache.
+    /// attempts to store data in cache. The type of data and/or from_authority indicates
+    /// if store in cache is required.
     fn handle_cache_put(&mut self,
                         from_authority: Authority,
                         from_address: NameType,


### PR DESCRIPTION
#[deny(missing_docs)] on MethodCall results in error. But it is fine on other traits

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/294)
<!-- Reviewable:end -->
