### PR TITLE
PUT messages should go to ClientManager

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -28,7 +28,7 @@ use types::{DestinationAddress, SourceAddress, FromAddress, ToAddress, NodeAddre
 use error::{RoutingError, ResponseError};
 use NameType;
 use cbor;
-use utils::{encode};
+use utils;
 use cbor::{CborError};
 
 #[derive(PartialEq, Eq, Clone, Debug, RustcEncodable, RustcDecodable)]
@@ -146,8 +146,7 @@ impl RoutingMessage {
     }
 
     pub fn client_key_as_name(&self) -> Option<NameType> {
-        self.client_key().map(
-            |key| NameType(crypto::hash::sha512::hash(&key[..])))
+        self.client_key().map(utils::public_key_to_client_name)
     }
 
     pub fn from_group(&self) -> Option<NameType /* Group name */> {
@@ -238,7 +237,7 @@ impl SignedRoutingMessage {
     pub fn new(message: &RoutingMessage, secret_key: &crypto::sign::SecretKey)
         -> Result<SignedRoutingMessage, CborError>
     {
-        let encoded_message = try!(encode(&message));
+        let encoded_message = try!(utils::encode(&message));
         let signature = crypto::sign::sign_detached(&encoded_message,
                                                     secret_key);
         let message = SignedRoutingMessage {

--- a/src/public_id.rs
+++ b/src/public_id.rs
@@ -52,6 +52,10 @@ impl PublicId {
       self.name.clone()
     }
 
+    pub fn client_name(&self) -> NameType {
+        utils::public_key_to_client_name(&self.public_sign_key)
+    }
+
     pub fn serialised_contents(&self)->Result<RoutingError, Vec<u8>> {
         let mut e = cbor::Encoder::from_memory();
         try!(e.encode(&[&self]));

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -86,7 +86,7 @@ impl<F> RoutingClient<F> where F: Interface {
         let message_id = self.get_next_message_id();
         let message =  Message::Unsigned(RoutingMessage {
             destination : DestinationAddress::Direct(location),
-            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.name()),
+            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.public_key()),
             message_type: MessageType::GetData(data),
             message_id  : message_id.clone(),
             authority   : Authority::Client(self.id.signing_public_key()),
@@ -101,8 +101,8 @@ impl<F> RoutingClient<F> where F: Interface {
         let message_id = self.get_next_message_id();
 
         let message = RoutingMessage {
-            destination : DestinationAddress::Direct(location),
-            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.name()),
+            destination : DestinationAddress::Direct(self.public_id.client_name()),
+            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.public_key()),
             message_type: MessageType::PutData(data),
             message_id  : message_id.clone(),
             authority   : Authority::Client(self.id.signing_public_key()),
@@ -120,7 +120,7 @@ impl<F> RoutingClient<F> where F: Interface {
 
         let message = RoutingMessage {
             destination : DestinationAddress::Direct(location),
-            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.name()),
+            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.public_key()),
             message_type: MessageType::PostData(data),
             message_id  : message_id.clone(),
             authority   : Authority::Client(self.id.signing_public_key()),
@@ -137,7 +137,7 @@ impl<F> RoutingClient<F> where F: Interface {
         let message_id = self.get_next_message_id();
         let message = RoutingMessage {
             destination : DestinationAddress::Direct(location),
-            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.name()),
+            source      : SourceAddress::RelayedForClient(self.bootstrap_address.0, self.public_id.public_key()),
             message_type: MessageType::DeleteData(data),
             message_id  : message_id.clone(),
             authority   : Authority::Client(self.id.signing_public_key()),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,6 +43,10 @@ pub fn decode<T>(bytes: &Vec<u8>) -> Result<T, CborError> where T: Decodable {
     }
 }
 
+pub fn public_key_to_client_name(key: &sign::PublicKey) -> NameType {
+    NameType(crypto::hash::sha512::hash(&key[..]))
+}
+
 // relocated_name = Hash(original_name + 1st closest node id + 2nd closest node id)
 // In case of only one close node provided (in initial network setup scenario),
 // relocated_name = Hash(original_name + 1st closest node id)


### PR DESCRIPTION
And few RelayedForClient takes a PublicKey
not name of the client (this would have been caught
by the compiler later though).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/456)
<!-- Reviewable:end -->
