### PR TITLE
fix/peer_manager: avoid calling connect for proxies or clients

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -108,9 +108,6 @@ pub enum DirectMessage {
         /// Signature of the originator of this message.
         signature: sign::Signature,
     },
-    /// Sent from a client that became a full routing node. The recipient can remove it from its
-    /// client map.
-    ClientToNode,
     /// Sent from a node that found a new node in the network to all its contacts who might need to
     /// add the new node to their routing table.
     NewNode(PublicId),
@@ -390,7 +387,6 @@ impl Debug for DirectMessage {
                        current_quorum_size)
             }
             DirectMessage::BootstrapDeny => write!(formatter, "BootstrapDeny"),
-            DirectMessage::ClientToNode => write!(formatter, "ClientToNode"),
             DirectMessage::ClientIdentify { client_restriction: true, .. } => {
                 write!(formatter, "ClientIdentify (client only)")
             }


### PR DESCRIPTION
This sends `NodeIdentify` messages instead of calling
`crust::Service::connect` for proxy and client nodes. The latter would
not result in a `ConnectSuccess` and fail to put the peer into the
routing table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1087)
<!-- Reviewable:end -->
