### PR TITLE
feat/core: split up large and deduplicate group messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
   allow_failures:
     - rust: nightly
 sudo: false
-branches:
-  only:
-    - master
 cache:
   cargo: true
   directories:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.21.0"
 [dependencies]
 accumulator = "~0.4.0"
 clippy = {version = "~0.0.73", optional = true}
-crust = "~0.14.0"
+crust = { git = "https://github.com/maidsafe/crust.git", branch = "async" }
 itertools = "~0.4.15"
 kademlia_routing_table = "~0.6.0"
 log = "~0.3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
     Features: "use-mock-crust"
   matrix:
     - RUST_VERSION: stable
-branches:
-  only:
-    - master
 
 clone_depth: 50
 

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -47,7 +47,7 @@ impl ExampleClient {
         let sign_keys = crypto::sign::gen_keypair();
         let encrypt_keys = crypto::box_::gen_keypair();
         let full_id = FullId::with_keys(encrypt_keys.clone(), sign_keys.clone());
-        let routing_client = unwrap_result!(Client::new(sender, Some(full_id), false));
+        let routing_client = unwrap_result!(Client::new(sender, Some(full_id)));
 
         // Wait indefinitely for a `Connected` event, notifying us that we are now ready to send
         // requests to the network.

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -52,7 +52,7 @@ impl ExampleNode {
     /// Creates a new node and attempts to establish a connection to the network.
     pub fn new(first: bool) -> ExampleNode {
         let (sender, receiver) = ::std::sync::mpsc::channel::<Event>();
-        let node = unwrap_result!(Node::new(sender.clone(), false, first));
+        let node = unwrap_result!(Node::new(sender.clone(), first));
 
         ExampleNode {
             node: node,
@@ -91,9 +91,8 @@ impl ExampleNode {
                     trace!("{} Received disconnected event", self.get_debug_name());
                 }
                 Event::GetNodeNameFailed => {
-                    let _ =
-                        mem::replace(&mut self.node,
-                                     unwrap_result!(Node::new(self.sender.clone(), false, false)));
+                    let _ = mem::replace(&mut self.node,
+                                         unwrap_result!(Node::new(self.sender.clone(), false)));
                 }
                 event => {
                     trace!("{} Received {:?} event", self.get_debug_name(), event);

--- a/src/action.rs
+++ b/src/action.rs
@@ -19,7 +19,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::sync::mpsc::Sender;
 use authority::Authority;
 use error::InterfaceError;
-use messages::{Request, RoutingMessage};
+use messages::{Request, UserMessage};
 use xor_name::XorName;
 
 /// An Action initiates a message flow < A | B > where we are (a part of) A.
@@ -31,7 +31,9 @@ use xor_name::XorName;
 #[derive(Clone)]
 pub enum Action {
     NodeSendMessage {
-        content: RoutingMessage,
+        src: Authority,
+        dst: Authority,
+        content: UserMessage,
         result_tx: Sender<Result<(), InterfaceError>>,
     },
     ClientSendRequest {

--- a/src/action.rs
+++ b/src/action.rs
@@ -34,11 +34,13 @@ pub enum Action {
         src: Authority,
         dst: Authority,
         content: UserMessage,
+        priority: u8,
         result_tx: Sender<Result<(), InterfaceError>>,
     },
     ClientSendRequest {
         content: Request,
         dst: Authority,
+        priority: u8,
         result_tx: Sender<Result<(), InterfaceError>>,
     },
     CloseGroup {

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ use core::{Core, Role};
 use data::{Data, DataIdentifier};
 use error::{InterfaceError, RoutingError};
 use authority::Authority;
-use messages::Request;
+use messages::{Request, DEFAULT_PRIORITY, CLIENT_GET_PRIORITY};
 use types::MessageId;
 
 type RoutingResult = Result<(), RoutingError>;
@@ -117,7 +117,7 @@ impl Client {
                             data_id: DataIdentifier,
                             message_id: MessageId)
                             -> Result<(), InterfaceError> {
-        self.send_action(Request::Get(data_id, message_id), dst)
+        self.send_action(Request::Get(data_id, message_id), dst, CLIENT_GET_PRIORITY)
     }
 
     /// Add something to the network
@@ -126,7 +126,7 @@ impl Client {
                             data: Data,
                             message_id: MessageId)
                             -> Result<(), InterfaceError> {
-        self.send_action(Request::Put(data, message_id), dst)
+        self.send_action(Request::Put(data, message_id), dst, DEFAULT_PRIORITY)
     }
 
     /// Change something already on the network
@@ -135,7 +135,7 @@ impl Client {
                              data: Data,
                              message_id: MessageId)
                              -> Result<(), InterfaceError> {
-        self.send_action(Request::Post(data, message_id), dst)
+        self.send_action(Request::Post(data, message_id), dst, DEFAULT_PRIORITY)
     }
 
     /// Remove something from the network
@@ -144,7 +144,7 @@ impl Client {
                                data: Data,
                                message_id: MessageId)
                                -> Result<(), InterfaceError> {
-        self.send_action(Request::Delete(data, message_id), dst)
+        self.send_action(Request::Delete(data, message_id), dst, DEFAULT_PRIORITY)
     }
 
     /// Request account information for the Client calling this function
@@ -152,13 +152,20 @@ impl Client {
                                          dst: Authority,
                                          message_id: MessageId)
                                          -> Result<(), InterfaceError> {
-        self.send_action(Request::GetAccountInfo(message_id), dst)
+        self.send_action(Request::GetAccountInfo(message_id),
+                         dst,
+                         CLIENT_GET_PRIORITY)
     }
 
-    fn send_action(&self, content: Request, dst: Authority) -> Result<(), InterfaceError> {
+    fn send_action(&self,
+                   content: Request,
+                   dst: Authority,
+                   priority: u8)
+                   -> Result<(), InterfaceError> {
         let action = Action::ClientSendRequest {
             content: content,
             dst: dst,
+            priority: priority,
             result_tx: self.interface_result_tx.clone(),
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,14 +63,11 @@ impl Client {
     /// cryptographically secure and uses group consensus. The restriction for the client name
     /// exists to ensure that the client cannot choose its `ClientAuthority`.
     #[cfg(not(feature = "use-mock-crust"))]
-    pub fn new(event_sender: Sender<Event>,
-               keys: Option<FullId>,
-               use_data_cache: bool)
-               -> Result<Client, RoutingError> {
+    pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
         sodiumoxide::init();  // enable shared global (i.e. safe to multithread now)
 
         // start the handler for routing with a restriction to become a full node
-        let (action_sender, mut core) = Core::new(event_sender, Role::Client, keys, use_data_cache);
+        let (action_sender, mut core) = Core::new(event_sender, Role::Client, keys);
         let (tx, rx) = channel();
 
         let raii_joiner = RaiiThreadJoiner::new(thread!("Client thread", move || {
@@ -87,14 +84,11 @@ impl Client {
 
     /// Create a new `Client` for unit testing.
     #[cfg(feature = "use-mock-crust")]
-    pub fn new(event_sender: Sender<Event>,
-               keys: Option<FullId>,
-               use_data_cache: bool)
-               -> Result<Client, RoutingError> {
+    pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
         sodiumoxide::init();  // enable shared global (i.e. safe to multithread now)
 
         // start the handler for routing with a restriction to become a full node
-        let (action_sender, core) = Core::new(event_sender, Role::Client, keys, use_data_cache);
+        let (action_sender, core) = Core::new(event_sender, Role::Client, keys);
         let (tx, rx) = channel();
 
         Ok(Client {

--- a/src/core.rs
+++ b/src/core.rs
@@ -34,7 +34,7 @@ use peer_manager::{ConnectState, PeerManager};
 use rand;
 use sodiumoxide::crypto::{box_, hash, sign};
 use std::{cmp, io, iter, fmt};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Formatter};
 use std::time::{Duration, Instant};
 use std::sync::mpsc;
@@ -43,15 +43,14 @@ use xor_name::{XorName, XOR_NAME_BITS};
 
 use action::Action;
 use authority::Authority;
-use data::{Data, DataIdentifier};
 use error::{RoutingError, InterfaceError};
 use event::Event;
 use id::{FullId, PublicId};
 use stats::Stats;
 use timer::Timer;
 use types::{MessageId, RoutingActionSender};
-use messages::{DirectMessage, HopMessage, Message, MessageContent, Request, RoutingMessage,
-               SignedMessage, Response};
+use messages::{DirectMessage, HopMessage, Message, MessageContent, RoutingMessage, SignedMessage,
+               UserMessage};
 use utils;
 
 /// The group size for the routing table. This is the maximum that can be used for consensus.
@@ -206,11 +205,10 @@ pub struct Core {
     /// The last joining node we have sent a `GetNodeName` response to, and when.
     sent_network_name_to: Option<(XorName, Instant)>,
     tick_timer_token: Option<u64>,
-    use_data_cache: bool,
-    data_cache: LruCache<XorName, Data>,
     tunnels: Tunnels,
     stats: Stats,
     send_filter: LruCache<(u64, PeerId, u8), ()>,
+    user_msg_cache: LruCache<(u64, u32), BTreeMap<u32, Vec<u8>>>,
     peer_mgr: PeerManager,
 }
 
@@ -220,8 +218,7 @@ impl Core {
     /// mpsc sender passed in.
     pub fn new(event_sender: mpsc::Sender<Event>,
                role: Role,
-               keys: Option<FullId>,
-               use_data_cache: bool)
+               keys: Option<FullId>)
                -> (RoutingActionSender, Self) {
         let (crust_tx, crust_rx) = mpsc::channel();
         let (action_tx, action_rx) = mpsc::channel();
@@ -274,11 +271,10 @@ impl Core {
             bucket_refresh_token_and_delay: None,
             sent_network_name_to: None,
             tick_timer_token: None,
-            use_data_cache: use_data_cache,
-            data_cache: LruCache::with_capacity(100),
             tunnels: Default::default(),
             stats: Default::default(),
             send_filter: LruCache::with_expiry_duration(Duration::from_secs(60 * 10)),
+            user_msg_cache: LruCache::with_expiry_duration(Duration::from_secs(60 * 20)),
             peer_mgr: Default::default(),
         };
 
@@ -434,8 +430,8 @@ impl Core {
 
     fn handle_action(&mut self, action: Action) -> bool {
         match action {
-            Action::NodeSendMessage { content, result_tx } => {
-                if result_tx.send(match self.send_message(content) {
+            Action::NodeSendMessage { src, dst, content, result_tx } => {
+                if result_tx.send(match self.send_user_message(src, dst, content) {
                         Err(RoutingError::Interface(err)) => Err(err),
                         Err(_err) => Ok(()),
                         Ok(()) => Ok(()),
@@ -446,13 +442,9 @@ impl Core {
             }
             Action::ClientSendRequest { content, dst, result_tx } => {
                 if result_tx.send(if let Ok(src) = self.get_client_authority() {
-                        let request_msg = RoutingMessage {
-                            content: MessageContent::Request(content),
-                            src: src,
-                            dst: dst,
-                        };
+                        let user_msg = UserMessage::Request(content);
 
-                        match self.send_message(request_msg) {
+                        match self.send_user_message(src, dst, user_msg) {
                             Err(RoutingError::Interface(err)) => Err(err),
                             Err(_) | Ok(()) => Ok(()),
                         }
@@ -787,7 +779,7 @@ impl Core {
     fn check_valid_client_message(&self, msg: &RoutingMessage) -> Result<(), RoutingError> {
         match msg.content {
             MessageContent::Ack(_) |
-            MessageContent::Request(_) => Ok(()),
+            MessageContent::UserMessagePart { .. } => Ok(()),
             _ => {
                 debug!("{:?} Illegitimate client message {:?}. Refusing to relay.",
                        self,
@@ -847,34 +839,6 @@ impl Core {
             };
         }
         Ok(())
-    }
-
-    /// Returns a cached response, if one is available for the given message, otherwise `None`.
-    fn get_from_cache(&mut self, routing_msg: &RoutingMessage) -> Option<RoutingMessage> {
-        let content = match routing_msg.content {
-            MessageContent::Request(Request::Get(DataIdentifier::Immutable(ref name), id)) => {
-                match self.data_cache.get(name) {
-                    Some(data) => MessageContent::Response(Response::GetSuccess(data.clone(), id)),
-                    _ => return None,
-                }
-            }
-            _ => return None,
-        };
-
-        let response_msg = RoutingMessage {
-            src: Authority::ManagedNode(*self.name()),
-            dst: routing_msg.src.clone(),
-            content: content,
-        };
-
-        Some(response_msg)
-    }
-
-    fn add_to_cache(&mut self, routing_msg: &RoutingMessage) {
-        if let MessageContent::Response(Response::GetSuccess(ref data @ Data::Immutable(_), _)) =
-               routing_msg.content {
-            let _ = self.data_cache.insert(data.name(), data.clone());
-        }
     }
 
     fn handle_routing_message(&mut self,
@@ -979,20 +943,27 @@ impl Core {
              Authority::ManagedNode(_),
              dst) => self.handle_get_close_group_response(close_group_ids, dst),
             (MessageContent::Ack(ack), _, _) => self.handle_ack_response(ack),
-            (MessageContent::Request(request), src, dst) => {
-                let event = Event::Request {
-                    request: request,
-                    src: src,
-                    dst: dst,
-                };
-                let _ = self.event_sender.send(event);
-                Ok(())
-            }
-            (MessageContent::Response(response), src, dst) => {
-                let event = Event::Response {
-                    response: response,
-                    src: src,
-                    dst: dst,
+            (MessageContent::UserMessagePart { hash, part_count, part_index, payload },
+             src,
+             dst) => {
+                let event = match self.add_user_msg_part(hash, part_count, part_index, payload) {
+                    Some(UserMessage::Request(request)) => {
+                        self.stats.count_request(&request);
+                        Event::Request {
+                            request: request,
+                            src: src,
+                            dst: dst,
+                        }
+                    }
+                    Some(UserMessage::Response(response)) => {
+                        self.stats.count_response(&response);
+                        Event::Response {
+                            response: response,
+                            src: src,
+                            dst: dst,
+                        }
+                    }
+                    None => return Ok(()),
                 };
                 let _ = self.event_sender.send(event);
                 Ok(())
@@ -1905,6 +1876,46 @@ impl Core {
 
     // ----- Send Functions -----------------------------------------------------------------------
 
+    /// Sends the given message, possibly splitting it up into smaller parts.
+    fn send_user_message(&mut self,
+                         src: Authority,
+                         dst: Authority,
+                         user_msg: UserMessage)
+                         -> Result<(), RoutingError> {
+        match user_msg {
+            UserMessage::Request(ref request) => self.stats.count_request(request),
+            UserMessage::Response(ref response) => self.stats.count_response(response),
+        }
+        for part in try!(user_msg.to_parts()) {
+            try!(self.send_message(RoutingMessage {
+                src: src.clone(),
+                dst: dst.clone(),
+                content: part,
+            }));
+        }
+        Ok(())
+    }
+
+    /// Adds the given one to the cache of received message parts, returning a `UserMessage` if the
+    /// given part was the last missing piece of it.
+    fn add_user_msg_part(&mut self,
+                         hash: u64,
+                         part_count: u32,
+                         part_index: u32,
+                         payload: Vec<u8>)
+                         -> Option<UserMessage> {
+        {
+            let entry = self.user_msg_cache.entry((hash, part_count)).or_insert_with(BTreeMap::new);
+            let _ = entry.insert(part_index, payload);
+            if entry.len() != part_count as usize {
+                return None;
+            }
+        }
+        self.user_msg_cache
+            .remove(&(hash, part_count))
+            .and_then(|part_map| UserMessage::from_parts(hash, part_map.values()).ok())
+    }
+
     fn send_message(&mut self, routing_msg: RoutingMessage) -> Result<(), RoutingError> {
         let signed_msg = try!(SignedMessage::new(routing_msg, &self.full_id));
         let hop = *self.name();
@@ -1982,13 +1993,6 @@ impl Core {
             sent_to: &[XorName])
             -> Result<(), RoutingError> {
         let routing_msg = signed_msg.routing_message();
-        // Cache handling
-        if self.state == State::Node && self.use_data_cache {
-            if let Some(response_msg) = self.get_from_cache(routing_msg) {
-                return self.send_message(response_msg);
-            }
-            self.add_to_cache(routing_msg);
-        }
 
         if let Authority::Client { ref peer_id, .. } = routing_msg.dst {
             if self.name() == routing_msg.dst.name() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,6 +114,8 @@ pub enum RoutingError {
     InvalidSource,
     /// Attempted to use a node as a tunnel that is not directly connected
     CannotTunnelThroughTunnel,
+    /// Decoded a user message with an unexpected hash.
+    HashMismatch,
 }
 
 impl From<::std::str::Utf8Error> for RoutingError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //! let (sender, _receiver) = mpsc::channel::<Event>();
 //! let full_id = FullId::new(); // Generate new keys.
-//! let _ = Client::new(sender, Some(full_id.clone()), true).unwrap();
+//! let _ = Client::new(sender, Some(full_id.clone())).unwrap();
 //!
 //! let _ = full_id.public_id().name();
 //! ```
@@ -79,9 +79,8 @@
 //! use routing::{Node, Event};
 //!
 //! let (sender, _receiver) = mpsc::channel::<Event>();
-//! let use_data_cache = true;
 //! let first_node = false;
-//! let _ = Node::new(sender, use_data_cache, first_node).unwrap();
+//! let _ = Node::new(sender, first_node).unwrap();
 //! ```
 //!
 //! Upon creation, the node will first connect to the network as a client. Once it has client

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -64,6 +64,36 @@ pub struct Stats {
 }
 
 impl Stats {
+    /// Increments the counter for the given request.
+    pub fn count_request(&mut self, request: &Request) {
+        match *request {
+            Request::Refresh(..) => self.msg_refresh += 1,
+            Request::Get(..) => self.msg_get += 1,
+            Request::Put(..) => self.msg_put += 1,
+            Request::Post(..) => self.msg_post += 1,
+            Request::Delete(..) => self.msg_delete += 1,
+            Request::GetAccountInfo(..) => self.msg_get_account_info += 1,
+        }
+        self.increment_msg_total();
+    }
+
+    /// Increments the counter for the given response.
+    pub fn count_response(&mut self, response: &Response) {
+        match *response {
+            Response::GetSuccess(..) => self.msg_get_success += 1,
+            Response::GetFailure { .. } => self.msg_get_failure += 1,
+            Response::PutSuccess(..) => self.msg_put_success += 1,
+            Response::PutFailure { .. } => self.msg_put_failure += 1,
+            Response::PostSuccess(..) => self.msg_post_success += 1,
+            Response::PostFailure { .. } => self.msg_post_failure += 1,
+            Response::DeleteSuccess(..) => self.msg_delete_success += 1,
+            Response::DeleteFailure { .. } => self.msg_delete_failure += 1,
+            Response::GetAccountInfoSuccess { .. } => self.msg_get_account_info_success += 1,
+            Response::GetAccountInfoFailure { .. } => self.msg_get_account_info_failure += 1,
+        }
+        self.increment_msg_total();
+    }
+
     /// Increments the counter for the given routing message type.
     pub fn count_routing_message(&mut self, msg: &RoutingMessage) {
         match msg.content {
@@ -71,31 +101,10 @@ impl Stats {
             MessageContent::ExpectCloseNode { .. } => self.msg_expect_close_node += 1,
             MessageContent::GetCloseGroup(..) => self.msg_get_close_group += 1,
             MessageContent::ConnectionInfo { .. } => self.msg_connection_info += 1,
-            MessageContent::Request(Request::Refresh(..)) => self.msg_refresh += 1,
-            MessageContent::Request(Request::Get(..)) => self.msg_get += 1,
-            MessageContent::Request(Request::Put(..)) => self.msg_put += 1,
-            MessageContent::Request(Request::Post(..)) => self.msg_post += 1,
-            MessageContent::Request(Request::Delete(..)) => self.msg_delete += 1,
-            MessageContent::Request(Request::GetAccountInfo(..)) => self.msg_get_account_info += 1,
-            MessageContent::Response(Response::GetSuccess(..)) => self.msg_get_success += 1,
-            MessageContent::Response(Response::GetFailure { .. }) => self.msg_get_failure += 1,
-            MessageContent::Response(Response::PutSuccess(..)) => self.msg_put_success += 1,
-            MessageContent::Response(Response::PutFailure { .. }) => self.msg_put_failure += 1,
-            MessageContent::Response(Response::PostSuccess(..)) => self.msg_post_success += 1,
-            MessageContent::Response(Response::PostFailure { .. }) => self.msg_post_failure += 1,
-            MessageContent::Response(Response::DeleteSuccess(..)) => self.msg_delete_success += 1,
-            MessageContent::Response(Response::DeleteFailure { .. }) => {
-                self.msg_delete_failure += 1
-            }
-            MessageContent::Response(Response::GetAccountInfoSuccess { .. }) => {
-                self.msg_get_account_info_success += 1
-            }
-            MessageContent::Response(Response::GetAccountInfoFailure { .. }) => {
-                self.msg_get_account_info_failure += 1
-            }
             MessageContent::GetCloseGroupResponse { .. } => self.msg_get_close_group_rsp += 1,
             MessageContent::GetNodeNameResponse { .. } => self.msg_get_node_name_rsp += 1,
             MessageContent::Ack(..) => self.msg_ack += 1,
+            MessageContent::UserMessagePart { .. } => return, // Counted as request/response.
         }
         self.increment_msg_total();
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -105,7 +105,7 @@ impl Stats {
             MessageContent::GetCloseGroupResponse { .. } => self.msg_get_close_group_rsp += 1,
             MessageContent::GetNodeNameResponse { .. } => self.msg_get_node_name_rsp += 1,
             MessageContent::Ack(..) => self.msg_ack += 1,
-            MessageContent::Hash(..) => self.msg_hash += 1,
+            MessageContent::GroupMessageHash(..) => self.msg_hash += 1,
             MessageContent::UserMessagePart { .. } => return, // Counted as request/response.
         }
         self.increment_msg_total();
@@ -138,7 +138,8 @@ impl Stats {
                    ConnectionInfo: {}, GetSuccess: {}, GetFailure: {}, PutSuccess: {}, \
                    PutFailure: {}, PostSuccess: {}, PostFailure: {}, DeleteSuccess: {}, \
                    DeleteFailure: {}, GetAccountInfoSuccess: {}, GetAccountInfoFailure: {}, \
-                   GetCloseGroupResponse: {}, GetNodeNameResponse: {}, Ack: {}, Hash: {}",
+                   GetCloseGroupResponse: {}, GetNodeNameResponse: {}, Ack: {}, \
+                   GroupMessageHash: {}",
                   self.msg_get,
                   self.msg_put,
                   self.msg_post,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -57,6 +57,7 @@ pub struct Stats {
     msg_get_close_group_rsp: usize,
     msg_get_node_name_rsp: usize,
     msg_ack: usize,
+    msg_hash: usize,
 
     msg_other: usize,
 
@@ -104,6 +105,7 @@ impl Stats {
             MessageContent::GetCloseGroupResponse { .. } => self.msg_get_close_group_rsp += 1,
             MessageContent::GetNodeNameResponse { .. } => self.msg_get_node_name_rsp += 1,
             MessageContent::Ack(..) => self.msg_ack += 1,
+            MessageContent::Hash(..) => self.msg_hash += 1,
             MessageContent::UserMessagePart { .. } => return, // Counted as request/response.
         }
         self.increment_msg_total();
@@ -136,7 +138,7 @@ impl Stats {
                    ConnectionInfo: {}, GetSuccess: {}, GetFailure: {}, PutSuccess: {}, \
                    PutFailure: {}, PostSuccess: {}, PostFailure: {}, DeleteSuccess: {}, \
                    DeleteFailure: {}, GetAccountInfoSuccess: {}, GetAccountInfoFailure: {}, \
-                   GetCloseGroupResponse: {}, GetNodeNameResponse: {}, Ack: {}",
+                   GetCloseGroupResponse: {}, GetNodeNameResponse: {}, Ack: {}, Hash: {}",
                   self.msg_get,
                   self.msg_put,
                   self.msg_post,
@@ -159,7 +161,8 @@ impl Stats {
                   self.msg_get_account_info_failure,
                   self.msg_get_close_group_rsp,
                   self.msg_get_node_name_rsp,
-                  self.msg_ack);
+                  self.msg_ack,
+                  self.msg_hash);
         }
     }
 }

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -86,7 +86,7 @@ impl TestNode {
         let first_node = index == 0;
 
         TestNode {
-            node: unwrap_result!(Node::new(sender, false, first_node)),
+            node: unwrap_result!(Node::new(sender, first_node)),
             _thread_joiner: joiner,
         }
     }
@@ -115,7 +115,7 @@ impl TestClient {
         TestClient {
             index: index,
             full_id: full_id.clone(),
-            client: unwrap_result!(Client::new(sender, Some(full_id), false)),
+            client: unwrap_result!(Client::new(sender, Some(full_id))),
             _thread_joiner: joiner,
         }
     }


### PR DESCRIPTION
This splits up requests and responses into chunks of at most 20 kB to
reduce network latency.

The caching functionality is removed, since hop nodes now only get to
see parts of `GetSuccess` responses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1038)
<!-- Reviewable:end -->
