### PR TITLE
fix/peer_manager

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -470,6 +470,7 @@ impl PeerManager {
             infos: match opt_their_info {
                 Some(their_info) => {
                     self.insert_state(pub_id, PeerState::CrustConnecting);
+                    let _ = self.pub_id_map.insert(their_info.id(), pub_id);
                     Some((our_info, their_info))
                 }
                 None => {


### PR DESCRIPTION
when migrate from ConnectionInfoPreparing to CrustConnecting, pub_id_map entry shall also be created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1097)
<!-- Reviewable:end -->
