### PR TITLE
Refactor main event loop in routing 

### DIFF
--- a/examples/simple_key_value_store.rs
+++ b/examples/simple_key_value_store.rs
@@ -132,6 +132,9 @@ impl Node {
                                         from_authority,
                                         response_token);
                 },
+                Event::Churn(our_close_group) => {
+                    self.handle_churn(our_close_group);
+                }
                 _ => {}
             }
         }
@@ -176,7 +179,7 @@ impl Node {
             Some(data) => data.clone(),
             None => return,
         };
-
+        println!("GET {:?}", name);
         self.routing.get_response(our_authority,
                                   from_authority,
                                   Data::PlainData(data),
@@ -195,6 +198,7 @@ impl Node {
 
         match our_authority {
             Authority::NaeManager(_) => {
+                println!("PUT {:?}", plain_data.name());
                 let _ = self.db.insert(plain_data.name(), plain_data);
             },
             _ => {
@@ -202,6 +206,17 @@ impl Node {
                 assert!(false);
             }
         }
+    }
+
+    fn handle_churn(&mut self, _our_close_group: Vec<::routing::NameType>) {
+
+        for value in self.db.values() {
+            println!("CHURN {:?}", value.name());
+            self.routing.put_request(::routing::authority::Authority::NaeManager(value.name()),
+                ::routing::authority::Authority::NaeManager(value.name()),
+                ::routing::data::Data::PlainData(value.clone()));
+        }
+        // self.db = BTreeMap::new();
     }
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -194,10 +194,10 @@ pub struct SignedMessage {
 impl SignedMessage {
     pub fn new(claimant: types::Address,
                message: RoutingMessage,
-               private_sign_key: &sign::SecretKey,
-               rng: &::rand::ThreadRng)
+               private_sign_key: &sign::SecretKey)
                -> Result<SignedMessage, CborError> {
 
+        let mut rng = ::rand::thread_rng();
         let random_bits = rng.gen::<u8>();
         let encoded_body = try!(utils::encode(&(&message, &claimant, &random_bits)));
         let signature    = sign::sign_detached(&encoded_body, private_sign_key);

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -107,7 +107,7 @@ impl RoutingNode {
             action_receiver: action_receiver,
             event_sender: event_sender,
             wakeup: WakeUpCaller::new(action_sender),
-            filter: ::filter::Filter::with_expiry_duration(Duration::seconds(2)),
+            filter: ::filter::Filter::with_expiry_duration(Duration::minutes(20)),
             // connection_filter: ::message_filter::MessageFilter::with_expiry_duration(
             //     ::time::Duration::seconds(1)),
             core: core,

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -147,45 +147,45 @@ impl RoutingNode {
                     break;
                 }
             };
-                match self.crust_receiver.try_recv() {
-                    Err(_) => {
-                        // FIXME (ben 16/08/2015) other reasons could induce an error
-                        // main error assumed now to be no new crust events
-                        // break;
-                    }
-                    Ok(crust::Event::NewMessage(endpoint, bytes)) => {
-                        match decode::<SignedMessage>(&bytes) {
-                            Ok(message) => {
-                                // handle SignedMessage for any identified endpoint
-                                match self.core.lookup_endpoint(&endpoint) {
-                                    Some(ConnectionName::Unidentified(_, _)) => debug!("message
-                                    from unidentified connection"),
+            match self.crust_receiver.try_recv() {
+                Err(_) => {
+                    // FIXME (ben 16/08/2015) other reasons could induce an error
+                    // main error assumed now to be no new crust events
+                    // break;
+                }
+                Ok(crust::Event::NewMessage(endpoint, bytes)) => {
+                    match decode::<SignedMessage>(&bytes) {
+                        Ok(message) => {
+                            // handle SignedMessage for any identified endpoint
+                            match self.core.lookup_endpoint(&endpoint) {
+                                Some(ConnectionName::Unidentified(_, _)) => debug!("message
+                                        from unidentified connection"),
                                     None => debug!("message from unknown endpoint"),
                                     _ => ignore(self.message_received(message)),
-                                };
-                            }
-                            // The message received is not a Signed Routing Message,
-                            // expect it to be an Hello message to identify a connection
-                            Err(_) => {
-                                match decode::<::direct_messages::DirectMessage>(&bytes) {
-                                    Ok(direct_message) => self.direct_message_received(
+                            };
+                        }
+                        // The message received is not a Signed Routing Message,
+                        // expect it to be an Hello message to identify a connection
+                        Err(_) => {
+                            match decode::<::direct_messages::DirectMessage>(&bytes) {
+                                Ok(direct_message) => self.direct_message_received(
                                         direct_message, endpoint),
                                     _ => error!("Unparsable message received on {:?}", endpoint),
-                                };
-                            }
-                        };
-                    }
-                    Ok(crust::Event::NewConnection(endpoint)) => {
-                        self.handle_new_connection(endpoint);
-                    }
-                    Ok(crust::Event::LostConnection(endpoint)) => {
-                        self.handle_lost_connection(endpoint);
-                    }
-                    Ok(crust::Event::NewBootstrapConnection(endpoint)) => {
-                        self.handle_new_bootstrap_connection(endpoint);
-                    }
-                };
-                thread::sleep_ms(1);
+                            };
+                        }
+                    };
+                }
+                Ok(crust::Event::NewConnection(endpoint)) => {
+                    self.handle_new_connection(endpoint);
+                }
+                Ok(crust::Event::LostConnection(endpoint)) => {
+                    self.handle_lost_connection(endpoint);
+                }
+                Ok(crust::Event::NewBootstrapConnection(endpoint)) => {
+                    self.handle_new_bootstrap_connection(endpoint);
+                }
+            };
+            thread::sleep_ms(1);
         }
     }
 

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -107,7 +107,7 @@ impl RoutingNode {
             action_receiver: action_receiver,
             event_sender: event_sender,
             wakeup: WakeUpCaller::new(action_sender),
-            filter: ::filter::Filter::with_expiry_duration(Duration::minutes(20)),
+            filter: ::filter::Filter::with_expiry_duration(Duration::seconds(2)),
             // connection_filter: ::message_filter::MessageFilter::with_expiry_duration(
             //     ::time::Duration::seconds(1)),
             core: core,
@@ -477,7 +477,7 @@ impl RoutingNode {
                     InternalRequest::Refresh(type_tag, bytes) => {
                         let refresh_authority = match our_authority {
                             Some(authority) => {
-                                if authority.is_group() { return Err(RoutingError::BadAuthority) };
+                                if !authority.is_group() { return Err(RoutingError::BadAuthority) };
                                 authority
                             },
                             None => return Err(RoutingError::BadAuthority),

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -109,7 +109,7 @@ impl RoutingNode {
             wakeup: WakeUpCaller::new(action_sender),
             filter: ::filter::Filter::with_expiry_duration(Duration::minutes(20)),
             connection_filter: ::message_filter::MessageFilter::with_expiry_duration(
-                ::time::Duration::seconds(20)),
+                ::time::Duration::minutes(20)),
             core: core,
             public_id_cache: LruCache::with_expiry_duration(Duration::minutes(10)),
             accumulator: MessageAccumulator::new(),


### PR DESCRIPTION
To accommodate both efficiency and also reduction in CPU usage. Can possibly be improved by only having a nanosleep when loop has not actually matched any receive channel. For now this appears to be successful in ensuring nodes are stable. There was an issue waiting on crust actions whilst routing was attempting to handle an event.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/660)
<!-- Reviewable:end -->
