### PR TITLE
feat/peer_manager: add AwaitingNodeIdentify peer state

### DIFF
--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -217,7 +217,7 @@ pub trait SendRoutingMessage: Debug {
         };
 
         if let Err(error) = self.send_routing_message_via_route(response, route) {
-            error!("{:?} - Failed to send ack: {:?}", self, error);
+            debug!("{:?} - Failed to send ack: {:?}", self, error);
         }
     }
 }

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -214,7 +214,7 @@ impl Node {
             let status_str = format!("{:?} {:?} - Routing Table size: {:3}",
                                      self,
                                      self.crust_service.id(),
-                                     self.peer_mgr.routing_table().len());
+                                     self.stats.cur_routing_table_size);
             info!(" -{}- ",
                   iter::repeat('-').take(status_str.len()).collect::<String>());
             info!("| {} |", status_str); // Temporarily error for ci_test.
@@ -236,7 +236,7 @@ impl Node {
                     .is_ok()
             }
             Action::CloseGroup { name, result_tx } => {
-                result_tx.send(self.peer_mgr.close_group(&name)).is_ok()
+                result_tx.send(self.peer_mgr.routing_table().close_nodes(&name, GROUP_SIZE)).is_ok()
             }
             Action::Name { result_tx } => result_tx.send(*self.name()).is_ok(),
             Action::QuorumSize { result_tx } => result_tx.send(self.dynamic_quorum_size()).is_ok(),
@@ -336,11 +336,18 @@ impl Node {
                   pub_id.name());
             return;
         }
+        // TODO: Keep track of this peer, even if this returns false.
         self.peer_mgr.connected_to(peer_id);
         debug!("{:?} Received ConnectSuccess from {:?}. Sending NodeIdentify.",
                self,
                peer_id);
-        let _ = self.send_node_identify(peer_id);
+        if let Err(error) = self.send_node_identify(peer_id) {
+            warn!("{:?} Failed to send NodeIdentify to {:?}: {:?}",
+                  self,
+                  peer_id,
+                  error);
+            self.disconnect_peer(&peer_id);
+        }
     }
 
     fn handle_connect_failure(&mut self, peer_id: PeerId) {
@@ -633,24 +640,10 @@ impl Node {
                 Ok(())
             }
             DirectMessage::ConnectionUnneeded(ref name) => {
-                if !self.peer_mgr.get_proxy_public_id(&peer_id).is_some() &&
-                   !self.peer_mgr.get_client(&peer_id).is_some() {
-                    match self.peer_mgr.remove_if_unneeded(name, &peer_id) {
-                        None => {
-                            debug!("{:?} Received ConnectionUnneeded from {:?} with name {:?}, \
-                                    but that name actually belongs to someone else.",
-                                   self,
-                                   peer_id,
-                                   name);
-                            return Err(RoutingError::InvalidSource);
-                        }
-                        Some(true) => {
-                            info!("{:?} Dropped {:?} from the routing table.", self, name);
-                            self.crust_service.disconnect(peer_id);
-                            let _ = self.handle_lost_peer(peer_id);
-                        }
-                        Some(false) => {}
-                    }
+                if self.peer_mgr.remove_if_unneeded(name, &peer_id) {
+                    info!("{:?} Dropped {:?} from the routing table.", self, name);
+                    self.crust_service.disconnect(peer_id);
+                    let _ = self.handle_lost_peer(peer_id);
                 }
                 Ok(())
             }
@@ -884,6 +877,7 @@ impl Node {
                    self,
                    peer_id);
             let _ = self.crust_service.disconnect(*peer_id);
+            let _ = self.peer_mgr.remove_peer(peer_id);
         }
     }
 


### PR DESCRIPTION
This adds a new `AwaitingNodeIdentify` state to the peer manager which
comes before `Connected`. With this, a peer is in `Connected` state if
and only if it is in the routing table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1104)
<!-- Reviewable:end -->
