### PR TITLE
feat/types: Add a zero constructor for MessageId.

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -896,7 +896,9 @@ impl Core {
         self.add_to_cache(signed_msg.content());
 
         if relay {
-            try!(self.send(signed_msg.clone(), hop_name, false));
+            if let Err(err) = self.send(signed_msg.clone(), hop_name, false) {
+                error!("Failed relaying message: {:?}", err);
+            }
         }
         if self.signed_message_filter.count(signed_msg) == 0 &&
            self.routing_table.is_recipient(dst.to_destination()) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,12 @@ impl MessageId {
         MessageId(random::<XorName>())
     }
 
+    /// Generate a `MessageId` with value 0. This should only be used for messages where there is
+    /// no danger of duplication.
+    pub fn zero() -> MessageId {
+        MessageId(XorName([0; 64]))
+    }
+
     /// Generate a new `MessageId` with contents extracted from lost node.
     pub fn from_lost_node(mut name: XorName) -> MessageId {
         name.0[0] = 'L' as u8;


### PR DESCRIPTION
This returns a MessageId with value 0 that can be used if there is no
danger of duplication anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/974)
<!-- Reviewable:end -->