### PR TITLE
use SignedMessage::Signature as FilterType for filtering messages

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -135,14 +135,13 @@ pub struct RoutingMessage {
     pub from_authority : Authority,
     pub to_authority   : Authority,
     pub content        : Content,
-    pub message_id     : types::MessageId,
 }
 
 impl RoutingMessage {
 
     #[allow(dead_code)]
     pub fn message_id(&self) -> types::MessageId {
-        self.message_id.clone()
+        unimplemented!()
     }
 
     #[allow(dead_code)]
@@ -157,7 +156,7 @@ impl RoutingMessage {
     /// Return the filter value for this message,
     /// defined as (from_authority, message_id, to_authority)
     pub fn get_filter(&self) -> types::FilterType {
-       (self.from_authority.clone(), self.message_id, self.to_authority.clone())
+       (self.from_authority.clone(), self.message_id(), self.to_authority.clone())
     }
 
     pub fn client_key(&self) -> Option<sign::PublicKey> {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -140,23 +140,12 @@ pub struct RoutingMessage {
 impl RoutingMessage {
 
     #[allow(dead_code)]
-    pub fn message_id(&self) -> types::MessageId {
-        unimplemented!()
-    }
-
-    #[allow(dead_code)]
     pub fn source(&self) -> Authority {
         self.from_authority.clone()
     }
 
     pub fn destination(&self) -> Authority {
         self.to_authority.clone()
-    }
-
-    /// Return the filter value for this message,
-    /// defined as (from_authority, message_id, to_authority)
-    pub fn get_filter(&self) -> types::FilterType {
-       (self.from_authority.clone(), self.message_id(), self.to_authority.clone())
     }
 
     pub fn client_key(&self) -> Option<sign::PublicKey> {

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -311,7 +311,7 @@ impl RoutingNode {
         let message = message_wrap.get_routing_message().clone();
 
         // filter check
-        if self.filter.check(&message.get_filter()) {
+        if self.filter.check(message_wrap.signature()) {
             // should just return quietly
             debug!("FILTER BLOCKED message {:?} from {:?} to {:?}", message.content,
                 message.source(), message.destination());
@@ -320,7 +320,7 @@ impl RoutingNode {
         debug!("message {:?} from {:?} to {:?}", message.content,
             message.source(), message.destination());
         // add to filter
-        self.filter.add(message.get_filter());
+        self.filter.add(message_wrap.signature().clone());
 
         // Forward
         ignore(self.send(message_wrap.clone()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,9 +16,11 @@
 // relating to use of the SAFE Network Software.
 
 use sodiumoxide::crypto;
+use sodiumoxide::crypto::sign::Signature;
+use sodiumoxide::crypto::sign;
 use rustc_serialize::{Decoder, Encodable, Encoder};
 use rand::random;
-use sodiumoxide::crypto::sign;
+
 use NameType;
 use authority::Authority;
 
@@ -77,11 +79,11 @@ struct SignedKey {
   encrypt_public_key: crypto::box_::PublicKey,
 }
 
-//                        +-> from_authority
-//                        |           +-> preserve the message_id when sending on
-//                        |           |         +-> to_authority
-//                        |           |         |
-pub type FilterType = (Authority, MessageId, Authority);
+// TODO (ben 12/08/2015) Discussion point, message_id from RoutingMessage has been removed
+// in favour the signature of the signed message.  There is an unresolved question on
+// how to handle an explicit double identical request (eg for a network based reference
+// counter).
+pub type FilterType = Signature;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum Address {


### PR DESCRIPTION
The Signature in the SignedMessage is already the hash of all fields, including claimant and RoutingMessage, making it a unique identifier for detecting duplicate versions of the same message without additional overhead

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/573)
<!-- Reviewable:end -->
