### PR TITLE
Optional min/max dates in StructuredData for proof of storage date

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -145,6 +145,8 @@ pub enum RoutingError {
     NotEnoughSignatures,
     /// Duplicate signatures
     DuplicateSignatures,
+    /// Current date is ouside specified range [min_date .. max_date] of structured data
+    OutOfRangeDate,
     /// duplicate request received
     FilterCheckFailed,
     /// failure to bootstrap off the provided endpoints
@@ -212,6 +214,7 @@ impl ::std::error::Error for RoutingError {
             RoutingError::FailedSignature => "Signature check failure",
             RoutingError::NotEnoughSignatures => "Not enough signatures",
             RoutingError::DuplicateSignatures => "Duplicated signatures",
+            RoutingError::OutOfRangeDate => "Current date is outside specified range",
             RoutingError::FailedToBootstrap => "Could not bootstrap",
             RoutingError::RoutingTableEmpty => "Routing table empty",
             RoutingError::RejectedPublicId => "Rejected Public Id",
@@ -255,6 +258,8 @@ impl ::std::fmt::Display for RoutingError {
                 ::std::fmt::Display::fmt("Not enough signatures (multi-sig)", formatter),
             RoutingError::DuplicateSignatures =>
                 ::std::fmt::Display::fmt("Duplicated signatures (multi-sig)", formatter),
+            RoutingError::OutOfRangeDate =>
+                ::std::fmt::Display::fmt("Current date is outside specified range", formatter),
             RoutingError::FailedToBootstrap =>
                 ::std::fmt::Display::fmt("Could not bootstrap", formatter),
             RoutingError::RoutingTableEmpty =>

--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -31,12 +31,14 @@ pub struct StructuredData {
     version: u64,
     current_owner_keys: Vec<::sodiumoxide::crypto::sign::PublicKey>,
     previous_owner_signatures: Vec<::sodiumoxide::crypto::sign::Signature>,
+    min_date: i64,
+    max_date: i64,
 }
 
 
 impl StructuredData {
 
-    /// Constructor
+    /// Constructor with default min/max dates.
     pub fn new(type_tag: u64,
                identifier: ::NameType,
                version: u64,
@@ -54,6 +56,39 @@ impl StructuredData {
             version: version,
             current_owner_keys: current_owner_keys,
             previous_owner_signatures: vec![],
+            min_date : 0i64,
+            max_date : i64::max_value(),
+        };
+
+        if let Some(key) = signing_key {
+            let _ = try!(structured_data.add_signature(key));
+        }
+        Ok(structured_data)
+    }
+
+    /// Constructor with min/max dates.
+    /// StructuredData::new cannot simply be called and then dates added because dates must be part of signed data.
+    pub fn with_dates(type_tag: u64,
+               identifier: ::NameType,
+               version: u64,
+               data: Vec<u8>,
+               current_owner_keys: Vec<::sodiumoxide::crypto::sign::PublicKey>,
+               previous_owner_keys: Vec<::sodiumoxide::crypto::sign::PublicKey>,
+               signing_key: Option<&::sodiumoxide::crypto::sign::SecretKey>,
+               min_date: i64,
+               max_date: i64)
+               -> Result<StructuredData, ::error::RoutingError> {
+
+        let mut structured_data = StructuredData {
+            type_tag: type_tag,
+            identifier: identifier,
+            data: data,
+            previous_owner_keys: previous_owner_keys,
+            version: version,
+            current_owner_keys: current_owner_keys,
+            previous_owner_signatures: vec![],
+            min_date : min_date,
+            max_date : max_date,
         };
 
         if let Some(key) = signing_key {
@@ -115,6 +150,18 @@ impl StructuredData {
         other.verify_previous_owner_signatures(owner_keys_to_match)
     }
 
+    /// Validate date. An error is generated when current date is not in the range [min_date .. max_date]
+    pub fn validate_date(&self) -> Result<(), ::error::RoutingError> {
+        use time;
+        let now_utc = time::now_utc().to_timespec().sec;
+        if now_utc < self.min_date || now_utc > self.max_date {
+            Err(::error::RoutingError::OutOfRangeDate)
+        }
+        else {
+            Ok(())
+        }
+    }
+ 
     /// Confirms *unique and valid* owner_signatures are at least 50% of total owners
     fn verify_previous_owner_signatures(&self,
             owner_keys: &Vec<::sodiumoxide::crypto::sign::PublicKey>)
@@ -155,6 +202,8 @@ impl StructuredData {
         try!(enc.encode(&self.previous_owner_keys));
         try!(enc.encode(&self.current_owner_keys));
         try!(enc.encode(self.version.to_string().as_bytes()));
+        try!(enc.encode(self.min_date.to_string().as_bytes()));
+        try!(enc.encode(self.max_date.to_string().as_bytes()));
         Ok(enc.into_bytes())
     }
 
@@ -213,17 +262,42 @@ impl StructuredData {
         &self.previous_owner_signatures
     }
 
+    /// Get the min date
+    pub fn get_min_date(&self) -> i64 {
+        self.min_date
+    }
+
+    /// Get the max date
+    pub fn get_max_date(&self) -> i64 {
+        self.max_date
+    }
+
     /// Return data size.
     pub fn payload_size(&self) -> usize {
         self.data.len()
     }
 }
 
+fn format_date(date: i64) -> String {
+    use time;
+    match date {
+        0 => "origin".to_string(),
+        x if x == i64::max_value() => "infinity".to_string(),
+        _ => {
+            let time_spec = time::Timespec::new(date, 0);
+            let tm = time::at_utc(time_spec);
+            let tm_fmt = tm.rfc3339();
+            format!("{}", tm_fmt)
+        }
+    }
+}
+
 impl ::std::fmt::Debug for StructuredData {
     fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         let _ = formatter.write_str(
-            &format!(" type_tag: {:?} , name: {:?} , version: {:?} , data: {:?}",
+            &format!(" type_tag: {:?} , name: {:?} , version: {:?} , dates: [{}..{}], data: {:?}",
                      self.type_tag, self.name(), self.version,
+                     format_date(self.min_date), format_date(self.max_date),
                      ::utils::get_debug_id(self.data.clone())));
 
         let prev_owner_keys : Vec<String> = self.previous_owner_keys.iter().map(|pub_key|
@@ -256,6 +330,86 @@ impl ::std::fmt::Debug for StructuredData {
 
 #[cfg(test)]
 mod test {
+
+    #[test]
+    fn default_dates() {
+        let keys = ::sodiumoxide::crypto::sign::gen_keypair();
+        let owner_keys = vec![keys.0];
+
+        match super::StructuredData::new(0,
+                                  ::test_utils::Random::generate_random(),
+                                  0,
+                                  vec![],
+                                  owner_keys.clone(),
+                                  vec![],
+                                  Some(&keys.1)) {
+            Ok(structured_data) => {
+                assert_eq!(structured_data.min_date, 0);
+                assert_eq!(structured_data.max_date, i64::max_value());
+                assert!(structured_data.validate_date().is_ok());
+                }
+            Err(error) => panic!("Error: {:?}", error),
+        }
+    }
+
+    #[test]
+    fn valid_dates() {
+        use time;
+        let keys = ::sodiumoxide::crypto::sign::gen_keypair();
+        let owner_keys = vec![keys.0];
+
+        // Current date is inside specified [min_date .. max_date] range
+        let now_utc = time::now_utc().to_timespec();
+        let min_date = (now_utc + time::Duration::minutes(-20)).sec;
+        let max_date = (now_utc + time::Duration::minutes(10)).sec;
+
+        match super::StructuredData::with_dates(0,
+                                  ::test_utils::Random::generate_random(),
+                                  0,
+                                  vec![],
+                                  owner_keys.clone(),
+                                  vec![],
+                                  Some(&keys.1),
+                                  min_date,
+                                  max_date) {
+            Ok(structured_data) => {
+                assert_eq!(structured_data.min_date, now_utc.sec - 20*60);
+                assert_eq!(structured_data.max_date, now_utc.sec + 10*60);
+                assert!(structured_data.validate_date().is_ok());
+                }
+            Err(error) => panic!("Error: {:?}", error),
+        }
+    }
+
+    #[test]
+    fn invalid_dates() {
+        use time;
+        let keys = ::sodiumoxide::crypto::sign::gen_keypair();
+        let owner_keys = vec![keys.0];
+
+        // Current date is outside specified [min_date .. max_date] range
+        let now_utc = time::now_utc().to_timespec();
+        let min_date = (now_utc + time::Duration::minutes(-20)).sec;
+        let max_date = (now_utc + time::Duration::minutes(-10)).sec;
+
+        match super::StructuredData::with_dates(0,
+                                  ::test_utils::Random::generate_random(),
+                                  0,
+                                  vec![],
+                                  owner_keys.clone(),
+                                  vec![],
+                                  Some(&keys.1),
+                                  min_date,
+                                  max_date) {
+            Ok(structured_data) => {
+                assert_eq!(structured_data.min_date, now_utc.sec - 20*60);
+                assert_eq!(structured_data.max_date, now_utc.sec - 10*60);
+                // Check that an error is returned
+                assert!(structured_data.validate_date().is_err());
+                }
+            Err(error) => panic!("Error: {:?}", error),
+        }
+    }
 
     #[test]
     fn single_owner() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,7 +28,7 @@ pub fn array_as_vector(arr: &[u8]) -> Vec<u8> {
 pub fn vector_as_u8_64_array(vector: Vec<u8>) -> [u8; 64] {
     assert!(vector.len() >= 64);
     let mut arr = [0u8;64];
-    for i in (0..64) {
+    for i in 0..64 {
         arr[i] = vector[i];
     }
     arr
@@ -38,7 +38,7 @@ pub fn vector_as_u8_64_array(vector: Vec<u8>) -> [u8; 64] {
 pub fn vector_as_u8_32_array(vector: Vec<u8>) -> [u8; 32] {
     assert!(vector.len() >= 32);
     let mut arr = [0u8;32];
-    for i in (0..32) {
+    for i in 0..32 {
         arr[i] = vector[i];
     }
     arr


### PR DESCRIPTION
This is an implementation of my proposal in following post:

https://forum.safenetwork.io/t/any-time-consensus-within-safenet/2891/14?u=tfa

The aim is to allow an optional proof of storage date of StructuredData that doesn’t need a complex time synchronization mechanism in the safe network.

The following elements have been added:
  - Two fields in StructuredData (min_date/max_date)
  - Two default values written to these fields in the existing constructor (StructuredData::new) so that the behavior of classic StructuredData remains unchanged (no date validation)
  - A new constructor (StructuredData::with_dates) with 2 supplementary arguments specifying a range of dates for the proof of storage.
  - A validation function (validate_date) that checks that current date is within the specified range.
  - inclusion of the new fields in the signed part of StructuredData
  - Two public getter functions (get_min_date/get_max_date)
  - Display of [min_date..max_date] range in the format debug trait of StructuredData
  - Three tests functions (default_dates, valid_dates, invalid_dates) that check the validation function in the three possible cases.
  - A new error code (RoutingError::OutOfRangeDate) which can be returned by the validation function

Usage notes:
  - The new constructor has to be called from the clients to activate this functionality
  - The validation function has to be called in each put and post request of SD. I searched for site calls for existing functions like replace_with_other or validate_self_against_successor but without success (including safe_vault crate). I have the feeling that these kind of controls are not yet activated (except in test functions). When they are, the validate_date function should also be called.

Potential problem:

This solution works only if validation is done when the user put or post the SD. It doesn’t work if the validation must be done again at later times (for example during churn events).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/730)
<!-- Reviewable:end -->
