### PR TITLE
feat/stats: record total message size

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -241,7 +241,6 @@ impl Core {
             Err(what) => panic!(format!("Unable to start crust::Service {:?}", what)),
         };
 
-
         let full_id = match keys {
             Some(full_id) => full_id,
             None => FullId::new(),
@@ -1109,6 +1108,7 @@ impl Core {
                     bytes: Vec<u8>,
                     priority: u8)
                     -> Result<(), RoutingError> {
+        self.stats.count_bytes(bytes.len());
         if let Err(err) = self.crust_service.send(*peer_id, bytes.clone(), priority) {
             info!("{:?} Connection to {:?} failed. Calling crust::Service::disconnect.",
                   self,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -62,6 +62,7 @@ pub struct Stats {
     msg_other: usize,
 
     msg_total: usize,
+    msg_total_bytes: u64,
 }
 
 impl Stats {
@@ -122,12 +123,17 @@ impl Stats {
         self.increment_msg_total();
     }
 
+    pub fn count_bytes(&mut self, len: usize) {
+        self.msg_total_bytes += len as u64;
+    }
+
     /// Increment the total message count, and if divisible by 100, log a message with the counts.
     fn increment_msg_total(&mut self) {
         self.msg_total += 1;
         if self.msg_total % MSG_LOG_COUNT == 0 {
-            info!("Stats - Sent {} messages in total, {} uncategorised",
+            info!("Stats - Sent {} messages in total, comprising {} bytes, {} uncategorised",
                   self.msg_total,
+                  self.msg_total_bytes,
                   self.msg_other);
             info!("Stats - Direct - NodeIdentify: {}, NewNode: {}, ConnectionUnneeded: {}",
                   self.msg_direct_node_identify,


### PR DESCRIPTION
This records the cumulative size of all messages sent via Crust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1041)
<!-- Reviewable:end -->
