### PR TITLE
Replacing Intra Thread signalling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -167,6 +167,8 @@ pub enum RoutingError {
     Cbor(::cbor::CborError),
     /// invalid response
     Response(ResponseError),
+    /// Current state is invalid for the operation
+    InvalidStateForOperation,
 }
 
 impl From<::std::str::Utf8Error> for RoutingError {
@@ -221,6 +223,7 @@ impl ::std::error::Error for RoutingError {
             RoutingError::Io(_) => "I/O error",
             RoutingError::Cbor(_) => "Serialisation error",
             RoutingError::Response(_) => "Response error",
+            RoutingError::InvalidStateForOperation => "Invalid State of Operation",
         }
     }
 
@@ -268,6 +271,8 @@ impl ::std::fmt::Display for RoutingError {
             RoutingError::Io(ref error) => ::std::fmt::Display::fmt(error, formatter),
             RoutingError::Cbor(ref error) => ::std::fmt::Display::fmt(error, formatter),
             RoutingError::Response(ref error) => ::std::fmt::Display::fmt(error, formatter),
+            RoutingError::InvalidStateForOperation =>
+                ::std::fmt::Display::fmt("Invalid state for operation", formatter),
         }
     }
 }

--- a/src/utilities/expiration_map.rs
+++ b/src/utilities/expiration_map.rs
@@ -62,6 +62,20 @@ impl<K, V> ExpirationMap<K, V> where K: PartialOrd + Ord + Clone, V: Clone {
         }
     }
 
+    /// Retrieves a mutable value for the given key if present in the map.
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        match self.map.get_mut(key) {
+            Some(&mut (ref mut value, time)) => {
+                if time + self.time_to_live < ::time::SteadyTime::now() {
+                    None
+                } else {
+                    Some(value)
+                }
+            }
+            None => None,
+        }
+    }
+
     /// Returns true if a value exists for the specified key.
     pub fn contains_key(&mut self, key: &K) -> bool {
         match self.map.get(key) {


### PR DESCRIPTION
removing internal signalling which might give unexpected results - eg.,
Current flow:
fun_0() -> fun_1() { queue event_x; queue_event_y; } -> return to fun_0 -> return to event loop -> execute fun_x -> return to event loop -> execute fun_y

Now the flow will be:
fun_0() -> fun_1() { fun_x(); fun_y(); }

which appears to be better as it is suspicious to have thread-A queue events in a thread-A itself.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/774)
<!-- Reviewable:end -->
