### PR TITLE
Churn fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ log = "~0.3.4"
 lru_time_cache = "~0.2.5"
 maidsafe_utilities = "~0.1.5"
 message_filter = "~0.2.0"
+rand = "~0.3.12"
 rustc-serialize = "~0.3.16"
 sodiumoxide = "~0.0.9"
 time = "~0.1.34"
@@ -29,7 +30,6 @@ xor_name = "~0.0.1"
 bit-vec = "~0.4.2"
 docopt = "~0.6.78"
 env_logger = "~0.3.2"
-rand = "~0.3.12"
 
 [[example]]
 bench = false

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -38,7 +38,7 @@ pub struct ExampleNode {
     client_accounts: HashMap<XorName, u64>,
     connected: bool,
     client_request_cache: LruCache<XorName, Vec<Authority>>, /* DataName vs List of ClientAuth asking for data */
-    lost_node_cache: LruCache<XorName, (XorName, MessageId)>, // DataName vs (LostNode, Churn MessageId)
+    lost_node_cache: LruCache<XorName, XorName>, // DataName vs LostNode
 }
 
 #[allow(unused)]
@@ -256,7 +256,7 @@ impl ExampleNode {
             }
         }
 
-        if let Some((lost_node, churn_id)) = self.lost_node_cache.remove(&data.name()) {
+        if let Some(lost_node) = self.lost_node_cache.remove(&data.name()) {
             trace!("{:?} GetSuccess received for lost node {:?} for data {:?}",
                    self,
                    lost_node,
@@ -280,7 +280,7 @@ impl ExampleNode {
                 let src = dst;
                 let dst = Authority::ManagedNode(node.clone());
                 unwrap_result!(self.node
-                                   .send_put_request(src.clone(), dst, data.clone(), id));
+                                   .send_put_request(src.clone(), dst, data.clone(), id.clone()));
 
                 // TODO currently we assume these msgs are saved by managed nodes we should wait for put success to
                 // confirm the same
@@ -291,7 +291,7 @@ impl ExampleNode {
                        unwrap_option!(self.dm_accounts.get(&data.name()), ""));
 
                 // Send Refresh message with updated storage locations in DataManager
-                self.send_data_manager_refresh_messages(churn_id);
+                self.send_data_manager_refresh_messages(id);
             }
         }
     }
@@ -314,7 +314,11 @@ impl ExampleNode {
         }
 
         if let Some(lost_close_node) = lost_close_node {
-            self.process_lost_close_node(lost_close_node, id);
+            self.process_lost_close_node(lost_close_node, id.clone());
+
+            // Send current dm_accounts here after removal of lost_close_node with id reversed
+            // will also get sent after chunk relocation with id
+            self.send_data_manager_refresh_messages(MessageId::from_reverse(&id));
         } else {
             self.send_data_manager_refresh_messages(id);
         }
@@ -325,7 +329,7 @@ impl ExampleNode {
         for dm_account in self.dm_accounts.iter_mut() {
             if let Some(lost_node_pos) = dm_account.1.iter().position(|elt| *elt == lost_node) {
                 let _ = self.lost_node_cache
-                            .insert(dm_account.0.clone(), (lost_node.clone(), id.clone()));
+                            .insert(dm_account.0.clone(), lost_node.clone());
                 let _ = dm_account.1.remove(lost_node_pos);
                 if dm_account.1.is_empty() {
                     error!("Chunk lost - No valid nodes left to retrieve chunk");
@@ -344,15 +348,12 @@ impl ExampleNode {
                                .send_get_request(src.clone(),
                                                  Authority::ManagedNode(it.clone()),
                                                  DataRequest::PlainData(dm_account.0.clone()),
-                                                 MessageId::from_xor_name(lost_node.clone())) {
+                                                 id.clone()) {
                         error!("Failed to send get request to retrieve chunk - {:?}", err);
                     }
                 }
             }
         }
-
-        // TODO: Probably better doing this on a per account held basis
-        self.send_data_manager_refresh_messages(id.from_reverse());
     }
 
     fn send_data_manager_refresh_messages(&mut self, id: MessageId) {

--- a/src/core.rs
+++ b/src/core.rs
@@ -949,7 +949,7 @@ impl Core {
 
                             // send churn
                             let event = Event::Churn {
-                                id: MessageId::from_xor_name(public_id.name().clone()),
+                                id: MessageId::from_added_node(public_id.name().clone()),
                                 lost_close_node: lost_close_node,
                             };
 
@@ -1544,7 +1544,7 @@ impl Core {
             if self.routing_table.is_close(&node_name) {
                 // If the lost node was in our close grp send Churn Event
                 let event = Event::Churn {
-                    id: MessageId::from_xor_name(node_name.clone()),
+                    id: MessageId::from_lost_node(node_name.clone()),
                     lost_close_node: Some(node_name),
                 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ extern crate itertools;
 extern crate lru_time_cache;
 extern crate kademlia_routing_table;
 extern crate message_filter;
+extern crate rand;
 extern crate rustc_serialize;
 extern crate sodiumoxide;
 extern crate time;


### PR DESCRIPTION
MessageId generated for churn event raised by routing is unique between a node added / lost.

This prevents churn getting ignored when a Node is Added and soon after lost. In this case previously both `MessageId`'s were the same thereby getting filtered by `signed_msg_filter`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/870)
<!-- Reviewable:end -->
