### PR TITLE
fix/core: fix build with nightly, and some cleanups

### DIFF
--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -16,8 +16,9 @@
 // relating to use of the SAFE Network Software.
 
 //! usage example (using default methods of connecting to the network):
-//!      starting a passive node:       simple_key_value_store --node
-//!      starting an interactive node:  simple_key_value_store
+//!      starting the first node:       `key_value_store --first`
+//!      starting a passive node:       `key_value_store --node`
+//!      starting an interactive node:  `key_value_store`
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
@@ -63,7 +64,6 @@ use std::io::Write;
 
 use docopt::Docopt;
 use xor_name::XorName;
-use rustc_serialize::{Decodable, Decoder};
 use sodiumoxide::crypto;
 
 use maidsafe_utilities::serialisation::{serialise, deserialise};
@@ -241,6 +241,12 @@ impl KeyValueStore {
 
     fn calculate_key_name(key: &str) -> XorName {
         XorName::new(crypto::hash::sha512::hash(key.as_bytes()).0)
+    }
+}
+
+impl Default for KeyValueStore {
+    fn default() -> KeyValueStore {
+        KeyValueStore::new()
     }
 }
 

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -24,7 +24,6 @@ use maidsafe_utilities::serialisation::{serialise, deserialise};
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::time::Duration;
-use rustc_serialize::{Encoder, Decoder};
 
 const STORE_REDUNDANCY: usize = 4;
 
@@ -166,7 +165,7 @@ impl ExampleNode {
     }
 
     fn process_failed_dm(&mut self, data_name: &XorName, dm_name: &XorName, id: MessageId) {
-        if let Some(dms) = self.dm_accounts.get_mut(&data_name) {
+        if let Some(dms) = self.dm_accounts.get_mut(data_name) {
             if let Some(i) = dms.iter().position(|n| n == dm_name) {
                 let _ = dms.remove(i);
             } else {

--- a/src/core_tests.rs
+++ b/src/core_tests.rs
@@ -251,10 +251,7 @@ fn create_connected_nodes(network: &Network, size: usize) -> Vec<TestNode> {
 
     // Create other nodes using the seed node endpoint as bootstrap contact.
     for i in 1..size {
-        nodes.push(TestNode::new(network,
-                                 Role::RoutingNode,
-                                 Some(config.clone()),
-                                 Some(Endpoint(i))));
+        nodes.push(TestNode::new(network, Role::Node, Some(config.clone()), Some(Endpoint(i))));
         poll_all(&mut nodes, &mut []);
     }
 
@@ -418,7 +415,7 @@ fn node_joins_in_front() {
     let mut nodes = create_connected_nodes(&network, 2 * GROUP_SIZE);
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
     nodes.insert(0,
-                 TestNode::new(&network, Role::RoutingNode, Some(config.clone()), None));
+                 TestNode::new(&network, Role::Node, Some(config.clone()), None));
     poll_all(&mut nodes, &mut []);
 
     verify_kademlia_invariant_for_all_nodes(&nodes);
@@ -432,10 +429,10 @@ fn multiple_joining_nodes() {
     let mut nodes = create_connected_nodes(&network, network_size);
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
     nodes.insert(0,
-                 TestNode::new(&network, Role::RoutingNode, Some(config.clone()), None));
+                 TestNode::new(&network, Role::Node, Some(config.clone()), None));
     nodes.insert(0,
-                 TestNode::new(&network, Role::RoutingNode, Some(config.clone()), None));
-    nodes.push(TestNode::new(&network, Role::RoutingNode, Some(config.clone()), None));
+                 TestNode::new(&network, Role::Node, Some(config.clone()), None));
+    nodes.push(TestNode::new(&network, Role::Node, Some(config.clone()), None));
     poll_all(&mut nodes, &mut []);
     nodes.retain(|node| !node.core.routing_table().is_empty());
     poll_all(&mut nodes, &mut []);

--- a/src/data.rs
+++ b/src/data.rs
@@ -16,7 +16,6 @@
 // relating to use of the SAFE Network Software.
 
 use std::fmt::{self, Debug, Formatter};
-use rustc_serialize::{Decoder, Encoder};
 pub use structured_data::StructuredData;
 pub use immutable_data::{ImmutableData, ImmutableDataBackup, ImmutableDataSacrificial};
 pub use plain_data::PlainData;

--- a/src/immutable_data.rs
+++ b/src/immutable_data.rs
@@ -17,7 +17,6 @@
 
 use std::fmt::{self, Debug, Formatter};
 
-use rustc_serialize::{Decoder, Encoder};
 use xor_name::{XorName, XOR_NAME_LEN};
 use sodiumoxide::crypto::hash::sha512;
 use data::DataIdentifier;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -20,7 +20,6 @@ use crust::PeerId;
 #[cfg(feature = "use-mock-crust")]
 use mock_crust::crust::PeerId;
 use maidsafe_utilities::serialisation::serialise;
-use rustc_serialize::{Decoder, Encoder};
 use sodiumoxide::crypto::{box_, sign};
 use std::fmt::{self, Debug, Formatter};
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -71,7 +71,7 @@ impl Node {
         let role = if first_node {
             Role::FirstNode
         } else {
-            Role::RoutingNode
+            Role::Node
         };
         // start the handler for routing without a restriction to become a full node
         let (action_sender, mut core) = Core::new(event_sender, role, None, use_data_cache);
@@ -100,7 +100,7 @@ impl Node {
         let role = if first_node {
             Role::FirstNode
         } else {
-            Role::RoutingNode
+            Role::Node
         };
         // start the handler for routing without a restriction to become a full node
         let (action_sender, core) = Core::new(event_sender, role, None, use_data_cache);

--- a/src/plain_data.rs
+++ b/src/plain_data.rs
@@ -16,7 +16,6 @@
 // relating to use of the SAFE Network Software.
 
 use std::fmt::{self, Debug, Formatter};
-use rustc_serialize::{Decoder, Encoder};
 use xor_name::XorName;
 use data::DataIdentifier;
 use utils;

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,6 @@
 
 use rand::random;
 use xor_name::XorName;
-use rustc_serialize::{Encoder, Decoder};
 use maidsafe_utilities::event_sender::MaidSafeObserver;
 
 pub type RoutingActionSender = MaidSafeObserver<::action::Action>;

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -192,7 +192,7 @@ fn wait_for_nodes_to_connect(nodes: &[TestNode],
                              event_receiver: &Receiver<TestEvent>) {
     // Wait for each node to connect to all the other nodes by counting churns.
     loop {
-        if let Ok(test_event) = recv_with_timeout(&event_receiver, Duration::from_secs(30)) {
+        if let Ok(test_event) = recv_with_timeout(event_receiver, Duration::from_secs(30)) {
             if let TestEvent(index, Event::NodeAdded(..)) = test_event {
                 connection_counts[index] += 1;
 

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -28,8 +28,9 @@ pub enum RecvWithTimeoutError {
     Timeout,
 }
 
-/// Blocks until something is received on the Receiver, or timeout, whichever
-/// happens sooner.
+/// Blocks until something is received on the `Receiver`, or timeout, whichever happens sooner.
+// TODO: Deny this lint again once `elapsed += interval` works with Rust stable.
+#[cfg_attr(feature="clippy", allow(assign_op_pattern))]
 pub fn recv_with_timeout<T>(receiver: &Receiver<T>,
                             timeout: Duration)
                             -> Result<T, RecvWithTimeoutError> {


### PR DESCRIPTION
Fix build errors and Clippy errors with Rust nightly, and rename
`Role::RoutingNode` to `Role::Node`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1020)
<!-- Reviewable:end -->
