### PR TITLE
Join limit

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1073,7 +1073,7 @@ impl Core {
 
                         if self.routing_table.len() >= ::kademlia_routing_table::group_size()
                                 && !self.proxy_map.is_empty() {
-                            trace!("Routing table reached quorum size. Dropping proxy.");
+                            trace!("Routing table reached group size. Dropping proxy.");
                             self.proxy_map.keys()
                                 .foreach(|&connection| self.crust_service.drop_node(connection));
                             self.proxy_map.clear();

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -49,6 +49,8 @@ pub enum DirectMessage {
         /// quorum size, dynamically calculated
         current_quorum_size: usize,
     },
+    /// Sent to the client to indicate that this node is not available as a bootstrap node.
+    BootstrapDeny,
     /// Sent from a newly connected client to the bootstrap node to inform it about the client's
     /// public ID.
     ClientIdentify {
@@ -56,6 +58,8 @@ pub enum DirectMessage {
         serialised_public_id: Vec<u8>,
         /// Signature of the client.
         signature: sign::Signature,
+        /// Indicate whether we intend to remain a client.
+        client_restriction: bool,
     },
     /// Sent from a node to a node.
     NodeIdentify {


### PR DESCRIPTION
Limit the number of prospective nodes in the bootstrapping process to one per proxy node.

We also disabled the direction check for now, since we found that it makes the ci_test less reliable. This is to be expected since the notion of a "close node" is currently ill-defined, but we should consider re-enabling it once that issue is fixed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/878)
<!-- Reviewable:end -->
