### PR TITLE
refactor/mock-crust: Use seeded pseudorandom number generator

### DIFF
--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -16,7 +16,6 @@
 // relating to use of the SAFE Network Software.
 
 use maidsafe_utilities::event_sender;
-use rand::{Rand, Rng};
 use std::cell::{RefCell, RefMut};
 use std::fmt;
 use std::io;
@@ -154,23 +153,12 @@ impl Drop for Service {
 }
 
 /// Mock version of `crust::PeerId`.
-///
-/// First element is the endpoint number of the peer (for easier log
-/// diagnostics), second one is some random number so the `PeerId` is different
-/// after restart.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, RustcEncodable, RustcDecodable)]
-pub struct PeerId(pub usize, pub u64);
+pub struct PeerId(pub usize);
 
 impl fmt::Debug for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Ignore the random number, as it would only clutter the debug output.
         write!(f, "PeerId({})", self.0)
-    }
-}
-
-impl Rand for PeerId {
-    fn rand<R: Rng>(rng: &mut R) -> PeerId {
-        PeerId(Rand::rand(rng), Rand::rand(rng))
     }
 }
 

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -15,12 +15,6 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-// It seems that code used only in tests is considered unused by rust.
-// TODO: Remove `unsafe_code` here again, once these changes are in stable:
-//       https://github.com/rust-lang/rust/issues/30756
-#![allow(unused, unsafe_code)]
-
-use rand;
 use std::cell::RefCell;
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -68,6 +62,7 @@ impl Network {
 
         handle
     }
+
 
     /// Generate unique Endpoint
     pub fn gen_endpoint(&self, opt_endpoint: Option<Endpoint>) -> Endpoint {
@@ -169,7 +164,7 @@ impl ServiceImpl {
         ServiceImpl {
             network: network,
             endpoint: endpoint,
-            peer_id: gen_peer_id(endpoint),
+            peer_id: PeerId(endpoint.0),
             config: config,
             listening_tcp: false,
             listening_udp: false,
@@ -207,7 +202,7 @@ impl ServiceImpl {
 
         self.disconnect_all();
 
-        self.peer_id = gen_peer_id(self.endpoint);
+        self.peer_id = PeerId(self.endpoint.0);
         self.listening_tcp = false;
         self.listening_udp = false;
 
@@ -458,10 +453,6 @@ impl Drop for ServiceImpl {
     fn drop(&mut self) {
         self.disconnect_all();
     }
-}
-
-fn gen_peer_id(endpoint: Endpoint) -> PeerId {
-    PeerId(endpoint.0, rand::random())
 }
 
 /// Simulated crust config file.

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -193,7 +193,7 @@ mod tests {
     use mock_crust::crust::PeerId;
 
     fn id(i: usize) -> PeerId {
-        PeerId(i, 0)
+        PeerId(i)
     }
 
     #[test]


### PR DESCRIPTION
This changes the use of the CSRNG in mock-crust tests to a seeded PRNG.  Failing tests cause the
seed to be printed as part of the error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1039)
<!-- Reviewable:end -->
