### PR TITLE
Directly add to relay_map on connect_request

### DIFF
--- a/src/routing_node_new.rs
+++ b/src/routing_node_new.rs
@@ -140,9 +140,10 @@ impl<F, G> RoutingNode<F, G> where F : Interface + 'static,
         // CRUST bootstrap
         let bootstrapped_to = try!(cm.bootstrap(bootstrap_list, beacon_port)
             .map_err(|_|RoutingError::FailedToBootstrap));
-        println!("bootstrap {:?}", bootstrapped_to);
+        println!("BOOTSTRAP {:?}", bootstrapped_to);
+        println!("NODE listening on {:?}", listeners.0.first());
         self.bootstrap_endpoint = Some(bootstrapped_to.clone());
-        // cm.connect(vec![bootstrapped_to.clone()]);
+        cm.connect(vec![bootstrapped_to.clone()]);
         // allow CRUST to connect
         thread::sleep_ms(100);
 


### PR DESCRIPTION
Patch: on connect_request, directly add to relay_map - bypass the "remember public_id"
The assumption was that first a connect_request was received on our listening port, and when both sides 'connection_manager.connect' a 'CRUST::NewConnection' would be triggered.

Turns out that CRUST gives a new CRUST::NewConnection for every single sided connect, and the NewMessage comes after that, for a given endpoint.  This patch should do, but post-sprint this logic needs to be reworked.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/319)
<!-- Reviewable:end -->
