### PR TITLE
fix/test: further increase message filter test timeouts

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -592,7 +592,10 @@ impl Core {
         if self.role == Role::Client {
             warn!("{:?} Received ConnectFailure event as a client.", self);
         } else if let Some(&pub_id) = self.peer_mgr.get_connecting_peer(&peer_id) {
-            info!("{:?} Failed to connect to peer {:?} with pub_id {:?}.", self, peer_id, pub_id);
+            info!("{:?} Failed to connect to peer {:?} with pub_id {:?}.",
+                  self,
+                  peer_id,
+                  pub_id);
             self.find_tunnel_for_peer(peer_id, &pub_id);
         }
     }
@@ -1363,8 +1366,9 @@ impl Core {
         let info = NodeInfo::new(public_id, peer_id);
 
         let bucket_index = self.name().bucket_index(&name);
-        let common_groups = self.peer_mgr.routing_table()
-                                         .is_in_any_close_group_with(bucket_index, GROUP_SIZE);
+        let common_groups = self.peer_mgr
+            .routing_table()
+            .is_in_any_close_group_with(bucket_index, GROUP_SIZE);
 
         match self.peer_mgr.add_to_routing_table(info) {
             None => {
@@ -1624,8 +1628,9 @@ impl Core {
             self.sent_network_name_to = None;
         }
 
-        let public_ids = match self.peer_mgr.routing_table().close_nodes(expect_id.name(),
-                                                                         GROUP_SIZE) {
+        let public_ids = match self.peer_mgr
+            .routing_table()
+            .close_nodes(expect_id.name(), GROUP_SIZE) {
             Some(close_group) => close_group.into_iter().map(|info| info.public_id).collect_vec(),
             None => return Err(RoutingError::InvalidDestination),
         };
@@ -1776,7 +1781,9 @@ impl Core {
             if let Some(token) = self.peer_mgr.get_connection_token(src, dst, their_public_id) {
                 self.crust_service.prepare_connection_info(token);
             } else {
-                trace!("{:?} Already sent connection info to {:?}!", self, their_name);
+                trace!("{:?} Already sent connection info to {:?}!",
+                       self,
+                       their_name);
             }
         }
         Ok(())
@@ -2300,11 +2307,12 @@ impl Core {
     }
 
     fn dropped_routing_node_connection(&mut self, peer_id: &PeerId) {
-        if let Some((name, DroppedNodeDetails{ incomplete_bucket })) =
-                self.peer_mgr.remove_peer(&peer_id) {
+        if let Some((name, DroppedNodeDetails { incomplete_bucket })) = self.peer_mgr
+            .remove_peer(peer_id) {
             info!("{:?} Dropped {:?} from the routing table.", self, &name);
 
-            let common_groups = self.peer_mgr.routing_table()
+            let common_groups = self.peer_mgr
+                .routing_table()
                 .is_in_any_close_group_with(self.name().bucket_index(&name), GROUP_SIZE);
             if common_groups {
                 // If the lost node shared some close group with us, send a NodeLost event.

--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -228,8 +228,8 @@ mod test {
     #[test]
     fn insert_resets_timeout() {
         // Check re-adding a message to a filter alters its expiry time.
-        let time_to_live = Duration::from_millis(300);
-        let sleep_duration = Duration::from_millis(180); // more than half of `time_to_live`
+        let time_to_live = Duration::from_millis(3000);
+        let sleep_duration = Duration::from_millis(1800); // more than half of `time_to_live`
         let mut msg_filter = MessageFilter::<usize>::with_expiry_duration(time_to_live);
 
         // Add "0".


### PR DESCRIPTION
The test failed again on Travis. This increases the timeouts tenfold.

Also fixes a Clippy lint and applies `rustfmt` to core.rs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1086)
<!-- Reviewable:end -->
