### PR TITLE
Updated ImmutableData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ version = "0.11.1"
 
 [dependencies]
 accumulator = "~0.2.0"
-clippy = {version = "~0.0.46", optional = true}
+clippy = {version = "~0.0.56", optional = true}
 crust = "~0.9.0"
-itertools = "~0.4.10"
+itertools = "~0.4.11"
 kademlia_routing_table = "~0.4.0"
 log = "~0.3.5"
 lru_time_cache = "~0.2.7"
-maidsafe_utilities = "~0.4.0"
+maidsafe_utilities = "~0.4.1"
 message_filter = "~0.3.1"
 rand = "~0.3.14"
 rustc-serialize = "~0.3.18"
@@ -27,7 +27,7 @@ xor_name = "~0.1.0"
 
 [dev-dependencies]
 docopt = "~0.6.78"
-libc = "~0.2.7"
+libc = "~0.2.8"
 
 [features]
 use-mock-crust = []

--- a/src/core.rs
+++ b/src/core.rs
@@ -866,10 +866,10 @@ impl Core {
     fn get_from_cache(&mut self, routing_msg: &RoutingMessage) -> Option<RoutingMessage> {
         let content = match *routing_msg {
             RoutingMessage::Request(RequestMessage {
-                    content: RequestContent::Get(DataRequest::Immutable(ref name, _), id),
+                    content: RequestContent::Get(DataRequest::Immutable(ref name), id),
                     ..
                 }) => {
-                match self.data_cache.get(&name) {
+                match self.data_cache.get(name.raw()) {
                     Some(data) => ResponseContent::GetSuccess(data.clone(), id),
                     _ => return None,
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,6 +89,8 @@ pub enum RoutingError {
     SendEventError(SendError<Event>),
     /// The bit index for a `XorName` was out of bounds.
     BitIndexOutOfBoundsError,
+    /// Failed to derive an ImmutableDataName
+    UnableToDeriveName,
     /// Current state is invalid for the operation
     InvalidStateForOperation,
     /// Serialisation Error

--- a/src/immutable_data.rs
+++ b/src/immutable_data.rs
@@ -17,73 +17,153 @@
 
 use std::fmt::{self, Debug, Formatter};
 
+use error::RoutingError;
 use rustc_serialize::{Decoder, Encodable, Encoder};
 use xor_name::XorName;
-use sodiumoxide::crypto;
+use sodiumoxide::crypto::hash::sha512;
 
 #[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd, RustcEncodable, RustcDecodable, Debug)]
 /// The type of an individual copy of immutable data.
-pub enum ImmutableDataType {
+pub enum ImmutableDataName {
     /// Used in normal operation. The name of the data is the SHA512 hash of its value.
-    Normal,
+    Normal(XorName),
     /// Used only when no normal copies are left, or if copies need to be relocated. Its name is
     /// `hash(hash(value))`.
-    Backup,
+    Backup(XorName),
     /// Only kept if there is unused space left. If storage space becomes scarce, this copy will be
     /// sacrificed. Its name is `hash(hash(hash(value)))`.
-    Sacrificial,
+    Sacrificial(XorName),
+}
+
+impl ImmutableDataName {
+    /// Construct a new Normal name by taking the SHA512 digest of `value`.
+    pub fn new(value: &[u8]) -> ImmutableDataName {
+        ImmutableDataName::Normal(XorName(sha512::hash(value).0))
+    }
+
+    /// Construct a new Normal name by copying `raw_name`.
+    pub fn from_raw(raw_name: &XorName) -> ImmutableDataName {
+        ImmutableDataName::Normal(*raw_name)
+    }
+
+    /// Returns the underlying data name without any type info.
+    pub fn raw(&self) -> &XorName {
+        match *self {
+            ImmutableDataName::Normal(ref name) => name,
+            ImmutableDataName::Backup(ref name) => name,
+            ImmutableDataName::Sacrificial(ref name) => name,
+        }
+    }
+
+    /// Converts `self` to a Backup name.  Returns an error if the initial type is not Normal or
+    /// Backup.
+    pub fn to_backup(&self) -> Result<ImmutableDataName, RoutingError> {
+        match *self {
+            ImmutableDataName::Normal(ref name) => {
+                Ok(ImmutableDataName::Backup(XorName(sha512::hash(&name.0).0)))
+            }
+            ImmutableDataName::Backup(_) => Ok(self.clone()),
+            ImmutableDataName::Sacrificial(_) => Err(RoutingError::UnableToDeriveName),
+        }
+    }
+
+    /// Converts `self` to a Sacrificial name.
+    pub fn to_sacrificial(&self) -> ImmutableDataName {
+        match *self {
+            ImmutableDataName::Normal(ref name) => {
+                ImmutableDataName::Sacrificial(XorName(sha512::hash(&sha512::hash(&name.0).0).0))
+            }
+            ImmutableDataName::Backup(ref name) => {
+                ImmutableDataName::Sacrificial(XorName(sha512::hash(&name.0).0))
+            }
+            ImmutableDataName::Sacrificial(_) => self.clone(),
+        }
+    }
 }
 
 /// An immutable chunk of data.
 ///
 /// Its name is computed from its content by applying the SHA512 hash up to three times, depending
-/// on the `ImmutableDataType`.
+/// on the type ([see `ImmutableDataName` for further details](enum.ImmutableDataName.html)).
 #[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd, RustcEncodable, RustcDecodable)]
 pub struct ImmutableData {
-    type_tag: ImmutableDataType,
+    name: ImmutableDataName,
     value: Vec<u8>,
 }
 
 impl ImmutableData {
-    /// Creates a new instance of ImmutableData
-    pub fn new(type_tag: ImmutableDataType, value: Vec<u8>) -> ImmutableData {
+    /// Creates a new Normal instance of ImmutableData.
+    pub fn new(value: Vec<u8>) -> ImmutableData {
         ImmutableData {
-            type_tag: type_tag,
+            name: ImmutableDataName::new(&value),
             value: value,
         }
     }
 
-    /// Returns the value
+    /// Returns the name (which also specifies the chunk type).
+    pub fn name(&self) -> &ImmutableDataName {
+        &self.name
+    }
+
+    /// Returns the underlying name without any type info.
+    pub fn raw_name(&self) -> &XorName {
+        self.name.raw()
+    }
+
+    /// Returns the value.
     pub fn value(&self) -> &Vec<u8> {
         &self.value
-    }
-
-    /// Returns the type
-    pub fn get_type_tag(&self) -> &ImmutableDataType {
-        &self.type_tag
-    }
-
-    /// Returns name ensuring invariant
-    pub fn name(&self) -> XorName {
-        let digest = crypto::hash::sha512::hash(&self.value);
-        match self.type_tag {
-            ImmutableDataType::Normal => XorName(digest.0),
-            ImmutableDataType::Backup => XorName(crypto::hash::sha512::hash(&digest.0).0),
-            ImmutableDataType::Sacrificial => {
-                XorName(crypto::hash::sha512::hash(&crypto::hash::sha512::hash(&digest.0).0).0)
-            }
-        }
     }
 
     /// Return size of contained value.
     pub fn payload_size(&self) -> usize {
         self.value.len()
     }
+
+    /// Converts the type to Normal, consuming `self`.
+    pub fn into_normal(self) -> ImmutableData {
+        if let ImmutableDataName::Normal(_) = self.name {
+            self
+        } else {
+            ImmutableData::new(self.value)
+        }
+    }
+
+    /// Converts the type to Backup, consuming `self`.
+    pub fn into_backup(self) -> ImmutableData {
+        match self.name {
+            ImmutableDataName::Normal(_) => {
+                ImmutableData {
+                    name: self.name.to_backup().expect("This can't fail"),
+                    value: self.value,
+                }
+            }
+            ImmutableDataName::Backup(_) => self,
+            ImmutableDataName::Sacrificial(_) => {
+                ImmutableData {
+                    name: ImmutableDataName::new(&self.value).to_backup().expect("This can't fail"),
+                    value: self.value,
+                }
+            }
+        }
+    }
+
+    /// Converts the type to Sacrificial, consuming `self`.
+    pub fn into_sacrificial(self) -> ImmutableData {
+        if let ImmutableDataName::Sacrificial(_) = self.name {
+            self
+        } else {
+            ImmutableData {
+                name: self.name.to_sacrificial(),
+                value: self.value,
+            }
+        }
+    }
 }
 
 impl Debug for ImmutableData {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "ImmutableData {{ {:?}, {} }}", self.type_tag, self.name())
+        write!(formatter, "ImmutableData {{ {:?} }}", self.name)
     }
 }
 
@@ -91,10 +171,10 @@ impl Debug for ImmutableData {
 mod test {
     extern crate rand;
 
-    use super::{ImmutableData, ImmutableDataType};
+    use super::*;
     use self::rand::Rng;
     use rustc_serialize::hex::ToHex;
-    use sodiumoxide::crypto;
+    use sodiumoxide::crypto::hash::sha512;
 
     fn generate_random() -> Vec<u8> {
         let size = 64;
@@ -108,28 +188,25 @@ mod test {
 
     #[test]
     fn deterministic_test() {
-
         let value = "immutable data value".to_owned().into_bytes();
         // Normal
-        let immutable_data = ImmutableData::new(ImmutableDataType::Normal, value);
-        let immutable_data_name = immutable_data.name().0.as_ref().to_hex();
+        let immutable_data = ImmutableData::new(value);
+        let immutable_data_name = immutable_data.raw_name().0.to_hex();
         let expected_immutable_data_name = "9f1c9e526f47e36d782de464ea9df0a31a5c19c321f2a5d9c8faac\
                                             dda4d59abc713445c8c853e1842d7c2c2311650df1ee2410737193\
                                             5b6be88a10cbf4cd2f8f";
         assert_eq!(&expected_immutable_data_name, &immutable_data_name);
         // Backup
-        let immutable_data_backup = ImmutableData::new(ImmutableDataType::Backup,
-                                                       immutable_data.value().clone());
-        let immutable_data_backup_name = immutable_data_backup.name().0.as_ref().to_hex();
+        let immutable_data_backup = immutable_data.into_backup();
+        let immutable_data_backup_name = immutable_data_backup.raw_name().0.to_hex();
         let expected_immutable_data_backup_name = "8c6377c848321dd3c6886a53b1a2bc28a5bc8ce35ac85d1\
                                                    0d75467a5df9434abaee19ce2c710507533d306302b165b\
                                                    4387458b752579fc15e520daaf984a2e38";
         assert_eq!(&expected_immutable_data_backup_name,
                    &immutable_data_backup_name);
         // Sacrificial
-        let immutable_data_sacrificial = ImmutableData::new(ImmutableDataType::Sacrificial,
-                                                            immutable_data.value().clone());
-        let immutable_data_sacrificial_name = immutable_data_sacrificial.name().0.as_ref().to_hex();
+        let immutable_data_sacrificial = immutable_data_backup.into_sacrificial();
+        let immutable_data_sacrificial_name = immutable_data_sacrificial.raw_name().0.to_hex();
         let expected_immutable_data_sacrificial_name = "ecb6c761c35d4da33b25057fbf6161e68711f9e0c1\
                                                         1122732e62661340e630d3c59f7c165f4862d51db5\
                                                         254a38ab9b15a9b8af431e8500a4eb558b9136bd41\
@@ -141,15 +218,14 @@ mod test {
     #[test]
     fn name_is_hash_of_lesser_type_name() {
         let value = generate_random();
-        let normal = ImmutableData::new(ImmutableDataType::Normal, value.clone());
-        let backup = ImmutableData::new(ImmutableDataType::Backup, value.clone());
-        let sacrificial = ImmutableData::new(ImmutableDataType::Sacrificial, value.clone());
-        assert_eq!(normal.name().0.as_ref().to_hex(),
-                   crypto::hash::sha512::hash(&value).0.to_hex());
-        assert_eq!(backup.name().0.as_ref().to_hex(),
-                   crypto::hash::sha512::hash(&normal.name().0).0.to_hex());
-        assert_eq!(sacrificial.name().0.as_ref().to_hex(),
-                   crypto::hash::sha512::hash(&backup.name().0).0.to_hex());
+        let normal = ImmutableData::new(value.clone());
+        let backup = normal.clone().into_backup();
+        let sacrificial = normal.clone().into_sacrificial();
+        assert_eq!(normal.raw_name().0.to_hex(),
+                   sha512::hash(&value).0.to_hex());
+        assert_eq!(backup.raw_name().0.to_hex(),
+                   sha512::hash(&normal.raw_name().0).0.to_hex());
+        assert_eq!(sacrificial.raw_name().0.to_hex(),
+                   sha512::hash(&backup.raw_name().0).0.to_hex());
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub use data::{Data, DataRequest};
 pub use error::{InterfaceError, RoutingError};
 pub use event::Event;
 pub use id::{FullId, PublicId};
-pub use immutable_data::{ImmutableData, ImmutableDataType};
+pub use immutable_data::{ImmutableData, ImmutableDataName};
 pub use messages::{RequestContent, RequestMessage, ResponseContent, ResponseMessage,
                    RoutingMessage, SignedMessage};
 pub use node::Node;


### PR DESCRIPTION
Affects mainly immutable_data.rs, but also minor impacts on other files.

This removes the tag from the ImmutableData struct and instead uses a new Name enum to define the type.

+@dirvine +@qima +@brian-js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/946)
<!-- Reviewable:end -->
