### PR TITLE
Make seeded RNG consistent regardless of running single or multiple tests

### DIFF
--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -53,7 +53,7 @@ impl Network {
             next_endpoint: 0,
             queue: VecDeque::new(),
             blocked_connections: HashSet::new(),
-            rng: rng,
+            rng: SeededRng::new(),
         })))
     }
 


### PR DESCRIPTION
This fixes an issue where the RNG returned by `Network::get_rng()` is different depending on whether
called from a test which was used to initialise libsodium or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1065)
<!-- Reviewable:end -->
