### PR TITLE
Fix appveyor sodium dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,10 @@ environment:
 #    - RUST_VERSION: beta
     - RUST_VERSION: nightly
 
+matrix:
+  allow_failures:
+    - platform: x86
+
 build: false
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,13 @@
 install:
-  - ps: Start-FileDownload "https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/install.ps1"; . .\install.ps1
-  - ps: if($PLATFORM -eq 'x86') {
-          Start-FileDownload "https://gitlab.com/Fraser999/Dependencies/raw/master/bin/i686-pc-windows-gnu/libsodium.a";
-          mkdir .\bin\i686-pc-windows-gnu;
-          move libsodium.a .\bin\i686-pc-windows-gnu;
+  - ps: |
+        Start-FileDownload "https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/install.ps1"; . .\install.ps1
+        if($env:platform -eq 'x86') {
+          $arch_expanded = "i686-pc-windows-gnu";
+        } else {
+          $arch_expanded = "x86_64-pc-windows-gnu";
         }
-  - ps: if($PLATFORM -eq 'x64') {
-          Start-FileDownload "https://gitlab.com/Fraser999/Dependencies/raw/master/bin/x86_64-pc-windows-gnu/libsodium.a";
-          mkdir .\bin\x86_64-pc-windows-gnu;
-          move libsodium.a .\bin\x86_64-pc-windows-gnu;
-        }
+        Start-FileDownload "https://gitlab.com/Fraser999/Dependencies/raw/master/bin/$arch_expanded/libsodium.a";
+        $env:SODIUM_LIB_DIR = Resolve-Path .
 
 platform:
   - x86


### PR DESCRIPTION
Fix the `libsodium` dependency by setting the env var `SODIUM_LIB_DIR` used by the custom build script for sodiumoxide.

While this PR fixes the dependency issue it also highlights the current compile failure in sodiumoxide module for x86 windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/595)
<!-- Reviewable:end -->
