### PR TITLE
fix/tests: re-enable ci tests, and fix a peer manager bug

### DIFF
--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -51,7 +51,7 @@ impl ExampleNode {
     /// Creates a new node and attempts to establish a connection to the network.
     pub fn new(first: bool) -> ExampleNode {
         let (sender, receiver) = mpsc::channel::<Event>();
-        let node = unwrap_result!(Node::new(sender.clone(), first));
+        let node = unwrap_result!(Node::builder().first(first).create(sender.clone()));
 
         ExampleNode {
             node: node,
@@ -92,8 +92,8 @@ impl ExampleNode {
                 }
                 Event::RestartRequired => {
                     info!("{} Received RestartRequired event", self.get_debug_name());
-                    let _ = mem::replace(&mut self.node,
-                                         unwrap_result!(Node::new(self.sender.clone(), false)));
+                    let new_node = unwrap_result!(Node::builder().create(self.sender.clone()));
+                    let _ = mem::replace(&mut self.node, new_node);
                 }
                 event => {
                     trace!("{} Received {:?} event", self.get_debug_name(), event);

--- a/src/client.rs
+++ b/src/client.rs
@@ -71,7 +71,7 @@ impl Client {
 
         // start the handler for routing with a restriction to become a full node
         let (action_sender, mut core) =
-            Core::new(event_sender, Role::Client, keys, Box::new(NullCache));
+            Core::new(event_sender, Role::Client, keys, Box::new(NullCache), false);
         let (tx, rx) = channel();
 
         let raii_joiner = RaiiThreadJoiner::new(thread!("Client thread", move || {
@@ -91,7 +91,7 @@ impl Client {
     pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
         // start the handler for routing with a restriction to become a full node
         let (action_sender, core) =
-            Core::new(event_sender, Role::Client, keys, Box::new(NullCache));
+            Core::new(event_sender, Role::Client, keys, Box::new(NullCache), false);
         let (tx, rx) = channel();
 
         Ok(Client {

--- a/src/core.rs
+++ b/src/core.rs
@@ -228,7 +228,8 @@ impl Core {
     pub fn new(event_sender: mpsc::Sender<Event>,
                role: Role,
                keys: Option<FullId>,
-               cache: Box<Cache>)
+               cache: Box<Cache>,
+               deny_other_local_nodes: bool)
                -> (RoutingActionSender, Self) {
         let (crust_tx, crust_rx) = mpsc::channel();
         let (action_tx, action_rx) = mpsc::channel();
@@ -295,7 +296,7 @@ impl Core {
         if role == Role::FirstNode {
             core.start_new_network();
         } else {
-            if role == Role::Node && core.crust_service.has_peers_on_lan() {
+            if deny_other_local_nodes && core.crust_service.has_peers_on_lan() {
                 error!("{:?} More than 1 routing node found on LAN. Currently this is not \
                         supported",
                        core);

--- a/src/core_tests.rs
+++ b/src/core_tests.rs
@@ -144,7 +144,7 @@ impl TestNode {
         let (event_tx, event_rx) = mpsc::channel();
         let handle = network.new_service_handle(config, endpoint);
         let node = mock_crust::make_current(&handle, || {
-            unwrap_result!(Node::with_cache(event_tx, first_node, cache))
+            unwrap_result!(Node::builder().cache(cache).first(first_node).create(event_tx))
         });
 
         TestNode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,7 @@
 //! use routing::{Node, Event};
 //!
 //! let (sender, _receiver) = mpsc::channel::<Event>();
-//! let first_node = false;
-//! let _ = Node::new(sender, first_node).unwrap();
+//! let _ = Node::builder().create(sender).unwrap();
 //! ```
 //!
 //! Upon creation, the node will first connect to the network as a client. Once it has client
@@ -186,7 +185,7 @@ pub use event::Event;
 pub use id::{FullId, PublicId};
 pub use immutable_data::ImmutableData;
 pub use messages::{Request, Response};
-pub use node::Node;
+pub use node::{Node, NodeBuilder};
 pub use plain_data::PlainData;
 pub use structured_data::{MAX_STRUCTURED_DATA_SIZE_IN_BYTES, StructuredData};
 pub use types::MessageId;

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -428,8 +428,8 @@ impl PeerManager {
 
     #[cfg(not(feature = "use-mock-crust"))]
     fn insert_state(&mut self, pub_id: PublicId, state: PeerState) {
-        self.remove_expired();
         let _ = self.node_map.insert(pub_id, (Instant::now(), state));
+        self.remove_expired();
     }
 
     fn get_state(&self, pub_id: &PublicId) -> Option<&PeerState> {

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -84,7 +84,7 @@ impl TestNode {
         let first_node = index == 0;
 
         TestNode {
-            node: unwrap_result!(Node::new(sender, first_node)),
+            node: unwrap_result!(Node::builder().first(first_node).create(sender)),
             _thread_joiner: joiner,
         }
     }
@@ -521,7 +521,6 @@ fn core() {
 }
 
 #[test]
-#[ignore]
 fn main() {
     init();
     core();


### PR DESCRIPTION
This enables the ci test and makes the "ci_test" example work again by
making the one-node-per-local-network limit configurable when
constructing a node.

Also fixes a bug in `PeerManager` that caused valid connection info tokens to
be considered expired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1076)
<!-- Reviewable:end -->
