### PR TITLE
preserve message_id on SendOn

### DIFF
--- a/src/message_header.rs
+++ b/src/message_header.rs
@@ -109,7 +109,7 @@ impl MessageHeader {
 
     // FIXME: add from_authority to filter value
     pub fn get_filter(&self) -> types::FilterType {
-        (self.source.from_node.clone(), self.message_id)
+        (self.source.from_node.clone(), self.message_id, self.destination.dest.clone())
     }
 
     pub fn from_authority(&self) -> Authority {

--- a/src/message_header.rs
+++ b/src/message_header.rs
@@ -130,7 +130,6 @@ impl MessageHeader {
                           destination : &NameType) -> MessageHeader {
         // implicitly preserve all non-mutated fields.
         let mut send_on_header = self.clone();
-        send_on_header.message_id = self.message_id.wrapping_add(1u32);
         send_on_header.source = types::SourceAddress {
             from_node : our_name.clone(),
             from_group : Some(self.destination.dest.clone()),

--- a/src/routing_membrane.rs
+++ b/src/routing_membrane.rs
@@ -82,6 +82,7 @@ enum ConnectionName {
     Routing(NameType),
     OurBootstrap,
     UnidentifiedConnection,
+    // ClaimedConnection(PublicId),
 }
 
 /// Routing Membrane

--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,11 @@ impl Decodable for NameAndTypeId {
   }
 }
 
-pub type FilterType = (NameType, MessageId);
+//                        +-> from_node name
+//                        |           +-> preserve the message_id when sending on
+//                        |           |         +-> destination name
+//                        |           |         |
+pub type FilterType = (NameType, MessageId, NameType);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct Signature {


### PR DESCRIPTION
Needs correction to message_filter now such that filter does not falslely block a sent-on message

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/396)
<!-- Reviewable:end -->
