### PR TITLE
refactor/log,core_tests: adjust logging, impl Debug for Node and Stat…

### DIFF
--- a/src/core_tests.rs
+++ b/src/core_tests.rs
@@ -559,7 +559,7 @@ fn less_than_group_size_nodes() {
 }
 
 #[test]
-fn group_size_nodes() {
+fn equal_group_size_nodes() {
     test_nodes(MIN_GROUP_SIZE);
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -154,7 +154,7 @@ pub struct HopMessage {
     route: u8,
     /// Every node this has already been sent to.
     sent_to: Vec<XorName>,
-    /// Signature to be validated against `name`'s public key.
+    /// Signature to be validated against the neighbouring sender's public key.
     signature: sign::Signature,
 }
 
@@ -970,20 +970,14 @@ mod tests {
         let hop_message_result =
             HopMessage::new(signed_message.clone(), 0, vec![], &secret_signing_key);
 
-        assert!(hop_message_result.is_ok());
-
         let hop_message = unwrap!(hop_message_result);
 
         assert_eq!(signed_message, *hop_message.content());
 
-        let verify_result = hop_message.verify(&public_signing_key);
-
-        assert!(verify_result.is_ok());
+        assert!(hop_message.verify(&public_signing_key).is_ok());
 
         let (public_signing_key, _) = sign::gen_keypair();
-        let verify_result = hop_message.verify(&public_signing_key);
-
-        assert!(verify_result.is_err());
+        assert!(hop_message.verify(&public_signing_key).is_err());
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -36,6 +36,8 @@ use states;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::sync::mpsc::{Receiver, Sender, channel};
+#[cfg(feature = "use-mock-crust")]
+use std::fmt::{self, Debug, Formatter};
 use types::{MessageId, RoutingActionSender};
 use xor_name::XorName;
 
@@ -479,6 +481,13 @@ impl Node {
     fn receive_action_result<T>(&self, rx: &Receiver<T>) -> Result<T, InterfaceError> {
         while self.poll() {}
         Ok(try!(rx.recv()))
+    }
+}
+
+#[cfg(feature = "use-mock-crust")]
+impl Debug for Node {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        self.machine.borrow().fmt(formatter)
     }
 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -25,6 +25,7 @@ use routing_table::RoutingTable;
 use states::{Bootstrapping, Client, Node};
 use std::mem;
 use std::sync::mpsc::{self, Receiver};
+use std::fmt::{self, Debug, Formatter};
 use timer::Timer;
 use types::RoutingActionSender;
 #[cfg(feature = "use-mock-crust")]
@@ -123,6 +124,17 @@ impl State {
                 }
             }
             _ => unreachable!(),
+        }
+    }
+}
+
+impl Debug for State {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match *self {
+            State::Bootstrapping(ref inner) => write!(formatter, "State::{:?}", inner),
+            State::Client(ref inner) => write!(formatter, "State::{:?}", inner),
+            State::Node(ref inner) => write!(formatter, "State::{:?}", inner),
+            State::Terminated => write!(formatter, "State::Terminated"),
         }
     }
 }
@@ -239,21 +251,23 @@ impl StateMachine {
         match transition {
             Transition::Stay => (),
             Transition::IntoBootstrapped { proxy_peer_id, proxy_public_id } => {
-                self.transition_to_bootstrapped(proxy_peer_id, proxy_public_id)
+                // Temporarily switch to `Terminated` to allow moving out of the current
+                // state without moving `self`.
+                let prev_state = mem::replace(&mut self.state, State::Terminated);
+                self.state = prev_state.into_bootstrapped(proxy_peer_id, proxy_public_id);
             }
             Transition::Terminate => self.terminate(),
         }
     }
 
-    fn transition_to_bootstrapped(&mut self, proxy_peer_id: PeerId, proxy_public_id: PublicId) {
-        // Temporarily switch to `Terminated` to allow moving out of the current
-        // state without moving `self`.
-        let prev_state = mem::replace(&mut self.state, State::Terminated);
-        self.state = prev_state.into_bootstrapped(proxy_peer_id, proxy_public_id);
-    }
-
     fn terminate(&mut self) {
         self.is_running = false;
+    }
+}
+
+impl Debug for StateMachine {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        self.state.fmt(formatter)
     }
 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -176,6 +176,7 @@ impl State {
     }
 }
 
+/// Enum returned from many message handlers
 pub enum Transition {
     // Stay in the current state.
     Stay,

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -36,6 +36,9 @@ use std::time::Duration;
 use super::common::{Base, Bootstrapped, USER_MSG_CACHE_EXPIRY_DURATION_SECS};
 use timer::Timer;
 
+/// A node connecting a user to the network, as opposed to a routing / data storage node.
+/// 
+/// Each client has a _proxy_: a node through which all requests are routed.
 pub struct Client {
     ack_mgr: AckManager,
     crust_service: Service,
@@ -238,6 +241,7 @@ impl Client {
         Ok(())
     }
 
+    /// Does the given authority represent us?
     fn in_authority(&self, auth: &Authority) -> bool {
         if let Authority::Client { ref client_key, .. } = *auth {
             client_key == self.full_id.public_id().signing_public_key()

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -26,6 +26,7 @@ use error::{InterfaceError, RoutingError};
 use event::Event;
 use id::{FullId, PublicId};
 use itertools::Itertools;
+use log::LogLevel;
 use maidsafe_utilities::serialisation;
 use messages::{DEFAULT_PRIORITY, DirectMessage, HopMessage, Message, MessageContent,
                RoutingMessage, SignedMessage, UserMessage, UserMessageCache};
@@ -194,15 +195,17 @@ impl Node {
         if self.stats.cur_routing_table_size != self.peer_mgr.routing_table().len() {
             self.stats.cur_routing_table_size = self.peer_mgr.routing_table().len();
 
-            let status_str = format!("{:?} {:?} - Routing Table size: {:3}",
-                                     self,
-                                     self.crust_service.id(),
-                                     self.stats.cur_routing_table_size);
-            info!(" -{}- ",
-                  iter::repeat('-').take(status_str.len()).collect::<String>());
-            info!("| {} |", status_str); // Temporarily error for ci_test.
-            info!(" -{}- ",
-                  iter::repeat('-').take(status_str.len()).collect::<String>());
+            const TABLE_LVL: LogLevel = LogLevel::Info;
+            if log_enabled!(TABLE_LVL) {
+                let status_str = format!("{:?} {:?} - Routing Table size: {:3}",
+                                         self,
+                                         self.crust_service.id(),
+                                         self.stats.cur_routing_table_size);
+                let sep_str = iter::repeat('-').take(status_str.len()).collect::<String>();
+                log!(TABLE_LVL, " -{}- ", sep_str);
+                log!(TABLE_LVL, "| {} |", status_str);
+                log!(TABLE_LVL, " -{}- ", sep_str);
+            }
         }
     }
 
@@ -705,7 +708,6 @@ impl Node {
             error!("{:?} Failed to start listening: {:?}", self, error);
             false
         } else {
-            info!("{:?} Attempting to start listener.", self);
             true
         }
     }


### PR DESCRIPTION
…eMachine

Test rename is to allow selection via `cargo test ... PATTERN`, which before this would always match at least two other tests.