### PR TITLE
Handle QuorumSize action in client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maidsafe/routing"
 version = "0.25.1"
 
 [dependencies]
-accumulator = "~0.4.0"
+accumulator = "~0.5.0"
 clippy = {version = "~0.0.79", optional = true}
 crust = "~0.16.1"
 itertools = "~0.4.16"

--- a/src/message_accumulator.rs
+++ b/src/message_accumulator.rs
@@ -46,7 +46,11 @@ impl MessageAccumulator {
     }
 
     pub fn set_quorum_size(&mut self, size: usize) {
-        self.accumulator.set_quorum_size(size)
+        self.accumulator.set_quorum(size)
+    }
+
+    pub fn quorum_size(&self) -> usize {
+        self.accumulator.quorum()
     }
 
     pub fn add(&mut self,

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -117,9 +117,7 @@ impl Client {
                 let _ = result_tx.send(*self.name());
             }
             Action::QuorumSize { result_tx } => {
-                // TODO: return the actual quorum size. To do that, we need to
-                // extend the MessageAccumulator's API with a method to retrieve it.
-                let _ = result_tx.send(0);
+                let _ = result_tx.send(self.msg_accumulator.quorum_size());
             }
             Action::Timeout(token) => self.handle_timeout(token),
             Action::Terminate => {


### PR DESCRIPTION
This PR implements proper handling of the QuorumSize action in the client. Since this requires a change to Accumulator (maidsafe/accumulator#65) I have temporarily updated the cargo dependency definition (it should not be merged like this).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1103)
<!-- Reviewable:end -->
