### PR TITLE
Needed correction to updated Authority 

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -77,7 +77,7 @@ impl Decodable for Authority {
 ///    -> Client Manager
 /// b) if the element is within our close group range
 ///       and the destination is the element
-///       and the source is not the destination
+///       and the source group is not the destination
 ///    -> Network-Addressable-Element Manager
 /// c) if the element is within our close group range
 ///       and the source is the destination, and equals the element
@@ -100,7 +100,7 @@ pub fn our_authority(element : &NameType, header : &MessageHeader,
         return Authority::ClientManager; }
     else if routing_table.address_in_our_close_group_range(element)
        && header.destination.dest == *element
-       && header.from() != header.destination.dest {
+       && header.from_group() != Some(header.destination.dest.clone()) {
         return Authority::NaeManager; }
     else if routing_table.address_in_our_close_group_range(element)
        && header.destination.dest == *element

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -100,7 +100,10 @@ pub fn our_authority(element : &NameType, header : &MessageHeader,
         return Authority::ClientManager; }
     else if routing_table.address_in_our_close_group_range(element)
        && header.destination.dest == *element
-       && header.from_group() != Some(header.destination.dest.clone()) {
+       && match header.from_group() {
+          Some(group_source) => {
+             group_source != header.destination.dest},
+          None => true } {
         return Authority::NaeManager; }
     else if routing_table.address_in_our_close_group_range(element)
        && header.destination.dest == *element


### PR DESCRIPTION
Needed correction to updated Authority definitions as it the introduction of OurCloseGroup had broken NaeManager, and as such broke the PutPublicId; 

Corrected by additional condition on Nae is from_group != destination  (because the OurCloseGroup is purely for group-to-group) (not from a single node)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/364)
<!-- Reviewable:end -->
