### PR TITLE
Add a message ID to GetNetworkName and ExpectCloseNode

### DIFF
--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -75,23 +75,23 @@ impl ExampleNode {
                 Event::Request(msg) => self.handle_request(msg),
                 Event::Response(msg) => self.handle_response(msg),
                 Event::NodeAdded(name) => {
-                    trace!("{:?} Received NodeAdded event {:?}",
+                    trace!("{} Received NodeAdded event {:?}",
                            self.get_debug_name(),
                            name);
                     self.handle_node_added(name);
                 }
                 Event::NodeLost(name) => {
-                    trace!("{:?} Received NodeLost event {:?}",
+                    trace!("{} Received NodeLost event {:?}",
                            self.get_debug_name(),
                            name);
                     self.handle_node_lost(name);
                 }
                 Event::Connected => {
-                    trace!("{:?} Received connected event", self.get_debug_name());
+                    trace!("{} Received connected event", self.get_debug_name());
                     self.connected = true;
                 }
                 Event::Disconnected => {
-                    trace!("{:?} Received disconnected event", self.get_debug_name());
+                    trace!("{} Received disconnected event", self.get_debug_name());
                     self.connected = false;
                 }
             }
@@ -373,7 +373,8 @@ impl ExampleNode {
                                };
                            dms.retain(|elt| close_grp.contains(elt));
                            if dms.is_empty() {
-                               error!("Chunk lost - No valid nodes left to retrieve chunk");
+                               error!("Chunk lost - No valid nodes left to retrieve chunk {:?}",
+                                      data_name);
                                return None;
                            }
                            Some((data_name, dms))

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -272,6 +272,8 @@ pub enum RequestContent {
     GetNetworkName {
         /// The client's `PublicId` (public keys and name)
         current_id: PublicId,
+        /// The message's unique identifier.
+        message_id: MessageId,
     },
     /// Notify a joining node's `NodeManager` so that it expects a `GetCloseGroup` request from it.
     ExpectCloseNode {
@@ -279,6 +281,8 @@ pub enum RequestContent {
         expect_id: PublicId,
         /// The client's current authority.
         client_auth: Authority,
+        /// The message's unique identifier.
+        message_id: MessageId,
     },
     /// Request the `PublicId`s of the recipient's close group.
     ///
@@ -331,6 +335,8 @@ pub enum ResponseContent {
         relocated_id: PublicId,
         /// Our close group `PublicId`s.
         close_group_ids: Vec<PublicId>,
+        /// The message's unique identifier.
+        message_id: MessageId,
     },
     /// Reply with the requested `PublicId`.
     ///
@@ -465,14 +471,18 @@ impl Debug for SignedMessage {
 impl Debug for RequestContent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
-            RequestContent::GetNetworkName { ref current_id } => {
-                write!(formatter, "GetNetworkName {{ {:?} }}", current_id)
-            }
-            RequestContent::ExpectCloseNode { ref expect_id, ref client_auth } => {
+            RequestContent::GetNetworkName { ref current_id, ref message_id } => {
                 write!(formatter,
-                       "ExpectCloseNode {{ {:?}, {:?} }}",
+                       "GetNetworkName {{ {:?}, {:?} }}",
+                       current_id,
+                       message_id)
+            }
+            RequestContent::ExpectCloseNode { ref expect_id, ref client_auth, ref message_id } => {
+                write!(formatter,
+                       "ExpectCloseNode {{ {:?}, {:?}, {:?} }}",
                        expect_id,
-                       client_auth)
+                       client_auth,
+                       message_id)
             }
             RequestContent::GetCloseGroup(id) => write!(formatter, "GetCloseGroup({:?})", id),
             RequestContent::Connect => write!(formatter, "Connect"),
@@ -503,11 +513,12 @@ impl Debug for RequestContent {
 impl Debug for ResponseContent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
-            ResponseContent::GetNetworkName { ref relocated_id, ref close_group_ids } => {
+            ResponseContent::GetNetworkName { ref relocated_id, ref close_group_ids, ref message_id } => {
                 write!(formatter,
-                       "GetNetworkName {{ {:?}, {:?} }}",
+                       "GetNetworkName {{ {:?}, {:?}, {:?} }}",
                        close_group_ids,
-                       relocated_id)
+                       relocated_id,
+                       message_id)
             }
             ResponseContent::GetPublicId { ref public_id } => {
                 write!(formatter, "GetPublicId {{ {:?} }}", public_id)


### PR DESCRIPTION
This prevents them from being filtered out if a client retries relocating.

(Also: Some fixes to log messages in example_node.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/949)
<!-- Reviewable:end -->