### PR TITLE
Churn handling fixes

### DIFF
--- a/examples/churn_node.rs
+++ b/examples/churn_node.rs
@@ -38,6 +38,7 @@ extern crate maidsafe_utilities;
 extern crate routing;
 extern crate xor_name;
 extern crate rustc_serialize;
+extern crate sodiumoxide;
 extern crate lru_time_cache;
 extern crate time;
 

--- a/examples/node.rs
+++ b/examples/node.rs
@@ -37,6 +37,7 @@ extern crate log;
 extern crate maidsafe_utilities;
 extern crate routing;
 extern crate xor_name;
+extern crate sodiumoxide;
 extern crate rustc_serialize;
 extern crate lru_time_cache;
 extern crate time;

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -66,7 +66,7 @@ impl ExampleClient {
             while let Ok(event) = self.receiver.try_recv() {
                 if let Event::Response(msg) = event {
                     match msg.content {
-                        ResponseContent::GetSuccess(data) => return Some(data),
+                        ResponseContent::GetSuccess(data, _) => return Some(data),
                         ResponseContent::GetFailure { .. } => return None,
                         _ => trace!("Received unexpected response {:?},", msg),
                     };

--- a/src/acceptors.rs
+++ b/src/acceptors.rs
@@ -67,13 +67,15 @@ impl Acceptors {
             Endpoint::Tcp(socket_addr) => {
                 if let Some(ref port) = self.tcp_accepting_port {
                     let _ = self.endpoints
-                                .insert(Endpoint::new(Self::ip_from_socketaddr(socket_addr), port.clone()));
+                                .insert(Endpoint::new(Self::ip_from_socketaddr(socket_addr),
+                                                      port.clone()));
                 }
             }
             Endpoint::Utp(socket_addr) => {
                 if let Some(ref port) = self.utp_accepting_port {
                     let _ = self.endpoints
-                                .insert(Endpoint::new(Self::ip_from_socketaddr(socket_addr), port.clone()));
+                                .insert(Endpoint::new(Self::ip_from_socketaddr(socket_addr),
+                                                      port.clone()));
                 }
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,6 +26,7 @@ use data::{Data, DataRequest};
 use error::{InterfaceError, RoutingError};
 use authority::Authority;
 use messages::RequestContent;
+use sodiumoxide::crypto::box_;
 
 type RoutingResult = Result<(), RoutingError>;
 
@@ -62,22 +63,22 @@ impl Client {
 
     /// Send a Get message with a DataRequest to an Authority, signed with given keys.
     pub fn send_get_request(&mut self, dst: Authority, data_request: DataRequest) -> Result<(), InterfaceError> {
-        self.send_action(RequestContent::Get(data_request), dst)
+        self.send_action(RequestContent::Get(data_request, box_::gen_nonce().0), dst)
     }
 
     /// Add something to the network
     pub fn send_put_request(&self, dst: Authority, data: Data) -> Result<(), InterfaceError> {
-        self.send_action(RequestContent::Put(data), dst)
+        self.send_action(RequestContent::Put(data, box_::gen_nonce().0), dst)
     }
 
     /// Change something already on the network
     pub fn send_post_request(&self, dst: Authority, data: Data) -> Result<(), InterfaceError> {
-        self.send_action(RequestContent::Post(data), dst)
+        self.send_action(RequestContent::Post(data, box_::gen_nonce().0), dst)
     }
 
     /// Remove something from the network
     pub fn send_delete_request(&self, dst: Authority, data: Data) -> Result<(), InterfaceError> {
-        self.send_action(RequestContent::Delete(data), dst)
+        self.send_action(RequestContent::Delete(data, box_::gen_nonce().0), dst)
     }
 
     fn send_action(&self, content: RequestContent, dst: Authority) -> Result<(), InterfaceError> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -62,7 +62,10 @@ impl Client {
     }
 
     /// Send a Get message with a DataRequest to an Authority, signed with given keys.
-    pub fn send_get_request(&mut self, dst: Authority, data_request: DataRequest) -> Result<(), InterfaceError> {
+    pub fn send_get_request(&mut self,
+                            dst: Authority,
+                            data_request: DataRequest)
+                            -> Result<(), InterfaceError> {
         self.send_action(RequestContent::Get(data_request, box_::gen_nonce().0), dst)
     }
 

--- a/src/connection_management/hole_punching_state.rs
+++ b/src/connection_management/hole_punching_state.rs
@@ -90,9 +90,15 @@ mod test {
                           is_rendezvous_connecting: bool) {
         match state {
             ::connection_management::HolePunchingState::Mapping(_) => assert!(is_mapping),
-            ::connection_management::HolePunchingState::Connecting(_, _, _) => assert!(is_connecting),
-            ::connection_management::HolePunchingState::Punching(_, _, _, _) => assert!(is_punching),
-            ::connection_management::HolePunchingState::RendezvousConnecting(_, _) => assert!(is_rendezvous_connecting),
+            ::connection_management::HolePunchingState::Connecting(_, _, _) => {
+                assert!(is_connecting)
+            }
+            ::connection_management::HolePunchingState::Punching(_, _, _, _) => {
+                assert!(is_punching)
+            }
+            ::connection_management::HolePunchingState::RendezvousConnecting(_, _) => {
+                assert!(is_rendezvous_connecting)
+            }
         }
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -475,7 +475,9 @@ impl Core {
         }
     }
 
-    fn get_from_cache(&mut self, routing_msg: &RoutingMessage) -> Option<(Data, [u8; box_::NONCEBYTES])> {
+    fn get_from_cache(&mut self,
+                      routing_msg: &RoutingMessage)
+                      -> Option<(Data, [u8; box_::NONCEBYTES])> {
         match *routing_msg {
             RoutingMessage::Request(RequestMessage {
                     content: RequestContent::Get(DataRequest::ImmutableData(ref name, _), nonce),

--- a/src/core.rs
+++ b/src/core.rs
@@ -155,6 +155,7 @@ impl Core {
 
     pub fn run(&mut self,
                category_rx: ::std::sync::mpsc::Receiver<::maidsafe_utilities::event_sender::MaidSafeEventCategory>) {
+        let mut cur_routing_table_size = 0;
         self.crust_service.bootstrap(0u32, Some(CRUST_DEFAULT_BEACON_PORT));
         for it in category_rx.iter() {
             match it {
@@ -270,7 +271,8 @@ impl Core {
                 }
             } // Category Match
 
-            if self.state == State::Node {
+            if self.state == State::Node && cur_routing_table_size != self.routing_table.len() {
+                cur_routing_table_size = self.routing_table.len();
                 trace!(" -----------------------------------");
                 trace!("| Routing Table size updated to: {}",
                        self.routing_table.len());
@@ -401,8 +403,8 @@ impl Core {
         }
 
         // Cache handling
-        if let Some(data) = self.get_from_cache(signed_msg.content()).cloned() {
-            let content = ResponseContent::GetSuccess(data);
+        if let Some((data, nonce)) = self.get_from_cache(signed_msg.content()) {
+            let content = ResponseContent::GetSuccess(data, nonce);
 
             let response_msg = ResponseMessage {
                 src: Authority::ManagedNode(self.full_id.public_id().name().clone()),
@@ -473,19 +475,24 @@ impl Core {
         }
     }
 
-    fn get_from_cache(&mut self, routing_msg: &RoutingMessage) -> Option<&Data> {
+    fn get_from_cache(&mut self, routing_msg: &RoutingMessage) -> Option<(Data, [u8; box_::NONCEBYTES])> {
         match *routing_msg {
             RoutingMessage::Request(RequestMessage {
-                    content: RequestContent::Get(DataRequest::ImmutableData(ref name, _)),
+                    content: RequestContent::Get(DataRequest::ImmutableData(ref name, _), nonce),
                     ..
-                }) => self.data_cache.get(&name),
+                }) => {
+                match self.data_cache.get(&name) {
+                    Some(data) => Some((data.clone(), nonce)),
+                    _ => None,
+                }
+            }
             _ => None,
         }
     }
 
     fn add_to_cache(&mut self, routing_msg: &RoutingMessage) {
         if let RoutingMessage::Response(ResponseMessage {
-                    content: ResponseContent::GetSuccess(ref data @ Data::ImmutableData(_)),
+                    content: ResponseContent::GetSuccess(ref data @ Data::ImmutableData(_), _),
                     ..
                 }) = *routing_msg {
             let _ = self.data_cache.insert(data.name().clone(), data.clone());
@@ -497,7 +504,6 @@ impl Core {
                               routing_msg: RoutingMessage,
                               public_id: PublicId)
                               -> Result<(), RoutingError> {
-        trace!("{:?} Rxd {:?}", self, routing_msg);
         if let &RoutingMessage::Request(RequestMessage { content: RequestContent::Refresh { ref nonce, ref content }, .. }) = &routing_msg {
             if self.state == State::Node {
                 return self.handle_refresh(nonce.clone(), content.clone(), public_id)
@@ -527,6 +533,7 @@ impl Core {
     fn dispatch_request_response(&mut self,
                                  routing_msg: RoutingMessage)
                                  -> Result<(), RoutingError> {
+        trace!("{:?} - Handling - {:?}", self, routing_msg);
         match routing_msg {
             RoutingMessage::Request(msg) => self.handle_request_message(msg),
             RoutingMessage::Response(msg) => self.handle_response_message(msg),
@@ -605,10 +612,10 @@ impl Core {
                                                          src_name,
                                                          dst_name)
             }
-            (RequestContent::Get(_), _, _) |
-            (RequestContent::Put(_), _, _) |
-            (RequestContent::Post(_), _, _) |
-            (RequestContent::Delete(_), _, _) => {
+            (RequestContent::Get(..), _, _) |
+            (RequestContent::Put(..), _, _) |
+            (RequestContent::Post(..), _, _) |
+            (RequestContent::Delete(..), _, _) => {
                 let event = Event::Request(request_msg);
                 let _ = self.event_sender.send(event);
                 Ok(())
@@ -659,10 +666,10 @@ impl Core {
              Authority::Client { client_key, proxy_node_name, }) => {
                 self.handle_get_close_group_response(close_group_ids, client_key, proxy_node_name)
             }
-            (ResponseContent::GetSuccess(_), _, _) |
-            (ResponseContent::PutSuccess(_), _, _) |
-            (ResponseContent::PostSuccess(_), _, _) |
-            (ResponseContent::DeleteSuccess(_), _, _) |
+            (ResponseContent::GetSuccess(..), _, _) |
+            (ResponseContent::PutSuccess(..), _, _) |
+            (ResponseContent::PostSuccess(..), _, _) |
+            (ResponseContent::DeleteSuccess(..), _, _) |
             (ResponseContent::GetFailure{..}, _, _) |
             (ResponseContent::PutFailure{..}, _, _) |
             (ResponseContent::PostFailure{..}, _, _) |
@@ -956,12 +963,8 @@ impl Core {
                         }
                     } else {
                         if self.routing_table.is_close(public_id.name()) {
-                            // send churn
-                            let event = Event::Churn(ChurnEventId { id: public_id.name().clone() });
-
-                            if let Err(err) = self.event_sender.send(event) {
-                                error!("Error sending event to routing user - {:?}", err);
-                            }
+                            // NOTE: Send LostCloseNode event before Churn
+                            // as this will prevent invalid data from getting refreshed due to churn
 
                             // If the new node is going to displace a node from the close group then
                             // inform the vaults about the node being moved out of close group
@@ -975,6 +978,13 @@ impl Core {
                                         error!("Error sending event to routing user - {:?}", err);
                                     }
                                 }
+                            }
+
+                            // send churn
+                            let event = Event::Churn(ChurnEventId { id: public_id.name().clone() });
+
+                            if let Err(err) = self.event_sender.send(event) {
+                                error!("Error sending event to routing user - {:?}", err);
                             }
                         }
 
@@ -1587,14 +1597,18 @@ impl Core {
     fn dropped_routing_node_connection(&mut self, connection: &::crust::Connection) {
         if let Some(node_name) = self.routing_table.drop_connection(connection) {
             if self.routing_table.is_close(&node_name) {
-                // If the lost node was in our close grp send Churn Event
-                let event = Event::Churn(ChurnEventId { id: node_name.clone() });
+                // NOTE: Send LostCloseNode event before Churn
+                // as this will prevent invalid data from getting refreshed due to churn
 
+                // If the lost node was in our close grp let the vaults know about the lost node
+                let event = Event::LostCloseNode(node_name);
                 if let Err(err) = self.event_sender.send(event) {
                     error!("Error sending event to routing user - {:?}", err);
                 }
-                // If the lost node was in our close grp let the vaults know about the lost node
-                let event = Event::LostCloseNode(node_name);
+
+                // If the lost node was in our close grp send Churn Event
+                let event = Event::Churn(ChurnEventId { id: node_name.clone() });
+
                 if let Err(err) = self.event_sender.send(event) {
                     error!("Error sending event to routing user - {:?}", err);
                 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -101,7 +101,9 @@ mod test {
 
         // name() resolves correctly for ImmutableData
         let value = "immutable data value".to_string().into_bytes();
-        let immutable_data = ::immutable_data::ImmutableData::new(::immutable_data::ImmutableDataType::Normal, value);
+        let immutable_data =
+            ::immutable_data::ImmutableData::new(::immutable_data::ImmutableDataType::Normal,
+                                                 value);
         assert_eq!(immutable_data.name(),
                    ::data::Data::ImmutableData(immutable_data).name());
 
@@ -133,7 +135,9 @@ mod test {
 
         // payload_size() resolves correctly for ImmutableData
         let value = "immutable data value".to_string().into_bytes();
-        let immutable_data = ::immutable_data::ImmutableData::new(::immutable_data::ImmutableDataType::Normal, value);
+        let immutable_data =
+            ::immutable_data::ImmutableData::new(::immutable_data::ImmutableDataType::Normal,
+                                                 value);
         assert_eq!(immutable_data.payload_size(),
                    ::data::Data::ImmutableData(immutable_data).payload_size());
 
@@ -154,7 +158,9 @@ mod test {
                    ::data::DataRequest::StructuredData(name, tag).name());
 
         // name() resolves correctly for ImmutableData
-        let actual_name = ::data::DataRequest::ImmutableData(name, ::immutable_data::ImmutableDataType::Normal).name();
+        let actual_name =
+            ::data::DataRequest::ImmutableData(name, ::immutable_data::ImmutableDataType::Normal)
+                .name();
         assert_eq!(name.clone(), actual_name);
 
         // name() resolves correctly for PlainData

--- a/src/immutable_data.rs
+++ b/src/immutable_data.rs
@@ -110,23 +110,27 @@ mod test {
         // Normal
         let immutable_data = ImmutableData::new(ImmutableDataType::Normal, value);
         let immutable_data_name = immutable_data.name().0.as_ref().to_hex();
-        let expected_immutable_data_name = "9f1c9e526f47e36d782de464ea9df0a31a5c19c321f2a5d9c8faacdda4d59abc713445c8c8\
-                                            53e1842d7c2c2311650df1ee24107371935b6be88a10cbf4cd2f8f";
+        let expected_immutable_data_name = "9f1c9e526f47e36d782de464ea9df0a31a5c19c321f2a5d9c8faac\
+                                            dda4d59abc713445c8c853e1842d7c2c2311650df1ee2410737193\
+                                            5b6be88a10cbf4cd2f8f";
         assert_eq!(&expected_immutable_data_name, &immutable_data_name);
         // Backup
-        let immutable_data_backup = ImmutableData::new(ImmutableDataType::Backup, immutable_data.value().clone());
+        let immutable_data_backup = ImmutableData::new(ImmutableDataType::Backup,
+                                                       immutable_data.value().clone());
         let immutable_data_backup_name = immutable_data_backup.name().0.as_ref().to_hex();
-        let expected_immutable_data_backup_name = "8c6377c848321dd3c6886a53b1a2bc28a5bc8ce35ac85d10d75467a5df9434abaee\
-                                                   19ce2c710507533d306302b165b4387458b752579fc15e520daaf984a2e38";
+        let expected_immutable_data_backup_name = "8c6377c848321dd3c6886a53b1a2bc28a5bc8ce35ac85d1\
+                                                   0d75467a5df9434abaee19ce2c710507533d306302b165b\
+                                                   4387458b752579fc15e520daaf984a2e38";
         assert_eq!(&expected_immutable_data_backup_name,
                    &immutable_data_backup_name);
         // Sacrificial
         let immutable_data_sacrificial = ImmutableData::new(ImmutableDataType::Sacrificial,
                                                             immutable_data.value().clone());
         let immutable_data_sacrificial_name = immutable_data_sacrificial.name().0.as_ref().to_hex();
-        let expected_immutable_data_sacrificial_name = "ecb6c761c35d4da33b25057fbf6161e68711f9e0c11122732e62661340e630\
-                                                        d3c59f7c165f4862d51db5254a38ab9b15a9b8af431e8500a4eb558b9136bd\
-                                                        4135";
+        let expected_immutable_data_sacrificial_name = "ecb6c761c35d4da33b25057fbf6161e68711f9e0c1\
+                                                        1122732e62661340e630d3c59f7c165f4862d51db5\
+                                                        254a38ab9b15a9b8af431e8500a4eb558b9136bd41\
+                                                        35";
         assert_eq!(&expected_immutable_data_sacrificial_name,
                    &immutable_data_sacrificial_name);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,8 @@ pub use error::{InterfaceError, RoutingError};
 pub use event::Event;
 pub use id::{FullId, PublicId};
 pub use immutable_data::{ImmutableData, ImmutableDataType};
-pub use messages::{RequestContent, RequestMessage, ResponseContent, ResponseMessage, RoutingMessage, SignedMessage};
+pub use messages::{RequestContent, RequestMessage, ResponseContent, ResponseMessage,
+                   RoutingMessage, SignedMessage};
 pub use node::Node;
 pub use plain_data::PlainData;
 pub use structured_data::{MAX_STRUCTURED_DATA_SIZE_IN_BYTES, StructuredData};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -246,13 +246,13 @@ pub enum RequestContent {
     },
     // ---------- External ------------
     /// Ask for data from network, passed from API with data name as parameter
-    Get(DataRequest),
+    Get(DataRequest, [u8; box_::NONCEBYTES]),
     /// Put data to network. Provide actual data as parameter
-    Put(Data),
+    Put(Data, [u8; box_::NONCEBYTES]),
     /// Post data to network. Provide actual data as parameter
-    Post(Data),
+    Post(Data, [u8; box_::NONCEBYTES]),
     /// Delete data from network. Provide actual data as parameter
-    Delete(Data),
+    Delete(Data, [u8; box_::NONCEBYTES]),
 }
 
 /// Types of respnses to exepect on the network.
@@ -294,15 +294,17 @@ pub enum ResponseContent {
     /// Should not be ignored. The data requested sent back
     /// (ManagedNode (cache) | NaeManagers) -> client
     /// ManagedNode -> NaeManagers
-    GetSuccess(Data),
+    GetSuccess(Data, [u8; box_::NONCEBYTES]),
     /// Success token for Put (may be ignored)
-    PutSuccess(sha512::Digest),
+    PutSuccess(sha512::Digest, [u8; box_::NONCEBYTES]),
     /// Success token for Post  (may be ignored)
-    PostSuccess(sha512::Digest),
+    PostSuccess(sha512::Digest, [u8; box_::NONCEBYTES]),
     /// Success token for delete  (may be ignored)
-    DeleteSuccess(sha512::Digest),
+    DeleteSuccess(sha512::Digest, [u8; box_::NONCEBYTES]),
     /// Error for Get, includes signed request to prevent injection attacks
     GetFailure {
+        /// Unique response identifier
+        nonce_bytes: [u8; box_::NONCEBYTES],
         /// Originators signed request
         request: RequestMessage,
         /// Error type sent back, may be injected form upper layers
@@ -310,6 +312,8 @@ pub enum ResponseContent {
     },
     /// Error for Put, includes signed request to prevent injection attacks
     PutFailure {
+        /// Unique response identifier
+        nonce_bytes: [u8; box_::NONCEBYTES],
         /// Originators signed request
         request: RequestMessage,
         /// Error type sent back, may be injected form upper layers
@@ -317,6 +321,8 @@ pub enum ResponseContent {
     },
     /// Error for Post, includes signed request to prevent injection attacks
     PostFailure {
+        /// Unique response identifier
+        nonce_bytes: [u8; box_::NONCEBYTES],
         /// Originators signed request
         request: RequestMessage,
         /// Error type sent back, may be injected form upper layers
@@ -324,6 +330,8 @@ pub enum ResponseContent {
     },
     /// Error for delete, includes signed request to prevent injection attacks
     DeleteFailure {
+        /// Unique response identifier
+        nonce_bytes: [u8; box_::NONCEBYTES],
         /// Originators signed request
         request: RequestMessage,
         /// Error type sent back, may be injected form upper layers

--- a/src/structured_data.rs
+++ b/src/structured_data.rs
@@ -80,7 +80,9 @@ impl StructuredData {
     /// This is done this way to allow types to be created and previous_owner_signatures added one by one
     /// To transfer ownership the current owner signs over the data, the previous owners field
     /// must have the previous owners of version - 1 as the current owners of that last version.
-    pub fn replace_with_other(&mut self, other: StructuredData) -> Result<(), ::error::RoutingError> {
+    pub fn replace_with_other(&mut self,
+                              other: StructuredData)
+                              -> Result<(), ::error::RoutingError> {
         try!(self.validate_self_against_successor(&other));
 
         self.type_tag = other.type_tag;
@@ -99,7 +101,9 @@ impl StructuredData {
     }
 
     /// Validate...
-    pub fn validate_self_against_successor(&self, other: &StructuredData) -> Result<(), ::error::RoutingError> {
+    pub fn validate_self_against_successor(&self,
+                                           other: &StructuredData)
+                                           -> Result<(), ::error::RoutingError> {
         let owner_keys_to_match = if other.previous_owner_keys.is_empty() {
             &other.current_owner_keys
         } else {
@@ -108,7 +112,8 @@ impl StructuredData {
 
         // TODO(dirvine) Increase error types to be more descriptive  :07/07/2015
         if other.type_tag != self.type_tag || other.identifier != self.identifier ||
-           other.version != self.version + 1 || *owner_keys_to_match != self.current_owner_keys {
+           other.version != self.version + 1 ||
+           *owner_keys_to_match != self.current_owner_keys {
             return Err(::error::RoutingError::UnknownMessageType);
         }
         other.verify_previous_owner_signatures(owner_keys_to_match)
@@ -138,7 +143,9 @@ impl StructuredData {
 
         let check_all_keys = |&sig| {
             owner_keys.iter()
-                      .any(|ref pub_key| ::sodiumoxide::crypto::sign::verify_detached(&sig, &data, pub_key))
+                      .any(|ref pub_key| {
+                          ::sodiumoxide::crypto::sign::verify_detached(&sig, &data, pub_key)
+                      })
         };
 
         if self.previous_owner_signatures
@@ -179,7 +186,8 @@ impl StructuredData {
     }
 
     /// Overwrite any existing signatures with the new signatures provided
-    pub fn replace_signatures(&mut self, new_signatures: Vec<::sodiumoxide::crypto::sign::Signature>) {
+    pub fn replace_signatures(&mut self,
+                              new_signatures: Vec<::sodiumoxide::crypto::sign::Signature>) {
         self.previous_owner_signatures = new_signatures;
     }
 
@@ -255,7 +263,9 @@ impl ::std::fmt::Debug for StructuredData {
 
         let prev_owner_signatures: Vec<String> = self.previous_owner_signatures
                                                      .iter()
-                                                     .map(|signature| ::utils::get_debug_id(&signature.0[..]))
+                                                     .map(|signature| {
+                                                         ::utils::get_debug_id(&signature.0[..])
+                                                     })
                                                      .collect();
         try!(write!(formatter, " , prev_owner_signatures : ("));
         for itr in &prev_owner_signatures {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -84,7 +84,8 @@ mod test {
         let mut close_nodes_one_entry: Vec<XorName> = Vec::new();
         close_nodes_one_entry.push(rand::random());
         let actual_relocated_name_one_entry =
-            unwrap_result!(super::calculate_relocated_name(close_nodes_one_entry.clone(), &original_name));
+            unwrap_result!(super::calculate_relocated_name(close_nodes_one_entry.clone(),
+                                                           &original_name));
         assert!(original_name != actual_relocated_name_one_entry);
 
         let mut combined_one_node_vec: Vec<XorName> = Vec::new();
@@ -98,7 +99,8 @@ mod test {
             }
         }
 
-        let expected_relocated_name_one_node = XorName(::sodiumoxide::crypto::hash::sha512::hash(&combined_one_node).0);
+        let expected_relocated_name_one_node =
+            XorName(::sodiumoxide::crypto::hash::sha512::hash(&combined_one_node).0);
 
         assert_eq!(actual_relocated_name_one_entry,
                    expected_relocated_name_one_node);
@@ -108,8 +110,8 @@ mod test {
         for _ in 0..::kademlia_routing_table::GROUP_SIZE {
             close_nodes.push(rand::random());
         }
-        let actual_relocated_name = unwrap_result!(super::calculate_relocated_name(close_nodes.clone(),
-                                                                                   &original_name));
+        let actual_relocated_name =
+            unwrap_result!(super::calculate_relocated_name(close_nodes.clone(), &original_name));
         assert!(original_name != actual_relocated_name);
         close_nodes.sort_by(|a, b| {
             if ::xor_name::closer_to_target(&a, &b, &original_name) {
@@ -132,7 +134,8 @@ mod test {
             combined.push(*i);
         }
 
-        let expected_relocated_name = XorName(::sodiumoxide::crypto::hash::sha512::hash(&combined).0);
+        let expected_relocated_name = XorName(::sodiumoxide::crypto::hash::sha512::hash(&combined)
+                                                  .0);
         assert_eq!(expected_relocated_name, actual_relocated_name);
 
         let mut invalid_combined: Vec<u8> = Vec::new();
@@ -145,7 +148,8 @@ mod test {
         for i in original_name.get_id().into_iter() {
             invalid_combined.push(*i);
         }
-        let invalid_relocated_name = XorName(::sodiumoxide::crypto::hash::sha512::hash(&invalid_combined).0);
+        let invalid_relocated_name =
+            XorName(::sodiumoxide::crypto::hash::sha512::hash(&invalid_combined).0);
         assert!(invalid_relocated_name != actual_relocated_name);
     }
 }


### PR DESCRIPTION
- Add NONCE to External Requests

This prevents repeated requests from getting filtered out, thereby allowing clients to request the same chunk twice. Also in the process of churn, NaeManagers might request a ManagedNode for a chunk which it might have previously retrieved for a client within the filter duration.

`Client` API generates a Nonce internally per request made by upper libraries.

`Node` API expects a Nonce in the API function for requests and responses since these will purely be used to respond to requests made by client from which the nonce is expected to be used to continue the message flow. The only action initiated by vaults directly for now is when chunks are relocated for `LostCloseNode`, for this a nonce is derived from the `lost_node` which should thereby yield the same nonce to the entire group.

- Emit `LostCloseNode` before `Churn`

This allows the refresh messages synchronised between persona groups of upper libraries hold accurate info.


__________

With these changes, Churn/LostCloseNode function as expected and is tested with the `key_value_store` example running 15 Nodes and killing 8. Data stored by client continue to be available even after the original nodes storing the chunks have gone offline.

TODO: Updates to make the examples more robust and simulate vault flow more accurately namely respond with failure responses when applicable across the personas. Also stop refreshing group info received in refresh messages once suitable entries are accumulated for all personas (This will prevent slow responding nodes within the accumulator expiry duration from resetting data held by the group if other nodes have updated corresponding info in the meantime)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/854)
<!-- Reviewable:end -->
