### PR TITLE
perf/data: make the name method a simple getter

### DIFF
--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -243,7 +243,7 @@ fn store_and_verify(requests: usize, batches: usize) {
             print!(" - getting - ");
             io::stdout().flush().expect("Could not flush stdout");
             stored_data.push(data.clone());
-            if let Some(got_data) = example_client.get(DataIdentifier::Plain(data.name())) {
+            if let Some(got_data) = example_client.get(DataIdentifier::Plain(*data.name())) {
                 assert_eq!(got_data, data);
                 print_color("OK\n", color::GREEN);
             } else {
@@ -266,7 +266,7 @@ fn store_and_verify(requests: usize, batches: usize) {
         for (i, data_item) in stored_data.iter().enumerate().take(requests) {
             print!("Get attempt #{} - Data {:?} - ", i + 1, data_item.name());
             io::stdout().flush().expect("Could not flush stdout");
-            if let Some(data) = example_client.get(DataIdentifier::Plain(data_item.name())) {
+            if let Some(data) = example_client.get(DataIdentifier::Plain(*data_item.name())) {
                 assert_eq!(data, stored_data[i]);
                 print_color("OK\n", color::GREEN);
             } else {

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -69,7 +69,7 @@ impl ExampleClient {
     pub fn get(&mut self, request: DataIdentifier) -> Option<Data> {
         let message_id = MessageId::new();
         unwrap_result!(self.routing_client
-            .send_get_request(Authority::NaeManager(request.name()),
+            .send_get_request(Authority::NaeManager(*request.name()),
                               request.clone(),
                               message_id));
 

--- a/src/core_tests.rs
+++ b/src/core_tests.rs
@@ -636,7 +636,7 @@ fn messages_accumulate_with_quorum() {
     let mut nodes = create_connected_nodes(&network, 15);
 
     let data = gen_immutable_data(&mut rng, 8);
-    let src = Authority::NaeManager(data.name()); // The data's NaeManager.
+    let src = Authority::NaeManager(*data.name()); // The data's NaeManager.
     sort_nodes_by_distance_to(&mut nodes, src.name());
 
     let send = |node: &mut TestNode, dst: &Authority, message_id: MessageId| {
@@ -836,7 +836,7 @@ fn successful_get_request() {
     let mut clients = create_connected_clients(&network, &mut nodes, 1);
 
     let data = gen_immutable_data(&mut rng, 1024);
-    let dst = Authority::NaeManager(data.name());
+    let dst = Authority::NaeManager(*data.name());
     let data_request = data.identifier();
     let message_id = MessageId::new();
 
@@ -848,7 +848,7 @@ fn successful_get_request() {
 
     let mut request_received_count = 0;
 
-    for node in nodes.iter().filter(|n| n.routing_table().is_close(&data.name(), GROUP_SIZE)) {
+    for node in nodes.iter().filter(|n| n.routing_table().is_close(data.name(), GROUP_SIZE)) {
         loop {
             match node.event_rx.try_recv() {
                 Ok(Event::Request { request: Request::Get(ref request, id), ref src, ref dst }) => {
@@ -902,7 +902,7 @@ fn failed_get_request() {
     let mut clients = create_connected_clients(&network, &mut nodes, 1);
 
     let data = gen_immutable_data(&mut rng, 1024);
-    let dst = Authority::NaeManager(data.name());
+    let dst = Authority::NaeManager(*data.name());
     let data_request = data.identifier();
     let message_id = MessageId::new();
 
@@ -914,7 +914,7 @@ fn failed_get_request() {
 
     let mut request_received_count = 0;
 
-    for node in nodes.iter().filter(|n| n.routing_table().is_close(&data.name(), GROUP_SIZE)) {
+    for node in nodes.iter().filter(|n| n.routing_table().is_close(data.name(), GROUP_SIZE)) {
         loop {
             match node.event_rx.try_recv() {
                 Ok(Event::Request { request: Request::Get(ref data_id, ref id),
@@ -968,8 +968,8 @@ fn disconnect_on_get_request() {
 
     let immutable_data = ImmutableData::new(gen_bytes(&mut rng, 1024));
     let data = Data::Immutable(immutable_data.clone());
-    let dst = Authority::NaeManager(data.name());
-    let data_request = DataIdentifier::Immutable(data.name());
+    let dst = Authority::NaeManager(*data.name());
+    let data_request = DataIdentifier::Immutable(*data.name());
     let message_id = MessageId::new();
 
     assert!(clients[0].inner
@@ -980,7 +980,7 @@ fn disconnect_on_get_request() {
 
     let mut request_received_count = 0;
 
-    for node in nodes.iter().filter(|n| n.routing_table().is_close(&data.name(), GROUP_SIZE)) {
+    for node in nodes.iter().filter(|n| n.routing_table().is_close(data.name(), GROUP_SIZE)) {
         loop {
             match node.event_rx.try_recv() {
                 Ok(Event::Request { request: Request::Get(ref request, ref id),
@@ -1089,7 +1089,7 @@ fn request_during_churn_node_to_group() {
 
         let data = gen_immutable_data(&mut rng, 8);
         let src = Authority::ManagedNode(nodes[index].name());
-        let dst = Authority::NaeManager(data.name());
+        let dst = Authority::NaeManager(*data.name());
         let data_id = data.identifier();
         let message_id = MessageId::new();
 
@@ -1162,7 +1162,7 @@ fn request_during_churn_group_to_node() {
 
     for _ in 0..REQUEST_DURING_CHURN_ITERATIONS {
         let data = gen_immutable_data(&mut rng, 8);
-        let src = Authority::NaeManager(data.name());
+        let src = Authority::NaeManager(*data.name());
         sort_nodes_by_distance_to(&mut nodes, src.name());
 
         let added_index = random_churn(&mut rng, &network, &mut nodes);
@@ -1232,7 +1232,7 @@ fn gen_immutable_data_not_close_to_first_node<T: Rng>(rng: &mut T, nodes: &mut [
 
     loop {
         let data = gen_immutable_data(rng, 8);
-        sort_nodes_by_distance_to(nodes, &data.name());
+        sort_nodes_by_distance_to(nodes, data.name());
 
         if nodes.iter().take(GROUP_SIZE).all(|node| node.name() != first_name) {
             return data;
@@ -1256,9 +1256,8 @@ fn response_caching() {
     // it would never be stored in the cache.
     let data = gen_immutable_data_not_close_to_first_node(&mut rng, &mut nodes);
     let data_id = data.identifier();
-    let data_name = data_id.name();
     let message_id = MessageId::new();
-    let dst = Authority::NaeManager(data_name);
+    let dst = Authority::NaeManager(*data.name());
 
     // No node has the data cached yet, so this request should reach the nodes
     // in the NAE manager group of the data.
@@ -1294,11 +1293,11 @@ fn response_caching() {
         clients[0],
         Event::Response {
             response: Response::GetSuccess(ref res_data, res_message_id),
-            src: Authority::NaeManager(src_name),
+            src: Authority::NaeManager(ref src_name),
             ..
         } if *res_data == data &&
              res_message_id == message_id &&
-             src_name == data_name
+             src_name == data.name()
     );
 
     // Drain remaining events if any.

--- a/src/data.rs
+++ b/src/data.rs
@@ -34,7 +34,7 @@ pub enum Data {
 
 impl Data {
     /// Return data name.
-    pub fn name(&self) -> XorName {
+    pub fn name(&self) -> &XorName {
         match *self {
             Data::Structured(ref data) => data.name(),
             Data::Immutable(ref data) => data.name(),
@@ -84,11 +84,11 @@ impl Debug for Data {
 
 impl DataIdentifier {
     /// DataIdentifier name.
-    pub fn name(&self) -> XorName {
+    pub fn name(&self) -> &XorName {
         match *self {
-            DataIdentifier::Structured(name, tag) => StructuredData::compute_name(tag, &name),
-            DataIdentifier::Immutable(name) |
-            DataIdentifier::Plain(name) => name,
+            DataIdentifier::Structured(ref name, _) |
+            DataIdentifier::Immutable(ref name) |
+            DataIdentifier::Plain(ref name) => name,
         }
     }
 }
@@ -117,7 +117,7 @@ mod test {
             Ok(structured_data) => {
                 assert_eq!(structured_data.clone().name(),
                            Data::Structured(structured_data.clone()).name());
-                assert_eq!(DataIdentifier::Structured(*structured_data.get_identifier(),
+                assert_eq!(DataIdentifier::Structured(*structured_data.name(),
                                                       structured_data.get_type_tag()),
                            structured_data.identifier());
             }
@@ -131,14 +131,14 @@ mod test {
         assert_eq!(immutable_data.name(),
                    Data::Immutable(immutable_data.clone()).name());
         assert_eq!(immutable_data.identifier(),
-                   DataIdentifier::Immutable(immutable_data.name()));
+                   DataIdentifier::Immutable(*immutable_data.name()));
 
         // name() resolves correctly for PlainData
         let name = XorName(sha256::hash(&[]).0);
         let plain_data = PlainData::new(name, vec![]);
         assert_eq!(plain_data.name(), Data::Plain(plain_data.clone()).name());
         assert_eq!(plain_data.identifier(),
-                   DataIdentifier::Plain(plain_data.name()));
+                   DataIdentifier::Plain(*plain_data.name()));
     }
 
     #[test]
@@ -179,14 +179,12 @@ mod test {
 
         // name() resolves correctly for StructuredData
         let tag = 0;
-        assert_eq!(StructuredData::compute_name(tag, &name),
-                   DataIdentifier::Structured(name, tag).name());
+        assert_eq!(&name, DataIdentifier::Structured(name, tag).name());
 
         // name() resolves correctly for ImmutableData
-        let actual_name = DataIdentifier::Immutable(name).name();
-        assert_eq!(name, actual_name);
+        assert_eq!(&name, DataIdentifier::Immutable(name).name());
 
         // name() resolves correctly for PlainData
-        assert_eq!(name, DataIdentifier::Plain(name).name());
+        assert_eq!(&name, DataIdentifier::Plain(name).name());
     }
 }

--- a/src/plain_data.rs
+++ b/src/plain_data.rs
@@ -46,8 +46,8 @@ impl PlainData {
 
 
     /// Returns the name.
-    pub fn name(&self) -> XorName {
-        self.name
+    pub fn name(&self) -> &XorName {
+        &self.name
     }
 
     /// Returns the size of the contained data. Equivalent to `value().len()`.
@@ -57,7 +57,7 @@ impl PlainData {
 
     /// Returns `DataIdentifier` for this data element.
     pub fn identifier(&self) -> DataIdentifier {
-        DataIdentifier::Plain(self.name())
+        DataIdentifier::Plain(*self.name())
     }
 }
 

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -275,7 +275,7 @@ fn core() {
 
                             unwrap_result!(node.send_put_success(dst,
                                                   src,
-                                                  DataIdentifier::Plain(data.name()),
+                                                  DataIdentifier::Plain(*data.name()),
                                                   id.clone()));
                         }
                     }
@@ -352,7 +352,7 @@ fn core() {
                                                src: Authority::Client { .. },
                                                dst: Authority::ClientManager(name) }) => {
                         let src = Authority::ClientManager(name);
-                        let dst = Authority::NaeManager(data.name());
+                        let dst = Authority::NaeManager(*data.name());
                         unwrap_result!(nodes[index]
                             .node
                             .send_put_request(src, dst, data.clone(), id.clone()));
@@ -453,7 +453,7 @@ fn core() {
                                            src: Authority::Client { .. },
                                            dst: Authority::ClientManager(name) }) => {
                     let src = Authority::ClientManager(name);
-                    let dst = Authority::NaeManager(data.name());
+                    let dst = Authority::NaeManager(*data.name());
                     unwrap_result!(nodes[index]
                         .node
                         .send_put_request(src, dst, data.clone(), id.clone()));
@@ -496,7 +496,7 @@ fn core() {
                     }
                     TestEvent(index, Event::Request { request, src, dst }) => {
                         // A node received request from the client. Reply with a success.
-                        let data_id = DataIdentifier::Plain(data.name());
+                        let data_id = DataIdentifier::Plain(*data.name());
                         if let Request::Put(_, id) = request {
                             unwrap_result!(nodes[index]
                                 .node
@@ -507,7 +507,7 @@ fn core() {
                               Event::Response { response: Response::PutSuccess(name, id), .. })
                         if index == client.index => {
                         assert!(received_ids.insert(id));
-                        assert_eq!(name, DataIdentifier::Plain(data.name()));
+                        assert_eq!(name, DataIdentifier::Plain(*data.name()));
                     }
                     _ => (),
                 }


### PR DESCRIPTION
Avoid computing hashes in the `name` methods of the data types and data
identifier. Also replace the structured data identifier with a name,
instead of computing the name as a hash of the type tag and identifier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1074)
<!-- Reviewable:end -->
