### PR TITLE
DISCUSS: Cause for external request

### DIFF
--- a/examples/simple_key_value_store.rs
+++ b/examples/simple_key_value_store.rs
@@ -153,7 +153,7 @@ impl Node {
                 }
             };
 
-            println!("Node: Receied event {:?}", event);
+            println!("Node: Received event {:?}", event);
 
             match event {
                 Event::Request{request,
@@ -410,4 +410,3 @@ fn main() {
         client.run();
     }
 }
-

--- a/examples/simple_key_value_store.rs
+++ b/examples/simple_key_value_store.rs
@@ -385,7 +385,7 @@ impl Client {
     }
 
     fn get_cause(&mut self) -> Cause {
-        self.request_counter.wrapping_add(1);
+        self. request_counter = self.request_counter.wrapping_add(1);
         crypto::hash::sha256::hash(&encode(&self.request_counter).unwrap()[..])
     }
 }

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -109,10 +109,10 @@ pub fn our_authority(message       : &RoutingMessage,
     let element = match message.content {
         Content::ExternalRequest(ref request) => {
             match *request {
-                ExternalRequest::Get(ref data_request) => Some(data_request.name().clone()),
-                ExternalRequest::Put(ref data)         => Some(data.name()),
-                ExternalRequest::Post(ref data)        => Some(data.name()),
-                ExternalRequest::Delete(_)             => None,
+                ExternalRequest::Get(ref data_request, _) => Some(data_request.name().clone()),
+                ExternalRequest::Put(ref data, _)         => Some(data.name()),
+                ExternalRequest::Post(ref data, _)        => Some(data.name()),
+                ExternalRequest::Delete(ref data, _)      => Some(data.name()),
             }
         },
         Content::InternalRequest(ref request) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,4 +81,4 @@ pub mod data;
 pub mod event;
 /// NameType is a 512bit name to address elements on the DHT network.
 pub use name_type::{NameType, closer_to_target};
-pub use messages::{SignedToken, ExternalRequest};
+pub use messages::{SignedToken, ExternalRequest, Cause};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -17,6 +17,7 @@
 
 use sodiumoxide::crypto::sign::Signature;
 use sodiumoxide::crypto::sign;
+use sodiumoxide::crypto;
 use std::fmt::{Debug, Formatter, Error};
 use cbor::{CborError};
 use std::collections::BTreeMap;
@@ -33,6 +34,8 @@ use NameType;
 use utils;
 
 pub static VERSION_NUMBER : u8 = 0;
+
+pub type Cause = crypto::hash::sha256::Digest;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct ConnectRequest {
@@ -67,13 +70,18 @@ impl Debug for SignedToken {
         formatter.write_str(&format!("SignedToken"))
     }
 }
+
 /// These are the messageTypes routing provides
+/// The Cause of a new ExternalRequest is the sha256 hash of a previous message, or
+/// external event (eg churn in the network, or a user action in clients) that caused this
+/// ExternalRequest.  This is solely to make identical requests different, as the filter
+/// will block a repeated appearance of an identical event (roughly within a 10 minute time frame).
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum ExternalRequest {
-    Get(DataRequest),
-    Put(Data),
-    Post(Data),
-    Delete(Data),
+    Get(DataRequest, Cause),
+    Put(Data, Cause),
+    Post(Data, Cause),
+    Delete(Data, Cause),
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, RustcEncodable, RustcDecodable)]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -31,7 +31,7 @@ use types::Bytes;
 use error::{RoutingError, ResponseError};
 use authority::Authority;
 use sodiumoxide::crypto;
-use messages::{ExternalRequest, ExternalResponse, InternalRequest, Content};
+use messages::{ExternalRequest, ExternalResponse, InternalRequest, Content, Cause};
 
 type RoutingResult = Result<(), RoutingError>;
 
@@ -96,31 +96,31 @@ impl Routing {
     }
 
     /// Send a Get message with a DataRequest to an Authority, signed with given keys.
-    pub fn get_request(&self, location : Authority, data_request : DataRequest) {
+    pub fn get_request(&self, location : Authority, data_request : DataRequest, cause : Cause) {
         let _ = self.action_sender.send(Action::SendContent(
                 location,
-                Content::ExternalRequest(ExternalRequest::Get(data_request))));
+                Content::ExternalRequest(ExternalRequest::Get(data_request, cause))));
     }
 
     /// Add something to the network
-    pub fn put_request(&self, location : Authority, data : Data) {
+    pub fn put_request(&self, location : Authority, data : Data, cause : Cause) {
         let _ = self.action_sender.send(Action::SendContent(
                 location,
-                Content::ExternalRequest(ExternalRequest::Put(data))));
+                Content::ExternalRequest(ExternalRequest::Put(data, cause))));
     }
 
     /// Change something already on the network
-    pub fn post_request(&self, location : Authority, data : Data) {
+    pub fn post_request(&self, location : Authority, data : Data, cause : Cause) {
         let _ = self.action_sender.send(Action::SendContent(
                 location,
-                Content::ExternalRequest(ExternalRequest::Post(data))));
+                Content::ExternalRequest(ExternalRequest::Post(data, cause))));
     }
 
     /// Remove something from the network
-    pub fn delete_request(&self, location : Authority, data : Data) {
+    pub fn delete_request(&self, location : Authority, data : Data, cause : Cause) {
         let _ = self.action_sender.send(Action::SendContent(
                 location,
-                Content::ExternalRequest(ExternalRequest::Delete(data))));
+                Content::ExternalRequest(ExternalRequest::Delete(data, cause))));
     }
     /// Respond to a get_request (no error can be sent)
     /// If we received the request from a group, we'll not get the signed_token.

--- a/src/routing_core.rs
+++ b/src/routing_core.rs
@@ -184,6 +184,7 @@ impl RoutingCore {
                         let trigger_churn = routing_table
                             .address_in_our_close_group_range(&name);
                         routing_table.drop_node(&name);
+                        info!("RT({:?}) dropped node {:?}", routing_table.size(), name);
                         if trigger_churn {
                             let mut close_group : Vec<NameType> = routing_table
                                     .our_close_group().iter()
@@ -218,6 +219,8 @@ impl RoutingCore {
                                     vec![endpoint.clone()], Some(endpoint));
                                 // TODO (ben 10/08/2015) drop connection of dropped node
                                 let (added, _) = routing_table.add_node(node_info);
+                                if added { info!("RT({:?}) added {:?}", routing_table.size(),
+                                      routing_name); };
                                 if added && trigger_churn {
                                     let mut close_group : Vec<NameType> = routing_table
                                             .our_close_group().iter()

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -211,7 +211,7 @@ impl RoutingNode {
 
     /// When CRUST reports a lost connection, ensure we remove the endpoint anywhere
     fn handle_lost_connection(&mut self, endpoint : Endpoint) {
-        error!("Lost connection on {:?}", endpoint);
+        debug!("Lost connection on {:?}", endpoint);
         let connection_name = self.core.lookup_endpoint(&endpoint);
           if connection_name.is_some() { self.core.drop_peer(&connection_name.unwrap()); }
     }
@@ -390,8 +390,6 @@ impl RoutingNode {
         // filter check
         if self.filter.check(message_wrap.signature()) {
             // should just return quietly
-            debug!("FILTER BLOCKED message {:?} from {:?} to {:?}",
-                message, message.source(), message.destination());
             return Err(RoutingError::FilterCheckFailed);
         }
         debug!("message {:?} from {:?} to {:?}", message.content,

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -295,15 +295,7 @@ impl RoutingNode {
                     // FIXME (ben 11/08/2015) we need to check his PublicId against the network
                     // but this requires an additional RFC so currently leave out such check
                     // refer to https://github.com/maidsafe/routing/issues/387
-                        alpha = match self.core.lookup_name(&his_name) {
-                            Some(ConnectionName::Routing(_)) => {
-                                // the new identity will be refused from core
-                                // as he is already present in the routing_table
-                                // with a different endpoint.  The closest name to zero is alpha
-                                &self.core.id().name() < &his_name
-                            },
-                            _ => false,
-                        };
+                        alpha = &self.core.id().name() < &his_name;
                         ConnectionName::Routing(his_name)
                     },
                     (Address::Client(his_public_key), Address::Node(our_name)) => {

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -259,6 +259,8 @@ impl RoutingNode {
                 let old_identity = match self.core.lookup_endpoint(&endpoint) {
                     // if already connected through the routing table, just confirm or destroy
                     Some(ConnectionName::Routing(known_name)) => {
+                        debug!("Endpoint {:?} registered to routing node {:?}", endpoint,
+                            known_name);
                         match hello.address {
                             // FIXME (ben 11/08/2015) Hello messages need to be signed and
                             // we also need to check the match with the PublicId stored in RT
@@ -762,6 +764,7 @@ impl RoutingNode {
                               from_authority : Authority,
                               to_authority   : Authority,
                               response_token : SignedToken) -> RoutingResult {
+        debug!("handle ConnectRequest");
         match request {
             InternalRequest::Connect(connect_request) => {
                 if !connect_request.requester_fob.is_relocated() {
@@ -805,6 +808,7 @@ impl RoutingNode {
                                response       : InternalResponse,
                                from_authority : Authority,
                                to_authority   : Authority) -> RoutingResult {
+        debug!("handle ConnectResponse");
         match response {
             InternalResponse::Connect(connect_response, signed_token) => {
                 if !signed_token.verify_signature(&self.core.id().signing_public_key()) {


### PR DESCRIPTION
Solution proposed here; but to be discussed tomorrow morning

items that are debatable;
1. we only need a limited number of bits, as the risk of collision is rather small - this only needs to differentiate multiple identical ExternalRequests in a short timeframe (where filter remembers);
Hash is a good candidate as we need deterministic differentiation (a single client can use random numbers, but vaults starting a Request need to do this uniformly over a group.  As such not providing a "Cause" gives, identical Requests, but would not be able to differentiate multiple (legitimate ?) requests;

Equally we can reduce the filter time out;

in either case std::hash  ::SipHash -> u64 would suffice, but the function hash was marked unstable.  As such in this POC I used crypto::hash ::sha256 which is far more than needed - again, we are looking for collision avoidance in a small space.

2. I made it external in the Routing API, as a vault close group on churn should provide a uniform cause. if we would exclude vaults (ie don't give them a cause-differentiator) then multiple identical requests would not register - again it is unlikely that identical requests in vault in a short time frame would even occur; but it is not excluded either 