### PR TITLE
refactor/base: simplify the Base trait

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -78,6 +78,17 @@ pub enum Message {
     },
 }
 
+impl Message {
+    pub fn priority(&self) -> u8 {
+        match *self {
+            Message::Direct(ref content) |
+            Message::TunnelDirect { ref content, .. } => content.priority(),
+            Message::Hop(ref content) |
+            Message::TunnelHop { ref content, .. } => content.content.content.priority(),
+        }
+    }
+}
+
 /// Messages sent via a direct connection.
 ///
 /// Allows routing to directly send specific messages between nodes.

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -279,7 +279,8 @@ impl Bootstrapping {
             client_restriction: self.client_restriction,
         };
 
-        self.send_direct_message(&peer_id, direct_message)
+        self.stats().count_direct_message(&direct_message);
+        self.send_message(&peer_id, Message::Direct(direct_message))
     }
 
     fn disconnect_peer(&mut self, peer_id: &PeerId) {


### PR DESCRIPTION
Replace `send_direct_message` with `send_message` and remove
`wrap_direct_message`, to get rid of some unnecessary indirection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1114)
<!-- Reviewable:end -->
