### PR TITLE
Maid 1349 refresh authority

### DIFF
--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -95,8 +95,8 @@ struct Args {
 struct Node {
     routing: Routing,
     receiver: Receiver<Event>,
-    db: BTreeMap<NameType, PlainData>,
-    client_accounts: BTreeMap<::sodiumoxide::crypto::sign::PublicKey, u64>,
+    db: BTreeMap<::routing::NameType, PlainData>,
+    client_accounts: BTreeMap<::routing::NameType, u64>,
 }
 
 impl Node {
@@ -134,7 +134,16 @@ impl Node {
                                         from_authority,
                                         response_token);
                 },
-                _ => {}
+                Event::Connected => println!("Node is connected."),
+                Event::Churn(our_close_group) => {
+                    self.handle_churn(our_close_group);
+                },
+                Event::Refresh(type_tag, our_authority, vec_of_bytes) => {
+                    if type_tag != 1u64 { error!("Reveived refresh for tag {:?} from {:?}",
+                        type_tag, our_authority); continue; };
+                    self.handle_refresh(our_authority, vec_of_bytes);
+                },
+                _ => {},
             }
         }
     }
@@ -188,7 +197,7 @@ impl Node {
 
     fn handle_put_request(&mut self, data            : Data,
                                      our_authority   : Authority,
-                                     from_authority : Authority,
+                                     from_authority  : Authority,
                                      _response_token : Option<SignedToken>) {
         let plain_data = match data.clone() {
             Data::PlainData(plain_data) => plain_data,
@@ -203,10 +212,12 @@ impl Node {
             Authority::ClientManager(_) => {
                 match from_authority {
                     ::routing::authority::Authority::Client(_, public_key) => {
-                        *self.client_accounts.entry(public_key)
+                        let client_name = ::routing::NameType::new(
+                            ::sodiumoxide::crypto::hash::sha512::hash(&public_key[..]).0);
+                        *self.client_accounts.entry(client_name)
                             .or_insert(0u64) += data.payload_size() as u64;
-                        println!("Client ({:?}) stored {:?} bits", public_key,
-                            self.client_accounts.get(&public_key));
+                        println!("Client ({:?}) stored {:?} bytes", client_name,
+                            self.client_accounts.get(&client_name));
                         debug!("Sending: key {:?}, value {:?}", plain_data.name(), plain_data);
                         self.routing.put_request(
                             our_authority, Authority::NaeManager(plain_data.name()), data);
@@ -222,6 +233,58 @@ impl Node {
                 println!("Node: Unexpected our_authority ({:?})", our_authority);
                 assert!(false);
             }
+        }
+    }
+
+    fn handle_churn(&mut self, _our_close_group: Vec<::routing::NameType>) {
+        println!("Handle churn for close group size {:?}", _our_close_group.len());
+        // for value in self.db.values() {
+        //     println!("CHURN {:?}", value.name());
+        //     self.routing.put_request(::routing::authority::Authority::NaeManager(value.name()),
+        //         ::routing::authority::Authority::NaeManager(value.name()),
+        //         ::routing::data::Data::PlainData(value.clone()));
+        // }
+
+        for (public_key, stored) in self.client_accounts.iter() {
+            let authority = ::routing::authority::Authority::ClientManager(
+                NameType::new(crypto::hash::sha512::hash(&public_key[..]).0));
+            println!("REFRESH {:?} - {:?}", authority, stored);
+            self.routing.refresh_request(1u64, authority,
+                encode(&stored).unwrap());
+        }
+        // self.db = BTreeMap::new();
+    }
+
+    fn handle_refresh(&mut self, our_authority: Authority, vec_of_bytes: Vec<Vec<u8>>) {
+        let mut records : Vec<u64> = Vec::new();
+        let mut fail_parsing_count = 0usize;
+        for bytes in vec_of_bytes {
+            match decode(&bytes) {
+                Ok(record) => records.push(record),
+                Err(_) => fail_parsing_count += 1usize,
+            };
+        }
+        let median = median(records.clone());
+        println!("Refresh for {:?}: median {:?} from {:?} (errs {:?})", our_authority, median,
+            records, fail_parsing_count);
+    }
+}
+
+/// Returns the median (rounded down to the nearest integral value) of `values` which can be
+/// unsorted.  If `values` is empty, returns `0`.
+pub fn median(mut values: Vec<u64>) -> u64 {
+    match values.len() {
+        0 => 0u64,
+        1 => values[0],
+        len if len % 2 == 0 => {
+            values.sort();
+            let lower_value = values[(len / 2) - 1];
+            let upper_value = values[len / 2];
+            (lower_value + upper_value) / 2
+        }
+        len => {
+            values.sort();
+            values[len / 2]
         }
     }
 }

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -206,7 +206,7 @@ impl Node {
 
         match our_authority {
             Authority::NaeManager(_) => {
-                debug!("Storing: key {:?}, value {:?}", plain_data.name(), plain_data);
+                println!("Storing: key {:?}, value {:?}", plain_data.name(), plain_data);
                 let _ = self.db.insert(plain_data.name(), plain_data);
             },
             Authority::ClientManager(_) => {
@@ -245,9 +245,7 @@ impl Node {
         //         ::routing::data::Data::PlainData(value.clone()));
         // }
 
-        for (public_key, stored) in self.client_accounts.iter() {
-            let authority = ::routing::authority::Authority::ClientManager(
-                NameType::new(crypto::hash::sha512::hash(&public_key[..]).0));
+        for (client_name, stored) in self.client_accounts.iter() {
             println!("REFRESH {:?} - {:?}", authority, stored);
             self.routing.refresh_request(1u64, authority,
                 encode(&stored).unwrap());
@@ -267,6 +265,12 @@ impl Node {
         let median = median(records.clone());
         println!("Refresh for {:?}: median {:?} from {:?} (errs {:?})", our_authority, median,
             records, fail_parsing_count);
+        match our_authority {
+             ::routing::authority::Authority::ClientManager(client_name) => {
+                 let _ = self.client_accounts.insert(client_name, median);
+             },
+             _ => {},
+        };
     }
 }
 

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -248,7 +248,7 @@ impl Node {
         for (client_name, stored) in self.client_accounts.iter() {
             println!("REFRESH {:?} - {:?}", client_name, stored);
             self.routing.refresh_request(1u64,
-                ::routing::authority::Authority::ClientManager(client_name),
+                ::routing::authority::Authority::ClientManager(client_name.clone()),
                 encode(&stored).unwrap());
         }
         // self.db = BTreeMap::new();

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -246,8 +246,9 @@ impl Node {
         // }
 
         for (client_name, stored) in self.client_accounts.iter() {
-            println!("REFRESH {:?} - {:?}", authority, stored);
-            self.routing.refresh_request(1u64, authority,
+            println!("REFRESH {:?} - {:?}", client_name, stored);
+            self.routing.refresh_request(1u64,
+                ::routing::authority::Authority::ClientManager(client_name),
                 encode(&stored).unwrap());
         }
         // self.db = BTreeMap::new();

--- a/src/event.rs
+++ b/src/event.rs
@@ -59,7 +59,7 @@ pub enum Event {
         location: Authority,
         interface_error: InterfaceError,
     },
-    Refresh(u64, NameType, Vec<Vec<u8>>),
+    Refresh(u64, Authority, Vec<Vec<u8>>),
     //      ~|~  ~~|~~~~~  ~~|~~~~~~~~~
     //       |     |         | payloads is a vector of serialised account records as sent out
     //       |     |         | routing has made no attempt at parsing the content

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -62,13 +62,17 @@ impl Filter {
 
     /// Block adds the digest of the routing message to the message blocker.  A blocked
     /// message will be held back by the filter, regardless of the claimant.
-    pub fn block(&mut self, routing_message: &::messages::RoutingMessage) {
+    pub fn block(&mut self, digest: RoutingMessageFilter) {
 
-      let digest = match ::utils::encode(routing_message) {
-          Ok(bytes) => ::sodiumoxide::crypto::hash::sha256::hash(&bytes[..]),
-          Err(_) => return,
-      };
-      self.message_filter.add(digest);
+        self.message_filter.add(digest);
     }
 
+    pub fn message_digest(routing_message: &::messages::RoutingMessage)
+        -> Option<RoutingMessageFilter> {
+
+        match ::utils::encode(routing_message) {
+            Ok(bytes) => Some(::sodiumoxide::crypto::hash::sha256::hash(&bytes[..])),
+            Err(_) => None,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod id;
 pub mod utils;
 pub mod public_id;
 pub mod error;
+// FIXME (ben 8/09/2015) make the module authority private
 pub mod authority;
 pub mod structured_data;
 pub mod immutable_data;
@@ -86,3 +87,4 @@ pub mod data;
 /// NameType is a 512bit name to address elements on the DHT network.
 pub use name_type::{NameType, closer_to_target};
 pub use messages::{SignedToken, ExternalRequest, ExternalResponse};
+pub use authority::Authority;

--- a/src/refresh_accumulator.rs
+++ b/src/refresh_accumulator.rs
@@ -17,17 +17,16 @@
 
 use lru_time_cache::LruCache;
 use std::collections::BTreeMap;
-use NameType;
 
 type Map<K,V> = BTreeMap<K,V>;
 pub type Bytes = Vec<u8>;
 //                     +-> Source and target group
 //                     |
-pub type Request = (NameType, u64);
+pub type Request = (::authority::Authority, u64);
 pub struct RefreshAccumulator {
     //                                 +-> Who sent it
     //                                 |
-    requests: LruCache<Request, Map<NameType, Bytes>>,
+    requests: LruCache<Request, Map<::NameType, Bytes>>,
 }
 
 const MAX_REQUEST_COUNT: usize = 1000;
@@ -41,8 +40,8 @@ impl RefreshAccumulator {
     pub fn add_message(&mut self,
                        threshold: usize,
                        type_tag: u64,
-                       sender_node: NameType,
-                       sender_group: NameType,
+                       sender_node: ::NameType,
+                       sender_group: ::authority::Authority,
                        payload: Bytes)
                        -> Option<Vec<Bytes>> {
         let request = (sender_group, type_tag);

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -148,11 +148,13 @@ impl Routing {
     /// This method needs to be called when churn is triggered.
     /// all the group members need to call this, otherwise it will not be resolved as a valid
     /// content.
-    pub fn refresh_request(&self, type_tag: u64, from_group: NameType, content: Bytes) {
-        let _ = self.action_sender.send(Action::SendContent(
-                Authority::NaeManager(from_group.clone()), Authority::NaeManager(from_group),
-                Content::InternalRequest(InternalRequest::Refresh(type_tag, content))));
-
+    pub fn refresh_request(&self, type_tag: u64, our_authority: Authority, content: Bytes) {
+        if !our_authority.is_group() {
+            error!("refresh request (type_tag {:?}) can only be made as a group authority: {:?}",
+                type_tag, our_authority);
+            return; };
+        let _ = self.action_sender.send(Action::SendContent(our_authority.clone(), our_authority,
+            Content::InternalRequest(InternalRequest::Refresh(type_tag, content))));
     }
 
     /// Dynamically enable/disable caching for Data types.

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -147,7 +147,7 @@ impl Routing {
     /// Refresh the content in the close group nodes of group address content::name.
     /// This method needs to be called when churn is triggered.
     /// all the group members need to call this, otherwise it will not be resolved as a valid
-    /// content.
+    /// content. If the authority provided (our_authority) is not a group, the request for refresh will be dropped.
     pub fn refresh_request(&self, type_tag: u64, our_authority: Authority, content: Bytes) {
         if !our_authority.is_group() {
             error!("refresh request (type_tag {:?}) can only be made as a group authority: {:?}",

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -1120,11 +1120,11 @@ impl RoutingNode {
                                  our_authority: Authority) -> RoutingResult {
         debug_assert!(our_authority.is_group());
         let threshold = self.group_threshold();
-        let group_name = our_authority.get_location().clone();
         match self.refresh_accumulator.add_message(threshold,
-            type_tag.clone(), sender, group_name.clone(), payload){
+            type_tag.clone(), sender, our_authority.clone(), payload){
             Some(vec_of_bytes) => {
-                let _ = self.event_sender.send(Event::Refresh(type_tag, group_name, vec_of_bytes));
+                let _ = self.event_sender.send(Event::Refresh(type_tag, our_authority,
+                    vec_of_bytes));
             },
             None => {},
         };
@@ -1164,13 +1164,13 @@ impl RoutingNode {
                 None => self.data_cache =
                     Some(LruCache::<NameType, Data>::with_expiry_duration(Duration::minutes(10))),
                 Some(_) => {},
-            }    
+            }
         } else {
             self.data_cache = None;
         }
     }
 
-    fn handle_cache_put(&mut self, message: &RoutingMessage) {  
+    fn handle_cache_put(&mut self, message: &RoutingMessage) {
         match self.data_cache {
             Some(ref mut data_cache) => {
                 match message.content.clone() {
@@ -1208,7 +1208,7 @@ impl RoutingNode {
             },
             None => {}
         }
-            
+
     }
 
     fn handle_cache_get(&mut self, message: &RoutingMessage) -> Option<Content> {

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -532,11 +532,11 @@ impl RoutingNode {
             Some(digest) => {
                 match result {
                     Ok(()) => {
-                        self.filter.block(digest);
+                        if self.client_restriction { self.filter.block(digest); };
                         Ok(())
                     },
                     Err(RoutingError::UnknownMessageType) => {
-                        self.filter.block(digest);
+                        if self.client_restriction { self.filter.block(digest); };
                         Err(RoutingError::UnknownMessageType)
                     },
                     Err(e) => Err(e),

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -407,6 +407,7 @@ impl RoutingNode {
         }
 
         let message = signed_message.get_routing_message().clone();
+        let mut message_digest = ::filter::Filter::message_digest(&message);
 
         // Cache a response if from a GetRequest and caching is enabled for the Data type.
         self.handle_cache_put(&message);
@@ -458,7 +459,6 @@ impl RoutingNode {
             None => return Err(::error::RoutingError::NotEnoughSignatures),
         };
 
-        let mut message_digest = ::filter::Filter::message_digest(&message);
         let result = match message.content {
             Content::InternalRequest(request) => {
                 match request {
@@ -532,11 +532,11 @@ impl RoutingNode {
             Some(digest) => {
                 match result {
                     Ok(()) => {
-                        if self.client_restriction { self.filter.block(digest); };
+                        self.filter.block(digest);
                         Ok(())
                     },
                     Err(RoutingError::UnknownMessageType) => {
-                        if self.client_restriction { self.filter.block(digest); };
+                        self.filter.block(digest);
                         Err(RoutingError::UnknownMessageType)
                     },
                     Err(e) => Err(e),


### PR DESCRIPTION
The code needed for the library is limited.  The key_value_store however, has no refresh message to test this behaviour at the routing layer.  I will further expand the example in the 8 points, to include an account, and corresponding refresh message.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/672)
<!-- Reviewable:end -->
