### PR TITLE
check duplicate previous_owner keys

### DIFF
--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -121,11 +121,12 @@ impl StructuredData {
             -> Result<(), ::error::RoutingError> {
         // Refuse any duplicate previous_owner_signatures (people can have many owner keys)
         // Any duplicates invalidates this type.
-        if self.previous_owner_signatures.iter().filter(|&sig| self.previous_owner_signatures.iter()
-                  .any(|ref sig_check| ::NameType(sig.0) == ::NameType(sig_check.0)))
-                  .count() > (owner_keys.len() + 1) / 2 {
-
-            return Err(::error::RoutingError::DuplicateSignatures);
+        for (i, sig) in self.previous_owner_signatures.iter().enumerate() {
+            for sig_check in &self.previous_owner_signatures[..i] {
+                if sig == sig_check {
+                    return Err(::error::RoutingError::DuplicateSignatures);
+                }
+            }
         }
 
         // Refuse when not enough previous_owner_signatures found


### PR DESCRIPTION
I'm not sure what the code I'm removing is supposed to do but it just seems to be a convoluted way of calculating `self.previous_owner_signatures.len() > (owner_keys.len() + 1) / 2`.

The code I'm replacing it with does what the comment says it does.

Thoughts?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/724)
<!-- Reviewable:end -->
