### PR TITLE
Implement responses in the example node.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ message_filter = "~0.3.1"
 rand = "~0.3.14"
 rustc-serialize = "~0.3.18"
 sodiumoxide = "~0.0.9"
+term = "0.4.4"
 time = "~0.1.34"
 xor_name = "~0.1.0"
 

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -230,7 +230,9 @@ impl KeyValueStore {
     pub fn put(&self, put_where: String, put_what: String) {
         let name = KeyValueStore::calculate_key_name(&put_where);
         let data = unwrap_result!(serialise(&(put_where, put_what)));
-        self.example_client.put(Data::Plain(PlainData::new(name, data)));
+        if self.example_client.put(Data::Plain(PlainData::new(name, data))).is_err() {
+            error!("Failed to put data.");
+        }
     }
 
     fn calculate_key_name(key: &str) -> XorName {

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -113,8 +113,8 @@ impl ExampleClient {
 
     /// Send a `Put` request to the network.
     ///
-    /// This is a blocking call and will wait indefinitely for a `PutSuccess` response.
-    pub fn put(&self, data: Data) {
+    /// This is a blocking call and will wait indefinitely for a `PutSuccess` or `PutFailure` response.
+    pub fn put(&self, data: Data) -> Result<(), ()> {
         let data_name = data.name();
         let message_id = MessageId::new();
         unwrap_result!(self.routing_client
@@ -126,23 +126,32 @@ impl ExampleClient {
         for it in self.receiver.iter() {
             match it {
                 Event::Response(ResponseMessage {
-                    content: ResponseContent::PutSuccess(_, id),
+                    content: ResponseContent::PutSuccess(id),
                     ..
                 }) => {
                     if message_id == id {
-                        println!("Successfully stored {:?}", data_name);
+                        trace!("Successfully stored {:?}", data_name);
+                        return Ok(());
                     } else {
-                        println!("Stored {:?}, but with wrong message_id {:?} instead of {:?}.",
-                                 data_name,
-                                 id,
-                                 message_id);
+                        error!("Stored {:?}, but with wrong message_id {:?} instead of {:?}.",
+                               data_name,
+                               id,
+                               message_id);
+                        return Err(());
                     }
-                    break;
+                }
+                Event::Response(ResponseMessage {
+                    content: ResponseContent::PutFailure { .. },
+                    ..
+                }) => {
+                    error!("Received PutFailure for {:?}.", data_name);
+                    return Err(());
                 }
                 Event::Disconnected => self.disconnected(),
                 _ => (),
             }
         }
+        Err(())
     }
 
     fn disconnected(&self) {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -22,7 +22,6 @@ use mock_crust::crust::PeerId;
 use maidsafe_utilities::serialisation::serialise;
 use rustc_serialize::{Decoder, Encoder};
 use sodiumoxide::crypto::{box_, sign};
-use sodiumoxide::crypto::hash::sha512;
 use std::fmt::{self, Debug, Formatter};
 
 use authority::Authority;
@@ -364,11 +363,11 @@ pub enum ResponseContent {
     /// may be shortcut if the data is in a node's cache.
     GetSuccess(Data, MessageId),
     /// Success token for Put (may be ignored)
-    PutSuccess(sha512::Digest, MessageId),
+    PutSuccess(MessageId),
     /// Success token for Post  (may be ignored)
-    PostSuccess(sha512::Digest, MessageId),
+    PostSuccess(MessageId),
     /// Success token for delete  (may be ignored)
-    DeleteSuccess(sha512::Digest, MessageId),
+    DeleteSuccess(MessageId),
     /// Error for `Get`, includes signed request to prevent injection attacks
     GetFailure {
         /// Unique message identifier
@@ -529,23 +528,14 @@ impl Debug for ResponseContent {
             ResponseContent::GetSuccess(ref data, ref message_id) => {
                 write!(formatter, "GetSuccess {{ {:?}, {:?} }}", data, message_id)
             }
-            ResponseContent::PutSuccess(ref digest, ref message_id) => {
-                write!(formatter,
-                       "PutSuccess {{ Digest({}), {:?} }}",
-                       utils::format_binary_array(digest),
-                       message_id)
+            ResponseContent::PutSuccess(ref message_id) => {
+                write!(formatter, "PutSuccess {{ {:?} }}", message_id)
             }
-            ResponseContent::PostSuccess(ref digest, ref message_id) => {
-                write!(formatter,
-                       "PostSuccess {{ Digest({}), {:?} }}",
-                       utils::format_binary_array(digest),
-                       message_id)
+            ResponseContent::PostSuccess(ref message_id) => {
+                write!(formatter, "PostSuccess {{ {:?} }}", message_id)
             }
-            ResponseContent::DeleteSuccess(ref digest, ref message_id) => {
-                write!(formatter,
-                       "DeleteSuccess {{ Digest({}), {:?} }}",
-                       utils::format_binary_array(digest),
-                       message_id)
+            ResponseContent::DeleteSuccess(ref message_id) => {
+                write!(formatter, "DeleteSuccess {{ {:?} }}", message_id)
             }
             ResponseContent::GetFailure { ref id, ref request, .. } => {
                 write!(formatter, "GetFailure {{ {:?}, {:?}, .. }}", id, request)
@@ -623,8 +613,7 @@ mod test {
 
         let signed_message = unwrap_result!(signed_message_result);
         let (public_signing_key, secret_signing_key) = sign::gen_keypair();
-        let hop_message_result = HopMessage::new(signed_message.clone(),
-                                                 &secret_signing_key);
+        let hop_message_result = HopMessage::new(signed_message.clone(), &secret_signing_key);
 
         assert!(hop_message_result.is_ok());
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -29,7 +29,6 @@ use data::{Data, DataRequest};
 use error::{InterfaceError, RoutingError};
 use event::Event;
 use messages::{RequestContent, RequestMessage, ResponseContent, ResponseMessage, RoutingMessage};
-use sodiumoxide::crypto::hash::sha512;
 use xor_name::XorName;
 use types::MessageId;
 
@@ -204,13 +203,12 @@ impl Node {
     pub fn send_put_success(&self,
                             src: Authority,
                             dst: Authority,
-                            request_hash: sha512::Digest,
                             id: MessageId)
                             -> Result<(), InterfaceError> {
         let routing_msg = RoutingMessage::Response(ResponseMessage {
             src: src,
             dst: dst,
-            content: ResponseContent::PutSuccess(request_hash, id),
+            content: ResponseContent::PutSuccess(id),
         });
         self.send_action(routing_msg)
     }
@@ -239,13 +237,12 @@ impl Node {
     pub fn send_post_success(&self,
                              src: Authority,
                              dst: Authority,
-                             request_hash: sha512::Digest,
                              id: MessageId)
                              -> Result<(), InterfaceError> {
         let routing_msg = RoutingMessage::Response(ResponseMessage {
             src: src,
             dst: dst,
-            content: ResponseContent::PostSuccess(request_hash, id),
+            content: ResponseContent::PostSuccess(id),
         });
         self.send_action(routing_msg)
     }
@@ -274,13 +271,12 @@ impl Node {
     pub fn send_delete_success(&self,
                                src: Authority,
                                dst: Authority,
-                               request_hash: sha512::Digest,
                                id: MessageId)
                                -> Result<(), InterfaceError> {
         let routing_msg = RoutingMessage::Response(ResponseMessage {
             src: src,
             dst: dst,
-            content: ResponseContent::DeleteSuccess(request_hash, id),
+            content: ResponseContent::DeleteSuccess(id),
         });
         self.send_action(routing_msg)
     }


### PR DESCRIPTION
The `ClientManager` now waits for a `PutSuccess` from the `NaeManager`
before sending it on to the client, more success and failure responses
are now handled, and cause corresponding updates to the `dm_accounts`.

Also, the output of ci_test is now a bit less redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/961)
<!-- Reviewable:end -->