### PR TITLE
MAID-1638 fix/all: add missing handling of group split messages

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -317,8 +317,10 @@ impl PeerManager {
 
     /// Splits the indicated group and returns the `PeerId`s of any peers to which we should not
     /// remain connected.
-    pub fn split_group(&mut self, prefix: Prefix<XorName>) -> Vec<PeerId> {
-        let names_to_drop = self.routing_table.split(prefix);
+    pub fn split_group(&mut self,
+                       prefix: Prefix<XorName>)
+                       -> (Vec<PeerId>, Option<Prefix<XorName>>) {
+        let (names_to_drop, our_new_prefix) = self.routing_table.split(prefix);
         let mut ids_to_drop = vec![];
         for name in &names_to_drop {
             if let Some(peer) = self.peer_map.remove_by_name(name) {
@@ -328,7 +330,7 @@ impl PeerManager {
                 }
             }
         }
-        ids_to_drop
+        (ids_to_drop, our_new_prefix)
     }
 
     // Returns the `OwnMergeState` from `RoutingTable` which defines what further action needs to be

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -63,6 +63,8 @@ pub struct Stats {
     msg_get_account_info_success: usize,
     msg_get_account_info_failure: usize,
     msg_get_close_group_rsp: usize,
+    msg_routing_table: usize,
+    msg_group_split: usize,
     msg_own_group_merge: usize,
     msg_other_group_merge: usize,
     msg_get_node_name_rsp: usize,
@@ -133,6 +135,8 @@ impl Stats {
             MessageContent::GetCloseGroup(..) => self.msg_get_close_group += 1,
             MessageContent::ConnectionInfo { .. } => self.msg_connection_info += 1,
             MessageContent::GetCloseGroupResponse { .. } => self.msg_get_close_group_rsp += 1,
+            MessageContent::RoutingTable(..) => self.msg_routing_table += 1,
+            MessageContent::GroupSplit(..) => self.msg_group_split += 1,
             MessageContent::OwnGroupMerge { .. } => self.msg_own_group_merge += 1,
             MessageContent::OtherGroupMerge { .. } => self.msg_other_group_merge += 1,
             MessageContent::GetNodeNameResponse { .. } => self.msg_get_node_name_rsp += 1,
@@ -172,13 +176,15 @@ impl Stats {
                   self.msg_direct_node_identify,
                   self.msg_direct_new_node);
             info!("Stats - Hops (Request/Response) - GetNodeName: {}/{}, ExpectCloseNode: {}, \
-                   GetCloseGroup: {}/{}, OwnGroupMerge: {}, OtherGroupMerge: {}, ConnectionInfo: \
-                   {}, Ack: {}, GroupMessageHash: {}",
+                   GetCloseGroup: {}/{}, RoutingTable: {}, GroupSplit: {}, OwnGroupMerge: {}, \
+                   OtherGroupMerge: {}, ConnectionInfo: {}, Ack: {}, GroupMessageHash: {}",
                   self.msg_get_node_name,
                   self.msg_get_node_name_rsp,
                   self.msg_expect_close_node,
                   self.msg_get_close_group,
                   self.msg_get_close_group_rsp,
+                  self.msg_routing_table,
+                  self.msg_group_split,
                   self.msg_own_group_merge,
                   self.msg_other_group_merge,
                   self.msg_connection_info,


### PR DESCRIPTION
This updates the 'RoutingTable' message to be a RoutingMessage (sent from a group) rather than a
'DirectMessage'.  It also adds the sending and handling of 'GroupSplit' messages.