### PR TITLE
Keep track of peers from whom we're awaiting a node identify

### DIFF
--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1339,7 +1339,7 @@ impl Node {
         while let Some(&(node_identify_token, peer_id)) = self.pending_node_identify.front() {
             if node_identify_token < token {
                 let _ = self.pending_node_identify.pop_front();
-                debug!("{:?} Unhandled pending `NodeIdentify` timeout for peer {} with timer \
+                debug!("{:?} Unhandled pending `NodeIdentify` timeout for {:?} with timer \
                         token {}.",
                        self,
                        peer_id,
@@ -1347,7 +1347,7 @@ impl Node {
             } else {
                 if node_identify_token == token {
                     let _ = self.pending_node_identify.pop_front();
-                    debug!("{:?} Timed out waiting for `NodeIdentify` from {}.",
+                    debug!("{:?} Timed out waiting for `NodeIdentify` from {:?}.",
                            self,
                            peer_id);
                     self.disconnect_peer(&peer_id);


### PR DESCRIPTION
After receiving a `ConnectSuccess` event the peer is added to a list of pending `NodeIdentify` messages, if after a given amount time this message isn't received we disconnect from the peer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/routing/1125)
<!-- Reviewable:end -->
