### PR TITLE
refactor/all: several cleanups

### DIFF
--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -62,29 +62,13 @@ use docopt::Docopt;
 
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use maidsafe_utilities::thread;
-use routing::{Data, DataIdentifier, FullId, StructuredData, XorName};
+use routing::{Data, DataIdentifier, StructuredData, XorName};
 use rust_sodium::crypto;
 use std::io;
 use std::io::Write;
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
 use utils::{ExampleClient, ExampleNode};
-
-/// Creates specific structured data
-fn create_structured_data(type_tag: u64,
-                          name: XorName,
-                          data: Vec<u8>,
-                          full_id: &FullId)
-                          -> StructuredData {
-    StructuredData::new(type_tag,
-                        name,
-                        0,
-                        data,
-                        vec![full_id.public_id().signing_public_key().clone()],
-                        vec![],
-                        Some(full_id.signing_private_key()))
-        .expect("Cannot create structured data for test")
-}
 
 // ==========================   Program Options   =================================
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -251,7 +235,7 @@ impl KeyValueStore {
     pub fn put(&self, put_where: String, put_what: String) {
         let name = KeyValueStore::calculate_key_name(&put_where);
         let data = unwrap!(serialise(&(put_where, put_what)));
-        let sd = create_structured_data(10000, name, data, self.example_client.full_id());
+        let sd = unwrap!(StructuredData::new(10000, name, 0, data, vec![], vec![], None));
         if self.example_client.put(Data::Structured(sd)).is_err() {
             error!("Failed to put data.");
         }

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -180,11 +180,6 @@ impl ExampleClient {
     pub fn name(&self) -> &XorName {
         self.full_id.public_id().name()
     }
-
-    /// Return a full id for this client
-    pub fn full_id(&self) -> &FullId {
-        &self.full_id
-    }
 }
 
 impl Default for ExampleClient {

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -25,7 +25,7 @@ use xor_name::XorName;
 ///
 /// An `Authority` can be an individual `Client` or `ManagedNode`, or a group of nodes, like a
 /// `NodeManager`, `ClientManager` or `NaeManager`.
-#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Eq, Ord, Clone, Hash)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Hash)]
 pub enum Authority {
     /// Manager of a Client.  XorName is the hash of the Client's `client_key`.
     ClientManager(XorName),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -276,7 +276,7 @@ impl RoutingMessage {
     pub fn ack_from(msg: &RoutingMessage, src: Authority) -> Result<Self, RoutingError> {
         Ok(RoutingMessage {
             src: src,
-            dst: msg.src.clone(),
+            dst: msg.src,
             content: MessageContent::Ack(try!(Ack::compute(msg)), msg.priority()),
         })
     }
@@ -298,8 +298,8 @@ impl RoutingMessage {
             _ => self.content.clone(),
         };
         Ok(RoutingMessage {
-            src: self.src.clone(),
-            dst: self.dst.clone(),
+            src: self.src,
+            dst: self.dst,
             content: content,
         })
     }

--- a/src/states/common/bootstrapped.rs
+++ b/src/states/common/bootstrapped.rs
@@ -130,7 +130,7 @@ pub trait Bootstrapped: Base {
     }
 
     fn send_ack(&mut self, routing_msg: &RoutingMessage, route: u8) {
-        self.send_ack_from(routing_msg, route, routing_msg.dst.clone());
+        self.send_ack_from(routing_msg, route, routing_msg.dst);
     }
 
     fn send_ack_from(&mut self, routing_msg: &RoutingMessage, route: u8, src: Authority) {

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -574,21 +574,12 @@ impl Node {
     fn dispatch_routing_message(&mut self,
                                 routing_msg: RoutingMessage)
                                 -> Result<(), RoutingError> {
-        let msg_content = routing_msg.content.clone();
-        let msg_src = routing_msg.src.clone();
-        let msg_dst = routing_msg.dst.clone();
-        match msg_content {
+        match routing_msg.content {
             MessageContent::Ack(..) => (),
-            _ => {
-                trace!("{:?} Got routing message {:?} from {:?} to {:?}.",
-                       self,
-                       msg_content,
-                       msg_src,
-                       msg_dst)
-            }
+            _ => trace!("{:?} Got routing message {:?}.", self, routing_msg),
         }
 
-        match (msg_content, msg_src, msg_dst) {
+        match (routing_msg.content, routing_msg.src, routing_msg.dst) {
             (MessageContent::GetNodeName { current_id, message_id },
              Authority::Client { client_key, proxy_node_name, peer_id },
              Authority::NaeManager(dst_name)) => {
@@ -637,7 +628,7 @@ impl Node {
                 self.handle_connection_info_from_node(encrypted_connection_info,
                                                       nonce_bytes,
                                                       src_name,
-                                                      routing_msg.dst.clone(),
+                                                      routing_msg.dst,
                                                       public_id)
             }
             (MessageContent::GetCloseGroupResponse { close_group_ids, .. },
@@ -659,8 +650,12 @@ impl Node {
                 }
                 Ok(())
             }
-            _ => {
-                debug!("{:?} Unhandled routing message {:?}", self, routing_msg);
+            (content, src, dst) => {
+                debug!("{:?} Unhandled routing message {:?} from {:?} to {:?}",
+                       self,
+                       content,
+                       src,
+                       dst);
                 Err(RoutingError::BadAuthority)
             }
         }
@@ -703,9 +698,9 @@ impl Node {
 
                         let priority = response.priority();
                         let src = Authority::ManagedNode(*self.name());
-                        let dst = routing_msg.src.clone();
+                        let dst = routing_msg.src;
 
-                        self.send_ack_from(routing_msg, route, src.clone());
+                        self.send_ack_from(routing_msg, route, src);
 
                         try!(self.send_user_message(src,
                                                     dst,
@@ -1175,9 +1170,8 @@ impl Node {
                    self,
                    close_node_id);
 
-            if let Err(error) = self.send_connection_info(close_node_id,
-                                      dst.clone(),
-                                      Authority::ManagedNode(*close_node_id.name())) {
+            let node_auth = Authority::ManagedNode(*close_node_id.name());
+            if let Err(error) = self.send_connection_info(close_node_id, dst, node_auth) {
                 debug!("{:?} - Failed to send connection info to {:?}: {:?}",
                        self,
                        close_node_id,
@@ -1278,7 +1272,7 @@ impl Node {
                        self,
                        close_node_id);
                 let ci_dst = Authority::ManagedNode(*close_node_id.name());
-                try!(self.send_connection_info(close_node_id, dst.clone(), ci_dst));
+                try!(self.send_connection_info(close_node_id, dst, ci_dst));
             }
         }
         Ok(())
@@ -1429,8 +1423,8 @@ impl Node {
 
         for part in try!(user_msg.to_parts(priority)) {
             try!(self.send_routing_message(RoutingMessage {
-                src: src.clone(),
-                dst: dst.clone(),
+                src: src,
+                dst: dst,
                 content: part,
             }));
         }
@@ -1744,7 +1738,7 @@ impl Node {
         };
         for target in &targets {
             let request_msg = RoutingMessage {
-                src: src.clone(),
+                src: src,
                 dst: Authority::NaeManager(target.lower_bound()),
                 content: request_content.clone(),
             };
@@ -1765,7 +1759,7 @@ impl Node {
                 group: group.clone(),
             };
             let request_msg = RoutingMessage {
-                src: src.clone(),
+                src: src,
                 dst: Authority::NaeManager(target.lower_bound()),
                 content: request_content,
             };


### PR DESCRIPTION
Make `Authority` `Copy`.
Make the `ExampleNode` store by `DataIdentifier`, not name.