### PR TITLE
Fix types vector functions

### DIFF
--- a/src/name_type.rs
+++ b/src/name_type.rs
@@ -71,7 +71,7 @@ impl NameType {
         if data.len() != NAME_TYPE_LEN {
             return Err(NameTypeFromHexError::InvalidLength);
         }
-        Ok(NameType(::types::vector_as_u8_64_array(data)))
+        Ok(NameType(::types::slice_as_u8_64_array(&data[..])))
     }
 
     // Private function exposed in fmt Debug {:?} and Display {} traits.

--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -526,7 +526,7 @@ mod test {
             ContactType::Far => {}
         };
 
-        ::NameType(::types::vector_as_u8_64_array(binary_id.to_bytes()))
+        ::NameType(::types::slice_as_u8_64_array(&binary_id.to_bytes()[..]))
     }
 
     struct Bucket {

--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -227,7 +227,7 @@ impl ::std::fmt::Debug for StructuredData {
                      ::utils::get_debug_id(self.data.clone())));
 
         let prev_owner_keys : Vec<String> = self.previous_owner_keys.iter().map(|pub_key|
-                ::utils::get_debug_id(::types::array_as_vector(&pub_key.0))).collect();
+                ::utils::get_debug_id(&pub_key.0)).collect();
         try!(write!(formatter, " , previous_owner_keys : ("));
         for itr in prev_owner_keys.iter() {
             try!(write!(formatter, "{:?} ", itr));
@@ -235,7 +235,7 @@ impl ::std::fmt::Debug for StructuredData {
         try!(write!(formatter, ")"));
 
         let current_owner_keys : Vec<String> = self.current_owner_keys.iter().map(|pub_key|
-                ::utils::get_debug_id(::types::array_as_vector(&pub_key.0))).collect();
+                ::utils::get_debug_id(&pub_key.0)).collect();
         try!(write!(formatter, " , current_owner_keys : ("));
         for itr in current_owner_keys.iter() {
             try!(write!(formatter, "{:?} ", itr));
@@ -244,7 +244,7 @@ impl ::std::fmt::Debug for StructuredData {
 
         let prev_owner_signatures: Vec<String> =
               self.previous_owner_signatures.iter().map(|signature|
-                ::utils::get_debug_id(::types::array_as_vector(&signature.0))).collect();
+                ::utils::get_debug_id(&signature.0[..])).collect();
         try!(write!(formatter, " , prev_owner_signatures : ("));
         for itr in prev_owner_signatures.iter() {
             try!(write!(formatter, "{:?} ", itr));

--- a/src/test_utils/messages_util.rs
+++ b/src/test_utils/messages_util.rs
@@ -24,7 +24,7 @@ pub fn generate_random_u8() -> u8 {
 }
 
 fn generate_random_nametype() -> ::NameType {
-    ::NameType(::types::vector_as_u8_64_array(::types::generate_random_vec_u8(64)))
+    ::NameType(::types::slice_as_u8_64_array(&::types::generate_random_vec_u8(64)[..]))
 }
 
 fn generate_random_authority(name: ::NameType, key: &::sodiumoxide::crypto::sign::PublicKey)

--- a/src/types.rs
+++ b/src/types.rs
@@ -159,13 +159,13 @@ mod test {
     #[test]
     fn check_conversions() {
         let bytes: super::Bytes = super::generate_random_vec_u8(64);
-        let array = super::vector_as_u8_64_array(bytes.clone());
+        let array = super::slice_as_u8_64_array(&bytes[..]);
 
         assert_eq!(64, array.len());
         assert_eq!(&bytes[..], &array[..]);
 
         let bytes: super::Bytes = super::generate_random_vec_u8(32);
-        let array = super::vector_as_u8_32_array(bytes.clone());
+        let array = super::slice_as_u8_32_array(&bytes[..]);
 
         assert_eq!(32, array.len());
         assert_eq!(&bytes[..], &array[..]);

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,31 +15,32 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-/// Convert a u8 array to u8 vector.
-pub fn array_as_vector(arr: &[u8]) -> Vec<u8> {
-    let mut vector = Vec::new();
-    for i in arr.iter() {
-        vector.push(*i);
-    }
-    vector
-}
-
 /// Convert u8 vector to a fixed 64 byte size array.
-pub fn vector_as_u8_64_array(vector: Vec<u8>) -> [u8; 64] {
-    assert!(vector.len() >= 64);
+/// 
+/// # Panics
+///
+/// Panics if the slice is not 64 bytes in length.
+pub fn slice_as_u8_64_array(slice: &[u8]) -> [u8; 64] {
+    assert!(slice.len() == 64);
     let mut arr = [0u8;64];
+    // TODO (canndrew): This should use copy_memory when it's stable
     for i in 0..64 {
-        arr[i] = vector[i];
+        arr[i] = slice[i];
     }
     arr
 }
 
-/// Convert u8 vector to a fixed 32 byte size array.
-pub fn vector_as_u8_32_array(vector: Vec<u8>) -> [u8; 32] {
-    assert!(vector.len() >= 32);
+/// Convert u8 slice to a fixed 32 byte size array.
+/// 
+/// # Panics
+///
+/// Panics if the slice is not 32 bytes in length
+pub fn slice_as_u8_32_array(slice: &[u8]) -> [u8; 32] {
+    assert!(slice.len() == 32);
     let mut arr = [0u8;32];
+    // TODO (canndrew): This should use copy_memory when it's stable
     for i in 0..32 {
-        arr[i] = vector[i];
+        arr[i] = slice[i];
     }
     arr
 }
@@ -159,17 +160,15 @@ mod test {
     fn check_conversions() {
         let bytes: super::Bytes = super::generate_random_vec_u8(64);
         let array = super::vector_as_u8_64_array(bytes.clone());
-        let vector = super::array_as_vector(&array);
 
-        assert_eq!(64, vector.len());
-        assert_eq!(bytes, vector);
+        assert_eq!(64, array.len());
+        assert_eq!(&bytes[..], &array[..]);
 
         let bytes: super::Bytes = super::generate_random_vec_u8(32);
         let array = super::vector_as_u8_32_array(bytes.clone());
-        let vector = super::array_as_vector(&array);
 
-        assert_eq!(32, vector.len());
-        assert_eq!(bytes, vector);
+        assert_eq!(32, array.len());
+        assert_eq!(&bytes[..], &array[..]);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -96,12 +96,12 @@ mod test {
             Ok(encoded) => encoded,
             Err(_) => panic!("Unexpected serialisation error.")
         };
-        let decoded = match super::decode(&encoded) {
+        let decoded: Vec<u8> = match super::decode(&encoded) {
             Ok(decoded) => decoded,
             Err(_) => panic!("Unexpected deserialisation error.")
         };
 
-        assert_eq!(name, ::NameType(::types::vector_as_u8_64_array(decoded)));
+        assert_eq!(name, ::NameType(::types::slice_as_u8_64_array(&decoded[..])));
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,8 +16,9 @@
 // relating to use of the SAFE Network Software.
 
 /// Formatted string from a vector of bytes.
-pub fn get_debug_id(input: Vec<u8>) -> ::std::string::String {
-  format!("BYTES:{:02x}{:02x}{:02x}..{:02x}{:02x}{:02x}",
+pub fn get_debug_id<V: AsRef<[u8]>>(input: V) -> ::std::string::String {
+    let input = input.as_ref();
+    format!("BYTES:{:02x}{:02x}{:02x}..{:02x}{:02x}{:02x}",
           input[0],
           input[1],
           input[2],


### PR DESCRIPTION
This PR removes/changes some of the functions in types.rs

* The `array_as_vector` function is pointless - you can already do this with `Vec::from(slice)` or `slice.to_owned()`.
* The `vector_as_u8_{32,64}_array` functions should takes slices not vectors - there's no reason for them to be taking owned data.

Note that several other repos will have to be updated to bring them in line with these changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/755)
<!-- Reviewable:end -->
