### PR TITLE
test/core: add a regression test for rebootstrap

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1882,11 +1882,9 @@ impl Core {
                        self,
                        unacked_msg);
                 self.stats.count_unacked();
-            } else {
-                if let Err(error) =
-                       self.send_message_via_route(unacked_msg.routing_msg, unacked_msg.route) {
-                    debug!("{:?} Failed to send message: {:?}", self, error);
-                }
+            } else if let Err(error) =
+                   self.send_message_via_route(unacked_msg.routing_msg, unacked_msg.route) {
+                debug!("{:?} Failed to send message: {:?}", self, error);
             }
         }
     }

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -57,8 +57,8 @@ impl Service {
     }
 
     /// Start the bootstrapping procedure.
-    pub fn start_bootstrap(&self, _blacklist: HashSet<SocketAddr>) -> Result<(), CrustError> {
-        self.lock_and_poll(|imp| imp.start_bootstrap());
+    pub fn start_bootstrap(&self, blacklist: HashSet<SocketAddr>) -> Result<(), CrustError> {
+        self.lock_and_poll(|imp| imp.start_bootstrap(blacklist));
         Ok(())
     }
 


### PR DESCRIPTION
This is a regression test for PR #1069. It asserts that when retrying to
bootstrap, a node first disconnects from its current bootstrap node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1075)
<!-- Reviewable:end -->
