### PR TITLE
MAID-1638: refactor/examples: fix examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ cache:
     - $HOME/elfutils
 script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/build_and_run_tests.sh | bash
-  - cd $TRAVIS_BUILD_DIR && cargo build --example ci_test
-  - cd $TRAVIS_BUILD_DIR && cargo build --example key_value_store
-#  - cd $TRAVIS_BUILD_DIR && cargo run --release --example ci_test > output.log
-#  - cat output.log
+  - cd $TRAVIS_BUILD_DIR && cargo build --release --example key_value_store
+  - cd $TRAVIS_BUILD_DIR && cargo build --release --example ci_test
+  # - cd $TRAVIS_BUILD_DIR && cargo run --release --example ci_test > output.log
+  # - cat output.log
 before_cache:
   - curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/install_elfutils.sh
   - . install_elfutils.sh

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -200,6 +200,7 @@ fn recv_with_timeout<T>(rx: &Receiver<T>, timeout: Duration) -> Option<T> {
         }
 
         if Instant::now() - start > timeout {
+            warn!("Timed out.");
             return None;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,7 @@ mod types;
 mod utils;
 mod xor_name;
 
-#[cfg(test)]
-#[cfg(feature = "use-mock-crust")]
+#[cfg(all(test, feature = "use-mock-crust"))]
 #[allow(unused)]
 mod core_tests;
 


### PR DESCRIPTION
This allows the ci_test example to pass again, but with a reduced network size of 10 nodes.  It also
fixes a long-standing bug in the key_value_store example.