### PR TITLE
Issue 312

### DIFF
--- a/examples/simple_key_value_store.rs
+++ b/examples/simple_key_value_store.rs
@@ -406,12 +406,13 @@ fn run_interactive_node(bootstrap_peers: Option<Vec<Endpoint>>) {
     let mutate_client = Arc::new(Mutex::new(test_client));
     let copied_client = mutate_client.clone();
     let _ = spawn(move || {
+        let _ = copied_client.lock().unwrap().bootstrap(bootstrap_peers, None);
+        thread::sleep_ms(100);
         loop {
             thread::sleep_ms(10);
             copied_client.lock().unwrap().run();
         }
     });
-    let _ = mutate_client.lock().unwrap().bootstrap(bootstrap_peers, None);
     let ref mut command = String::new();
     let docopt: Docopt = Docopt::new(CLI_USAGE).unwrap_or_else(|error| error.exit());
     let mut stdin = io::stdin();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ mod frequency;
 mod routing_table;
 mod relay;
 mod utils;
+mod who_are_you;
 
 pub mod client_interface;
 pub mod node_interface;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -172,6 +172,11 @@ impl RelayMap {
         }
     }
 
+    /// Returns true if the endpoint has been registered as an unknown NewConnection
+    pub fn lookup_unknown_connection(&self, endpoint: &Endpoint) -> bool {
+        self.unknown_connections.contains_key(endpoint)
+    }
+
     /// Returns true if the relay map was instantiated with a self_relocated id.
     /// A self_relocated id should only be used by the first node to start a network.
     pub fn zero_node(&self) -> bool {

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -22,20 +22,22 @@
 //! These messages include bootstrap actions by starting nodes or relay messages for clients.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use lru_time_cache::LruCache;
-use time::{Duration};
+use time::{SteadyTime};
 use crust::Endpoint;
 use types::{Id, PublicId};
 use NameType;
 
-const MAX_RELAY : usize = 5;
+const MAX_RELAY : usize = 100;
 
 /// The relay map is used to maintain a list of contacts for whom
 /// we are relaying messages, when we are ourselves connected to the network.
 pub struct RelayMap {
     relay_map: BTreeMap<NameType, (PublicId, BTreeSet<Endpoint>)>,
     lookup_map: HashMap<Endpoint, NameType>,
-    accepted_connect_requests: LruCache<Endpoint, PublicId>,
+    // FIXME : we don't want to store a value; but LRUcache can clear itself out
+    // however, we want the explicit timestamp stored and clear it at routing,
+    // to drop the connection on clearing; for now CM will just keep all these connections
+    unknown_connections: HashMap<Endpoint, SteadyTime>,
     our_name: NameType,
     self_relocated: bool
 }
@@ -46,7 +48,7 @@ impl RelayMap {
         RelayMap {
             relay_map: BTreeMap::new(),
             lookup_map: HashMap::new(),
-            accepted_connect_requests: LruCache::with_expiry_duration(Duration::minutes(1)),
+            unknown_connections: HashMap::new(),
             our_name: our_id.get_name(),
             self_relocated: our_id.is_self_relocated()
         }
@@ -156,21 +158,18 @@ impl RelayMap {
         self.our_name = new_name.clone();
     }
 
-    /// On unknown connect request, register the PublicId we intended to connect to.
-    /// Only an unrelocated Id is accepted into the cache.
-    pub fn register_accepted_connect_request(&mut self, endpoints: &Vec<Endpoint>, public_id: &PublicId) {
-        // Note: consider whether we can reduce/remove this state-holder
-        // This should be possible with a connect success message.
-        if public_id.is_relocated() { return; }
-        for endpoint in endpoints {
-            self.accepted_connect_requests.add(endpoint.clone(), public_id.clone());
-        }
+    /// On unknown NewConnection, register the endpoint we are connected to.
+    pub fn register_unknown_connection(&mut self, endpoint: Endpoint) {
+        // TODO: later prune and drop old unknown connections
+        self.unknown_connections.insert(endpoint, SteadyTime::now());
     }
 
-    /// When we receive a new connection_event from CRUST we can pop the Id
-    /// and add it to the RelayMap
-    pub fn pop_accepted_connect_request(&mut self, endpoint: &Endpoint) -> Option<PublicId> {
-        self.accepted_connect_requests.remove(endpoint)
+    /// When we receive an "I am" message on this connection, drop it
+    pub fn remove_unknown_connection(&mut self, endpoint: &Endpoint) -> Option<Endpoint> {
+        match self.unknown_connections.remove(endpoint) {
+            Some(addded_timestamp) => Some(endpoint.clone()), // return the endpoint
+            None => None
+        }
     }
 
     /// Returns true if the relay map was instantiated with a self_relocated id.
@@ -281,4 +280,6 @@ mod test {
     }
 
     // TODO: add test for drop_endpoint
+
+    // TODO: add tests for unknown_connections
 }

--- a/src/routing_membrane.rs
+++ b/src/routing_membrane.rs
@@ -51,6 +51,7 @@ use sendable::Sendable;
 use types;
 use types::{MessageId, NameAndTypeId, Signature, Bytes, DestinationAddress};
 use authority::{Authority, our_authority};
+use who_are_you::{WhoAreYou};
 use message_header::MessageHeader;
 use messages::find_group::FindGroup;
 use messages::find_group_response::FindGroupResponse;
@@ -330,9 +331,9 @@ impl<F> RoutingMembrane<F> where F: Interface {
                 // again, already connected so examine later
             },
             None => {
-                self.relay_map.register_unknown_connection(endpoint);
+                self.relay_map.register_unknown_connection(endpoint.clone());
                 // Send "Who are you?" message
-                // self.connection_manager.send()
+                ignore(self.send_who_are_you_msg(endpoint));
             }
       }
     }
@@ -728,6 +729,12 @@ impl<F> RoutingMembrane<F> where F: Interface {
                 None => Err(RoutingError::FailedToBootstrap)
             }
         }
+    }
+
+    fn send_who_are_you_msg(&mut self, endpoint: Endpoint) -> RoutingResult {
+        let message = try!(encode(&WhoAreYou {nonce : 0u8}));
+        ignore(self.connection_manager.send(endpoint, message));
+        Ok(())
     }
 
     // -----Address and various functions----------------------------------------

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -160,42 +160,51 @@ impl<F, G> RoutingNode<F, G> where F : Interface + 'static,
         // FIXME: for now just write out explicitly in this function the bootstrapping loop
         // - fully check match of returned public id with ours
         // - break from loop if unsuccessful; no response; retry
+        // - this initial bootstrap should only use the WhoAreYou paradigm,
+        //   not the unknown_connect_request as currently used.
         println!("Waiting for responses from network");
         loop {
             match event_input.recv() {
-                Err(_) => (),
+                Err(_) => {},
                 Ok(crust::Event::NewMessage(endpoint, bytes)) => {
-                    let message = try!(decode::<RoutingMessage>(&bytes));
-                    match message.message_type {
-                        MessageTypeTag::ConnectResponse => {
-                            // for now, ignore the actual response message
-                            // bootstrap node responded, try to put our id to the network
-                            println!("Received connect response");
-                            let put_public_id_msg
-                                = self.construct_put_public_id_msg(
-                                &types::PublicId::new(&unrelocated_id));
-                            let serialised_message = try!(encode(&put_public_id_msg));
-                            debug_assert!(cm.send(bootstrapped_to.clone(), serialised_message)
-                                .is_ok());
+                    match decode::<RoutingMessage>(&bytes) {
+                        Ok(message) => {
+                            match message.message_type {
+                                MessageTypeTag::ConnectResponse => {
+                                    // for now, ignore the actual response message
+                                    // bootstrap node responded, try to put our id to the network
+                                    println!("Received connect response");
+                                    let put_public_id_msg
+                                        = self.construct_put_public_id_msg(
+                                        &types::PublicId::new(&unrelocated_id));
+                                    let serialised_message = try!(encode(&put_public_id_msg));
+                                    debug_assert!(cm.send(bootstrapped_to.clone(), serialised_message)
+                                        .is_ok());
+                                },
+                                MessageTypeTag::PutPublicIdResponse => {
+                                    println!("Received PutPublicId response");
+                                    let put_public_id_response =
+                                        try!(decode::<PutPublicIdResponse>(&message.serialised_body));
+                                    relocated_name = Some(put_public_id_response.public_id.name());
+                                    debug_assert!(put_public_id_response.public_id.is_relocated());
+                                    if put_public_id_response.public_id.validation_token
+                                        != self.id.get_validation_token() {
+                                        return Err(RoutingError::FailedToBootstrap); }
+                                    break;
+                                },
+                                _ => {
+                                    println!("Received unexpected message");
+                                }
+                            }
                         },
-                        MessageTypeTag::PutPublicIdResponse => {
-                            println!("Received PutPublicId response");
-                            let put_public_id_response =
-                                try!(decode::<PutPublicIdResponse>(&message.serialised_body));
-                            relocated_name = Some(put_public_id_response.public_id.name());
-                            debug_assert!(put_public_id_response.public_id.is_relocated());
-                            if put_public_id_response.public_id.validation_token
-                                != self.id.get_validation_token() {
-                                return Err(RoutingError::FailedToBootstrap); }
-                            break;
-                        },
-                        _ => {
-                            println!("Received unexpected message");
+                        Err(_) => {
+                            println!("Received non-RoutingMessage on {:?},
+                                presumably WhoAreYou; ignoring.", endpoint);
                         }
-                    }
+                    };
                 },
                 Ok(crust::Event::NewConnection(endpoint)) => {
-                    // FIXME: handle this; safe to ignore for now
+                    println!("NewConnection on {:?} while waiting on network.", endpoint);
                 },
                 Ok(crust::Event::LostConnection(endpoint)) => {
                     return Err(RoutingError::FailedToBootstrap);

--- a/src/who_are_you.rs
+++ b/src/who_are_you.rs
@@ -1,0 +1,67 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use cbor::CborTagEncode;
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use types::PublicId;
+use utils::decode;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct WhoAreYou {
+    nonce: u8  // FIXME: a placeholder for nonce
+}
+// TODO: add nonce to be signed for added security later
+
+impl Encodable for WhoAreYou {
+    fn encode<E: Encoder>(&self, encoder: &mut E)->Result<(), E::Error> {
+        CborTagEncode::new(5483_001, &(&self.nonce)).encode(encoder)
+    }
+}
+
+impl Decodable for WhoAreYou {
+    fn decode<D: Decoder>(decoder: &mut D)->Result<WhoAreYou, D::Error> {
+        try!(decoder.read_u64());
+        let nonce = try!(Decodable::decode(decoder));
+        Ok(WhoAreYou { nonce: nonce })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct IAm {
+    pub public_id: PublicId,
+    // FIXME: return signed nonce
+}
+
+impl Encodable for IAm {
+    fn encode<E: Encoder>(&self, encoder: &mut E)->Result<(), E::Error> {
+        CborTagEncode::new(5483_001, &(&self.public_id)).encode(encoder)
+    }
+}
+
+impl Decodable for IAm {
+    fn decode<D: Decoder>(decoder: &mut D)->Result<IAm, D::Error> {
+        try!(decoder.read_u64());
+        let public_id = try!(Decodable::decode(decoder));
+        Ok(IAm { public_id: public_id })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO: add encode / decode test
+    // TODO: add validation test
+}

--- a/src/who_are_you.rs
+++ b/src/who_are_you.rs
@@ -22,7 +22,7 @@ use utils::decode;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct WhoAreYou {
-    nonce: u8  // FIXME: a placeholder for nonce
+    pub nonce: u8  // FIXME: a placeholder for nonce
 }
 // TODO: add nonce to be signed for added security later
 


### PR DESCRIPTION
Connection problem of client was in routing_client::send_bootstrap... where the match statement would always fail because we don't know the bootstrap's name;

This routing_client very clearly shows that relying on WhoAreYou for a direct connection (established over bootstrap) is far more sensible than the current ConnectRequest method.  To get it to connect just now, I'm leaving it as is.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/341)
<!-- Reviewable:end -->
