### PR TITLE
add_peer() purged of action_sender

### DIFF
--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -1770,7 +1770,7 @@ impl RoutingNode {
                                                line!()),
                             }
                         },
-                        None => ()
+                        None => info!("No node removed from RT as a result of node addition"),
                     }
 
                     if add_node_result.0 {

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -1785,7 +1785,9 @@ impl RoutingNode {
                             info!("Routing Node has connected to {:?} nodes.", size);
 
                             self.state = State::GroupConnected;
-                            let _ = self.event_sender.send(Event::Connected);
+                            if let Err(err) = self.event_sender.send(Event::Connected) {
+                                error!("Error sending {:?} to event_sender", err.0);
+                            }
                         }
 
                         info!("RT({:?}) added {:?}", size, routing_name);


### PR DESCRIPTION
removing internal signalling which might give unexpected results - eg.,
Current flow:
fun_0() -> fun_1() { queue event_x; queue_event_y; } -> return to fun_0 -> return to event loop -> execute fun_x -> return to event loop -> execute fun_y

Now the flow will be:
fun_0() -> fun_1() { fun_x(); fun_y(); }

which appears to be better as it is suspicious to have thread-A queue events in a thread-A itself.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/771)
<!-- Reviewable:end -->
