### PR TITLE
Block bootstrap fn until IAm msg arrives

### DIFF
--- a/examples/simple_key_value_store.rs
+++ b/examples/simple_key_value_store.rs
@@ -361,7 +361,7 @@ fn run_interactive_node(_bootstrap_peers: Option<Vec<Endpoint>>) {
         thread::sleep_ms(100);
         loop {
             thread::sleep_ms(10);
-            copied_client.lock().unwrap().run_one();
+            copied_client.lock().unwrap().poll_one();
         }
     });
     let ref mut command = String::new();

--- a/src/client_interface.rs
+++ b/src/client_interface.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use error::ResponseError;
+use error::{ResponseError, RoutingError};
 use data::Data;
 use NameType;
 


### PR DESCRIPTION
So that client can start sending/receiving messages right after
bootstrap fn returns. Also renames 'run_one' fn to 'poll_one' to
be use consistent terminology with boost asio.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/534)
<!-- Reviewable:end -->
