### PR TITLE
MAID-1664: fix/node: pass Prefixes as well as PublicIds to joining nodes

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -347,8 +347,8 @@ pub enum MessageContent {
     GetNodeNameResponse {
         /// Supplied `PublicId`, but with the new name
         relocated_id: PublicId,
-        /// Our close group `PublicId`s.
-        close_group_ids: Vec<PublicId>,
+        /// The routing table structure of our group, including the `PublicId`s of our contacts.
+        groups: Vec<(Prefix<XorName>, Vec<PublicId>)>,
         /// The message's unique identifier.
         message_id: MessageId,
     },
@@ -361,8 +361,6 @@ pub enum MessageContent {
         /// The message ID.
         message_id: MessageId,
     },
-    /// Sent to a joining node to allow it to establish connections to the included contacts.
-    RoutingTable(Vec<PublicId>),
     /// Sent to all connected peers when our own group splits
     GroupSplit(Prefix<XorName>),
     /// Sent amongst members of a newly-merged group to allow synchronisation of their routing
@@ -485,12 +483,12 @@ impl Debug for MessageContent {
             MessageContent::GetCloseGroup(id) => write!(formatter, "GetCloseGroup({:?})", id),
             MessageContent::ConnectionInfo { .. } => write!(formatter, "ConnectionInfo {{ .. }}"),
             MessageContent::GetNodeNameResponse { ref relocated_id,
-                                                  ref close_group_ids,
+                                                  ref groups,
                                                   ref message_id } => {
                 write!(formatter,
                        "GetNodeNameResponse {{ {:?}, {:?}, {:?} }}",
-                       close_group_ids,
                        relocated_id,
+                       groups,
                        message_id)
             }
             MessageContent::GetCloseGroupResponse { ref close_group_ids, message_id } => {
@@ -498,9 +496,6 @@ impl Debug for MessageContent {
                        "GetCloseGroupResponse {{ {:?}, {:?} }}",
                        close_group_ids,
                        message_id)
-            }
-            MessageContent::RoutingTable(ref public_ids) => {
-                write!(formatter, "RoutingTable({:?})", public_ids)
             }
             MessageContent::GroupSplit(ref prefix) => write!(formatter, "GroupSplit({:?})", prefix),
             MessageContent::OwnGroupMerge { ref sender_prefix, ref merge_prefix, ref groups } => {

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -286,11 +286,12 @@ impl PeerManager {
                 (*prefix, members.into_iter().map(|pub_id| *pub_id.name()).collect_vec())
             })
             .collect_vec();
-        // Nothing can be done to recover from an error here - use unwrap.
+        // TODO - nothing can be done to recover from an error here - use `unwrap!` for now, but
+        // consider refactoring to return an error which can be used to transition the state
+        // machine to `Terminate`.
         let new_rt = unwrap!(RoutingTable::new_with_groups(*our_public_id.name(),
                                                            MIN_GROUP_SIZE,
                                                            groups_as_names));
-        // RoutingTable::new_with_groups(*our_public_id.name(), MIN_GROUP_SIZE, groups);
         let old_rt = mem::replace(&mut self.routing_table, new_rt);
         for name in old_rt.iter() {
             let _ = self.peer_map.remove_by_name(name);

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -62,7 +62,11 @@ impl Network {
         let mut new_table = {
             let close_node = self.close_node(name);
             let close_peer = &self.nodes[&close_node];
-            unwrap!(RoutingTable::new_with_prefixes(name, MIN_GROUP_SIZE, close_peer.prefixes()))
+            unwrap!(RoutingTable::new_with_groups(name,
+                                                  MIN_GROUP_SIZE,
+                                                  close_peer.prefixes()
+                                                      .into_iter()
+                                                      .map(|prefix| (prefix, None))))
         };
 
         let mut split_prefixes = BTreeSet::new();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -63,7 +63,6 @@ pub struct Stats {
     msg_get_account_info_success: usize,
     msg_get_account_info_failure: usize,
     msg_get_close_group_rsp: usize,
-    msg_routing_table: usize,
     msg_group_split: usize,
     msg_own_group_merge: usize,
     msg_other_group_merge: usize,
@@ -135,7 +134,6 @@ impl Stats {
             MessageContent::GetCloseGroup(..) => self.msg_get_close_group += 1,
             MessageContent::ConnectionInfo { .. } => self.msg_connection_info += 1,
             MessageContent::GetCloseGroupResponse { .. } => self.msg_get_close_group_rsp += 1,
-            MessageContent::RoutingTable(..) => self.msg_routing_table += 1,
             MessageContent::GroupSplit(..) => self.msg_group_split += 1,
             MessageContent::OwnGroupMerge { .. } => self.msg_own_group_merge += 1,
             MessageContent::OtherGroupMerge { .. } => self.msg_other_group_merge += 1,
@@ -176,14 +174,13 @@ impl Stats {
                   self.msg_direct_node_identify,
                   self.msg_direct_new_node);
             info!("Stats - Hops (Request/Response) - GetNodeName: {}/{}, ExpectCloseNode: {}, \
-                   GetCloseGroup: {}/{}, RoutingTable: {}, GroupSplit: {}, OwnGroupMerge: {}, \
-                   OtherGroupMerge: {}, ConnectionInfo: {}, Ack: {}, GroupMessageHash: {}",
+                   GetCloseGroup: {}/{}, GroupSplit: {}, OwnGroupMerge: {}, OtherGroupMerge: {}, \
+                   ConnectionInfo: {}, Ack: {}, GroupMessageHash: {}",
                   self.msg_get_node_name,
                   self.msg_get_node_name_rsp,
                   self.msg_expect_close_node,
                   self.msg_get_close_group,
                   self.msg_get_close_group_rsp,
-                  self.msg_routing_table,
                   self.msg_group_split,
                   self.msg_own_group_merge,
                   self.msg_other_group_merge,


### PR DESCRIPTION
This removes the 'RoutingTable' message type, replacing it by changing the 'GetNodeNameResponse' to
contain the contents of the RT.