### PR TITLE
Implements RFC-0023.

### DIFF
--- a/src/immutable_data.rs
+++ b/src/immutable_data.rs
@@ -27,7 +27,7 @@ const NORMAL_TO_BACKUP: [u8; XOR_NAME_LEN] =
      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 const NORMAL_TO_SACRIFICIAL: [u8; XOR_NAME_LEN] = [255; XOR_NAME_LEN];
-#[allow(unused)]
+
 const BACKUP_TO_SACRIFICIAL: [u8; XOR_NAME_LEN] =
     [127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,

--- a/src/immutable_data.rs
+++ b/src/immutable_data.rs
@@ -108,27 +108,32 @@ impl Debug for ImmutableData {
     }
 }
 
-#[allow(unused)]
+/// Convert normal ImmutableData name to backup name.
 pub fn normal_to_backup(name: &XorName) -> XorName {
     xor(&name.0, NORMAL_TO_BACKUP)
 }
-#[allow(unused)]
+
+/// Convert backup ImmutableData name to normal name.
 pub fn backup_to_normal(name: &XorName) -> XorName {
     xor(&name.0, NORMAL_TO_BACKUP)
 }
-#[allow(unused)]
+
+/// Convert normal ImmutableData name to sacrificial name.
 pub fn normal_to_sacrificial(name: &XorName) -> XorName {
     xor(&name.0, NORMAL_TO_SACRIFICIAL)
 }
-#[allow(unused)]
+
+/// Convert sacrificial ImmutableData name to normal name.
 pub fn sacrificial_to_normal(name: &XorName) -> XorName {
     xor(&name.0, NORMAL_TO_SACRIFICIAL)
 }
-#[allow(unused)]
+
+/// Convert backup ImmutableData name to sacrificial name.
 pub fn backup_to_sacrificial(name: &XorName) -> XorName {
     xor(&name.0, BACKUP_TO_SACRIFICIAL)
 }
-#[allow(unused)]
+
+/// Convert sacrificial ImmutableData name to backup name.
 pub fn sacrificial_to_backup(name: &XorName) -> XorName {
     xor(&name.0, BACKUP_TO_SACRIFICIAL)
 }

--- a/src/immutable_data.rs
+++ b/src/immutable_data.rs
@@ -18,8 +18,30 @@
 use std::fmt::{self, Debug, Formatter};
 
 use rustc_serialize::{Decoder, Encodable, Encoder};
-use xor_name::XorName;
-use sodiumoxide::crypto;
+use xor_name::{XorName, XOR_NAME_LEN};
+use sodiumoxide::crypto::hash::sha512;
+
+const NORMAL_TO_BACKUP: [u8; XOR_NAME_LEN] =
+    [128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+const NORMAL_TO_SACRIFICIAL: [u8; XOR_NAME_LEN] = [255; XOR_NAME_LEN];
+#[allow(unused)]
+const BACKUP_TO_SACRIFICIAL: [u8; XOR_NAME_LEN] =
+    [127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+     255, 255, 255, 255];
+
+fn xor(lhs: &[u8; XOR_NAME_LEN], mut rhs: [u8; XOR_NAME_LEN]) -> XorName {
+    for i in 0..XOR_NAME_LEN {
+        rhs[i] ^= lhs[i];
+    }
+
+    XorName(rhs)
+}
 
 #[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd, RustcEncodable, RustcDecodable, Debug)]
 /// The type of an individual copy of immutable data.
@@ -65,13 +87,12 @@ impl ImmutableData {
 
     /// Returns name ensuring invariant
     pub fn name(&self) -> XorName {
-        let digest = crypto::hash::sha512::hash(&self.value);
+        let digest = sha512::hash(&self.value);
         match self.type_tag {
             ImmutableDataType::Normal => XorName(digest.0),
-            ImmutableDataType::Backup => XorName(crypto::hash::sha512::hash(&digest.0).0),
-            ImmutableDataType::Sacrificial => {
-                XorName(crypto::hash::sha512::hash(&crypto::hash::sha512::hash(&digest.0).0).0)
-            }
+            ImmutableDataType::Backup => xor(&digest.0, NORMAL_TO_BACKUP),
+            ImmutableDataType::Sacrificial => xor(&digest.0, NORMAL_TO_SACRIFICIAL),
+
         }
     }
 
@@ -87,14 +108,40 @@ impl Debug for ImmutableData {
     }
 }
 
+#[allow(unused)]
+pub fn normal_to_backup(name: &XorName) -> XorName {
+    xor(&name.0, NORMAL_TO_BACKUP)
+}
+#[allow(unused)]
+pub fn backup_to_normal(name: &XorName) -> XorName {
+    xor(&name.0, NORMAL_TO_BACKUP)
+}
+#[allow(unused)]
+pub fn normal_to_sacrificial(name: &XorName) -> XorName {
+    xor(&name.0, NORMAL_TO_SACRIFICIAL)
+}
+#[allow(unused)]
+pub fn sacrificial_to_normal(name: &XorName) -> XorName {
+    xor(&name.0, NORMAL_TO_SACRIFICIAL)
+}
+#[allow(unused)]
+pub fn backup_to_sacrificial(name: &XorName) -> XorName {
+    xor(&name.0, BACKUP_TO_SACRIFICIAL)
+}
+#[allow(unused)]
+pub fn sacrificial_to_backup(name: &XorName) -> XorName {
+    xor(&name.0, BACKUP_TO_SACRIFICIAL)
+}
+
 #[cfg(test)]
 mod test {
     extern crate rand;
 
-    use super::{ImmutableData, ImmutableDataType};
+    use super::*;
     use self::rand::Rng;
     use rustc_serialize::hex::ToHex;
-    use sodiumoxide::crypto;
+    use sodiumoxide::crypto::hash::sha512;
+    use xor_name::XorName;
 
     fn generate_random() -> Vec<u8> {
         let size = 64;
@@ -108,48 +155,51 @@ mod test {
 
     #[test]
     fn deterministic_test() {
-
         let value = "immutable data value".to_owned().into_bytes();
+
         // Normal
         let immutable_data = ImmutableData::new(ImmutableDataType::Normal, value);
         let immutable_data_name = immutable_data.name().0.as_ref().to_hex();
-        let expected_immutable_data_name = "9f1c9e526f47e36d782de464ea9df0a31a5c19c321f2a5d9c8faac\
-                                            dda4d59abc713445c8c853e1842d7c2c2311650df1ee2410737193\
-                                            5b6be88a10cbf4cd2f8f";
+        let expected_immutable_data_name = "9f1c9e526f47e36d782de464ea9df0a31a5c19c321f\
+                                            2a5d9c8faacdda4d59abc713445c8c853e1842d7c2c\
+                                            2311650df1ee24107371935b6be88a10cbf4cd2f8f";
+
         assert_eq!(&expected_immutable_data_name, &immutable_data_name);
+
         // Backup
-        let immutable_data_backup = ImmutableData::new(ImmutableDataType::Backup,
-                                                       immutable_data.value().clone());
+        let immutable_data_backup = ImmutableData::new(ImmutableDataType::Backup, immutable_data.value().clone());
         let immutable_data_backup_name = immutable_data_backup.name().0.as_ref().to_hex();
-        let expected_immutable_data_backup_name = "8c6377c848321dd3c6886a53b1a2bc28a5bc8ce35ac85d1\
-                                                   0d75467a5df9434abaee19ce2c710507533d306302b165b\
-                                                   4387458b752579fc15e520daaf984a2e38";
-        assert_eq!(&expected_immutable_data_backup_name,
-                   &immutable_data_backup_name);
+        let expected_immutable_data_backup_name = "1f1c9e526f47e36d782de464ea9df0a31a5c19c321f\
+                                                   2a5d9c8faacdda4d59abc713445c8c853e1842d7c2c\
+                                                   2311650df1ee24107371935b6be88a10cbf4cd2f8f";
+
+        assert_eq!(&expected_immutable_data_backup_name, &immutable_data_backup_name);
+
         // Sacrificial
         let immutable_data_sacrificial = ImmutableData::new(ImmutableDataType::Sacrificial,
                                                             immutable_data.value().clone());
         let immutable_data_sacrificial_name = immutable_data_sacrificial.name().0.as_ref().to_hex();
-        let expected_immutable_data_sacrificial_name = "ecb6c761c35d4da33b25057fbf6161e68711f9e0c1\
-                                                        1122732e62661340e630d3c59f7c165f4862d51db5\
-                                                        254a38ab9b15a9b8af431e8500a4eb558b9136bd41\
-                                                        35";
-        assert_eq!(&expected_immutable_data_sacrificial_name,
-                   &immutable_data_sacrificial_name);
+        let expected_immutable_data_sacrificial_name = "60e361ad90b81c9287d21b9b15620f5ce5a3e63cde0\
+                                                        d5a26370553225b2a65438ecbba3737ac1e7bd283d3\
+                                                        dcee9af20e11dbef8c8e6ca4941775ef340b32d070";
+
+        assert_eq!(&expected_immutable_data_sacrificial_name, &immutable_data_sacrificial_name);
     }
 
     #[test]
-    fn name_is_hash_of_lesser_type_name() {
+    fn name_is_xor_related_to_lesser_type_name() {
         let value = generate_random();
         let normal = ImmutableData::new(ImmutableDataType::Normal, value.clone());
         let backup = ImmutableData::new(ImmutableDataType::Backup, value.clone());
         let sacrificial = ImmutableData::new(ImmutableDataType::Sacrificial, value.clone());
-        assert_eq!(normal.name().0.as_ref().to_hex(),
-                   crypto::hash::sha512::hash(&value).0.to_hex());
-        assert_eq!(backup.name().0.as_ref().to_hex(),
-                   crypto::hash::sha512::hash(&normal.name().0).0.to_hex());
-        assert_eq!(sacrificial.name().0.as_ref().to_hex(),
-                   crypto::hash::sha512::hash(&backup.name().0).0.to_hex());
+
+        assert_eq!(normal.name(), XorName(sha512::hash(&value).0));
+        assert_eq!(normal.name(), backup_to_normal(&backup.name()));
+        assert_eq!(normal.name(), sacrificial_to_normal(&sacrificial.name()));
+        assert_eq!(backup.name(), normal_to_backup(&normal.name()));
+        assert_eq!(backup.name(), sacrificial_to_backup(&sacrificial.name()));
+        assert_eq!(sacrificial.name(), normal_to_sacrificial(&normal.name()));
+        assert_eq!(sacrificial.name(), backup_to_sacrificial(&backup.name()));
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,8 @@ pub use data::{Data, DataRequest};
 pub use error::{InterfaceError, RoutingError};
 pub use event::Event;
 pub use id::{FullId, PublicId};
-pub use immutable_data::{ImmutableData, ImmutableDataType};
+pub use immutable_data::{ImmutableData, ImmutableDataType, normal_to_backup, backup_to_normal, normal_to_sacrificial,
+                         sacrificial_to_normal, backup_to_sacrificial, sacrificial_to_backup};
 pub use messages::{RequestContent, RequestMessage, ResponseContent, ResponseMessage,
                    RoutingMessage, SignedMessage};
 pub use node::Node;


### PR DESCRIPTION
Implements RFC-0023.

Allow all ImmutableData type managers to obtain a copy of a chunk from any ImmutableData type manager by applying a deterministic naming scheme to the 3 ImmutableData types. 

Refer to https://github.com/maidsafe/rfcs/blob/master/proposed/0023-immutable-data-type-naming/0023-immutable-data-type-naming.md which includes the code used in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/950) &emsp; Multiple assignees:&emsp;<img alt="@Fraser999" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/190532?s=40&v=3">&nbsp;<a href="/maidsafe/routing/pulls/assigned/Fraser999">Fraser999</a>,&emsp;<img alt="@afck" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/7894725?s=40&v=3">&nbsp;<a href="/maidsafe/routing/pulls/assigned/afck">afck</a>,&emsp;<img alt="@dirvine" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/123627?s=40&v=3">&nbsp;<a href="/maidsafe/routing/pulls/assigned/dirvine">dirvine</a>,&emsp;<img alt="@maqi" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/568777?s=40&v=3">&nbsp;<a href="/maidsafe/routing/pulls/assigned/maqi">maqi</a>
<!-- Reviewable:end -->
