### PR TITLE
fix/core_tests: fix node sorting

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,7 +19,7 @@ use messages::{Request, Response};
 
 /// A cache that stores `Response`s keyed by `Requests`. Should be implemented
 /// by layers above routing.
-pub trait Cache : Send {
+pub trait Cache: Send {
     /// Retrieve cached response for the given request.
     fn get(&self, request: &Request) -> Option<Response>;
 
@@ -32,6 +32,8 @@ pub trait Cache : Send {
 pub struct NullCache;
 
 impl Cache for NullCache {
-    fn get(&self, _: &Request) -> Option<Response> { None }
+    fn get(&self, _: &Request) -> Option<Response> {
+        None
+    }
     fn put(&self, _: Response) {}
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -70,10 +70,8 @@ impl Client {
         sodiumoxide::init();  // enable shared global (i.e. safe to multithread now)
 
         // start the handler for routing with a restriction to become a full node
-        let (action_sender, mut core) = Core::new(event_sender,
-                                                  Role::Client,
-                                                  keys,
-                                                  Box::new(NullCache));
+        let (action_sender, mut core) =
+            Core::new(event_sender, Role::Client, keys, Box::new(NullCache));
         let (tx, rx) = channel();
 
         let raii_joiner = RaiiThreadJoiner::new(thread!("Client thread", move || {
@@ -92,10 +90,8 @@ impl Client {
     #[cfg(feature = "use-mock-crust")]
     pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
         // start the handler for routing with a restriction to become a full node
-        let (action_sender, core) = Core::new(event_sender,
-                                              Role::Client,
-                                              keys,
-                                              Box::new(NullCache));
+        let (action_sender, core) =
+            Core::new(event_sender, Role::Client, keys, Box::new(NullCache));
         let (tx, rx) = channel();
 
         Ok(Client {

--- a/src/core.rs
+++ b/src/core.rs
@@ -902,7 +902,7 @@ impl Core {
                         let src = Authority::ManagedNode(*self.name());
                         let dst = routing_msg.src.clone();
 
-                        self.send_ack_from(&routing_msg, route, src.clone());
+                        self.send_ack_from(routing_msg, route, src.clone());
 
                         try!(self.send_user_message(src,
                                                     dst,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -774,7 +774,8 @@ impl UserMessageCache {
                hash: u64,
                part_count: u32,
                part_index: u32,
-               payload: Vec<u8>) -> Option<UserMessage> {
+               payload: Vec<u8>)
+               -> Option<UserMessage> {
         {
             let entry = self.0.entry((hash, part_count)).or_insert_with(BTreeMap::new);
             let _ = entry.insert(part_index, payload);
@@ -783,8 +784,9 @@ impl UserMessageCache {
             }
         }
 
-        self.0.remove(&(hash, part_count))
-              .and_then(|part_map| UserMessage::from_parts(hash, part_map.values()).ok())
+        self.0
+            .remove(&(hash, part_count))
+            .and_then(|part_map| UserMessage::from_parts(hash, part_map.values()).ok())
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -73,9 +73,10 @@ impl Node {
 
     /// Create a new `Node` given a cache instance.
     #[cfg(not(feature = "use-mock-crust"))]
-    pub fn with_cache(event_sender: Sender<Event>, first_node: bool, cache: Box<Cache>)
-                      -> Result<Node, RoutingError>
-    {
+    pub fn with_cache(event_sender: Sender<Event>,
+                      first_node: bool,
+                      cache: Box<Cache>)
+                      -> Result<Node, RoutingError> {
         sodiumoxide::init();  // enable shared global (i.e. safe to multithread now)
 
         let role = if first_node {
@@ -108,9 +109,10 @@ impl Node {
 
     /// Create a new `Node` for unit testing.
     #[cfg(feature = "use-mock-crust")]
-    pub fn with_cache(event_sender: Sender<Event>, first_node: bool, cache: Box<Cache>)
-                      -> Result<Node, RoutingError>
-    {
+    pub fn with_cache(event_sender: Sender<Event>,
+                      first_node: bool,
+                      cache: Box<Cache>)
+                      -> Result<Node, RoutingError> {
         let role = if first_node {
             Role::FirstNode
         } else {


### PR DESCRIPTION
Sorting nodes by name causes the `name()` method to be called, which
causes mock Crust event polling. Sorting should therefore only be done
when there are no events to process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1066)
<!-- Reviewable:end -->
