### PR TITLE
MAID-1651 test/performance: decrease group and quorum size when using mock crust

### DIFF
--- a/src/core_tests.rs
+++ b/src/core_tests.rs
@@ -599,7 +599,10 @@ fn client_connects_to_nodes() {
 fn messages_accumulate_with_quorum() {
     let network = Network::new(None);
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, 15);
+    // Note: this was hard-coded to 15 when group-size was 8.
+    // I assume it was meant to be size*2 - 1.
+    let num_nodes = MIN_GROUP_SIZE * 2 - 1;
+    let mut nodes = create_connected_nodes(&network, num_nodes);
 
     let data = gen_immutable_data(&mut rng, 8);
     let src = Authority::NaeManager(*data.name()); // The data's NaeManager.

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -31,9 +31,19 @@ use std::time::{Duration, Instant};
 use xor_name::XorName;
 
 /// The minimum group size for the routing table.
+#[cfg(not(feature="use-mock-crust"))]
 pub const MIN_GROUP_SIZE: usize = 8;
+/// The minimum group size for the routing table (reduced for mock crust)
+#[cfg(feature="use-mock-crust")]
+pub const MIN_GROUP_SIZE: usize = 5;
+
 /// The quorum for group consensus.
+#[cfg(not(feature="use-mock-crust"))]
 pub const QUORUM_SIZE: usize = 5;
+/// The quorum for group consensus (reduced for mock crust).
+#[cfg(feature="use-mock-crust")]
+pub const QUORUM_SIZE: usize = 3;
+
 /// Time (in seconds) after which a joining node will get dropped from the map of joining nodes.
 const JOINING_NODE_TIMEOUT_SECS: u64 = 300;
 /// Time (in seconds) after which the connection to a peer is considered failed.


### PR DESCRIPTION
messages_accumulate_with_quorum: reduce number of nodes and make dependent on group size.