### PR TITLE
unplug sentinel

### DIFF
--- a/src/routing_membrane.rs
+++ b/src/routing_membrane.rs
@@ -1001,20 +1001,25 @@ impl<F> RoutingMembrane<F> where F: Interface {
             Authority::Unknown          => return Err(RoutingError::BadAuthority),
         };
 
-        let resolved = match self.put_sentinel.add_claim(
-                        SentinelPutRequest::new(message.clone(), data.clone(),
-                                                our_authority.clone(), source_authority),
-                        source, signed_message.signature().clone(),
-                        signed_message.encoded_body().clone(), quorum, quorum) {
-                            Some(result) =>  match  result {
-                                AddResult::RequestKeys(_) => {
-                                    // Get Key Request
-                                    return Ok(())
-                                },
-                                AddResult::Resolved(request, serialised_claim) => (request, serialised_claim)
-                                },
-                            None => return Ok(())
-                        };
+        // FIXME(ben 24/07/2015) plugging in sentinel should go in as a feature;
+        // partial solutions and not-working changes can no longer be accepted to
+        // interfere with the functioning of master.
+        let resolved = (SentinelPutRequest::new(message.clone(), data.clone(),
+            our_authority.clone(), source_authority), true);
+        // let resolved = match self.put_sentinel.add_claim(
+        //                 SentinelPutRequest::new(message.clone(), data.clone(),
+        //                                         our_authority.clone(), source_authority),
+        //                 source, signed_message.signature().clone(),
+        //                 signed_message.encoded_body().clone(), quorum, quorum) {
+        //                     Some(result) =>  match  result {
+        //                         AddResult::RequestKeys(_) => {
+        //                             // Get Key Request
+        //                             return Ok(())
+        //                         },
+        //                         AddResult::Resolved(request, serialised_claim) => (request, serialised_claim)
+        //                         },
+        //                     None => return Ok(())
+        //                 };
 
         match self.mut_interface().handle_put(our_authority.clone(), from_authority, from, to, data.clone()) {
             Ok(method_calls) => {


### PR DESCRIPTION
The work done on Sentinel for Put is wiping out functional parts of routing with wip-parts;
this is directly caused by not respecting the outlined tasks in JIRA

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/515)
<!-- Reviewable:end -->
