### PR TITLE
Code clean up - intra-thread channel communication removal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-3.0"
 homepage = "http://maidsafe.net"
 
 [dependencies]
+maidsafe_utilities = "*"
 rustc-serialize = "*"
 cbor = "*"
 time = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ extern crate sodiumoxide;
 extern crate time;
 
 extern crate crust;
+#[allow(unused_extern_crates)] // TODO(Spandan) This will be removed as functionalities get exposed from this crate
+#[macro_use] extern crate maidsafe_utilities;
+
 // extern crate accumulator;
 extern crate lru_time_cache;
 extern crate message_filter;


### PR DESCRIPTION
<1>
removing internal signalling which might give unexpected results - eg.,
Current flow:
fun_0() -> fun_1() { queue event_x; queue_event_y; } -> return to fun_0 -> return to event loop -> execute fun_x -> return to event loop -> execute fun_y

Now the flow will be:
fun_0() -> fun_1() { fun_x(); fun_y(); }

which appears to be better as it is suspicious to have thread-A queue events in a thread-A itself.

<2>
Integrating Using maidsafe_utilities

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/770)
<!-- Reviewable:end -->
