### PR TITLE
MAID-1378 on core::reset(), collect all open connections and re-initialise

### DIFF
--- a/src/relay.rs
+++ b/src/relay.rs
@@ -171,6 +171,11 @@ impl RelayMap {
         }
         false
     }
+
+    /// Returns all connections listed
+    pub fn all_connections(&self) -> Vec<::crust::Connection> {
+        self.lookup_map.keys().map(|c| c.clone()).collect::<Vec<::crust::Connection>>()
+    }
 }
 
 #[cfg(test)]

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -135,7 +135,10 @@ impl RoutingNode {
                 Ok(Action::SetCacheOptions(cache_options)) => {
                     self.set_cache_options(cache_options);
                 },
-                Ok(Action::Rebootstrap) => {},
+                Ok(Action::Rebootstrap) => {
+                    let _open_connections = self.core.reset(self.client_restriction);
+                    self.crust_service.bootstrap();
+                },
                 Ok(Action::Terminate) => {
                     debug!("routing node terminated");
                     let _ = self.event_sender.send(Event::Terminated);

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -136,7 +136,7 @@ impl RoutingNode {
                     self.set_cache_options(cache_options);
                 },
                 Ok(Action::Rebootstrap) => {
-                    let _open_connections = self.core.reset(self.client_restriction);
+                    self.reset();
                     self.crust_service.bootstrap();
                 },
                 Ok(Action::Terminate) => {
@@ -201,6 +201,26 @@ impl RoutingNode {
             };
             ::std::thread::sleep_ms(1);
         }
+    }
+
+    /// reset keeps the persistant state, but drops all connections
+    /// and restarts the cycle from disconnected.
+    fn reset(&mut self) {
+          let open_connections = self.core.reset(self.client_restriction);
+          for connection in open_connections {
+              self.crust_service.drop_node(connection);
+          }
+          self.filter = ::filter::Filter::with_expiry_duration(::time::Duration::minutes(20));
+          self.connection_filter = ::message_filter::MessageFilter::with_expiry_duration(
+              ::time::Duration::seconds(20));
+          self.public_id_cache = LruCache::with_expiry_duration(::time::Duration::minutes(10));
+          self.accumulator = ::message_accumulator::MessageAccumulator::with_expiry_duration(
+              ::time::Duration::minutes(5));
+          self.refresh_accumulator = ::refresh_accumulator::RefreshAccumulator
+              ::with_expiry_duration(::time::Duration::minutes(5), self.event_sender.clone());
+          self.data_cache = None;
+          let preserve_cache_options = self.cache_options.clone();
+          self.set_cache_options(preserve_cache_options);
     }
 
     /// When CRUST receives a connect to our listening port and establishes a new connection,

--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -314,6 +314,11 @@ impl RoutingTable {
         self.our_id.clone()
     }
 
+    /// Returns all connections listed in the routing table
+    pub fn all_connections(&self) -> Vec<::crust::Connection> {
+        self.routing_table.iter().filter_map(|n| n.connection.clone()).collect::<Vec<::crust::Connection>>()
+    }
+
     /// This returns true if the provided id is closer than or equal to the furthest node in our
     /// close group. If the routing table contains less than GroupSize nodes, then every address is
     /// considered to be in our close group range.


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/733)
<!-- Reviewable:end -->
