### PR TITLE
fix/routing_table: update group merge prefixes to remain consistently sorted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ cache:
   directories:
     - $HOME/elfutils
 script:
-  - curl -sSL https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/build_and_run_tests.sh | bash
+  - curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/build_and_run_tests.sh
+  - travis_wait 40 . build_and_run_tests.sh
   - cd $TRAVIS_BUILD_DIR && cargo build --release --example key_value_store
   - cd $TRAVIS_BUILD_DIR && cargo build --release --example ci_test
   # - cd $TRAVIS_BUILD_DIR && cargo run --release --example ci_test > output.log

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -120,7 +120,7 @@ pub use self::error::Error;
 pub use self::prefix::Prefix;
 pub use self::xorable::Xorable;
 use std::{iter, mem};
-use std::collections::{HashMap, HashSet, hash_map, hash_set};
+use std::collections::{BTreeSet, HashMap, HashSet, hash_map, hash_set};
 use std::fmt::{Binary, Debug, Formatter};
 use std::fmt::Result as FmtResult;
 use std::hash::Hash;
@@ -227,7 +227,7 @@ pub struct RemovalDetails<T: Binary + Clone + Copy + Default + Hash + Xorable> {
     // If, after removal, our group needs to merge, this is set to `Some`. It contains the
     // appropriate targets (all members of the merging groups) and the merge details they each need
     // to receive (the new prefix and all groups in the table).
-    pub targets_and_merge_details: Option<(Vec<Prefix<T>>, OwnMergeDetails<T>)>,
+    pub targets_and_merge_details: Option<(BTreeSet<Prefix<T>>, OwnMergeDetails<T>)>,
 }
 
 
@@ -238,7 +238,7 @@ pub enum OwnMergeState<T: Binary + Clone + Copy + Default + Hash + Xorable> {
     // returned, containing the appropriate targets (all the merging groups' `Prefix`es) and the
     // merge details they each need to receive (the new prefix and all groups in the table).
     Initialised {
-        targets: Vec<Prefix<T>>,
+        targets: BTreeSet<Prefix<T>>,
         merge_details: OwnMergeDetails<T>,
     },
     // If an ongoing merge is happening, and this call to `merge_own_group()` doesn't complete the
@@ -250,7 +250,7 @@ pub enum OwnMergeState<T: Binary + Clone + Copy + Default + Hash + Xorable> {
     // containing the appropriate targets (the `Prefix`es of all groups outwith the merging ones)
     // and the merge details they each need to receive (the new prefix and merged group).
     Completed {
-        targets: Vec<Prefix<T>>,
+        targets: BTreeSet<Prefix<T>>,
         merge_details: OtherMergeDetails<T>,
     },
     // The merge has already completed, implying that no further action by the caller is required.
@@ -830,7 +830,7 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
 
     // Returns prefixes of all groups we're connected to (i.e. non-empty groups from `self.groups`)
     // which are merging into a new group defined by `merge_prefix`.
-    fn prefixes_within_merge(&self, merge_prefix: &Prefix<T>) -> Vec<Prefix<T>> {
+    fn prefixes_within_merge(&self, merge_prefix: &Prefix<T>) -> BTreeSet<Prefix<T>> {
         self.groups
             .iter()
             .filter(|&(prefix, names)| merge_prefix.is_compatible(prefix) && !names.is_empty())

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -30,8 +30,8 @@ use routing_table::xorable::Xorable;
 
 const MIN_GROUP_SIZE: usize = 8;
 
-type OwnMergeInfo = (Vec<Prefix<u64>>, OwnMergeDetails<u64>);
-type OtherMergeInfo = (Vec<Prefix<u64>>, OtherMergeDetails<u64>);
+type OwnMergeInfo = (BTreeSet<Prefix<u64>>, OwnMergeDetails<u64>);
+type OtherMergeInfo = (BTreeSet<Prefix<u64>>, OtherMergeDetails<u64>);
 
 /// A simulated network, consisting of a set of "nodes" (routing tables) and a random number
 /// generator.
@@ -144,16 +144,14 @@ impl Network {
                 for target in targets {
                     let target_node = unwrap!(self.nodes.get_mut(&target));
                     match target_node.merge_own_group(merge_own_details.clone()) {
-                        OwnMergeState::Initialised { mut targets, merge_details } => {
-                            targets.sort();
+                        OwnMergeState::Initialised { targets, merge_details } => {
                             Network::store_merge_info(&mut merge_own_info,
                                                       *target_node.our_group_prefix(),
                                                       (targets, merge_details));
                         }
                         OwnMergeState::Ongoing |
                         OwnMergeState::AlreadyMerged => (),
-                        OwnMergeState::Completed { mut targets, merge_details } => {
-                            targets.sort();
+                        OwnMergeState::Completed { targets, merge_details } => {
                             Network::store_merge_info(&mut merge_other_info,
                                                       *target_node.our_group_prefix(),
                                                       (targets, merge_details));
@@ -182,7 +180,7 @@ impl Network {
         }
     }
 
-    fn nodes_covered_by_prefixes(&self, prefixes: &[Prefix<u64>]) -> Vec<u64> {
+    fn nodes_covered_by_prefixes(&self, prefixes: &BTreeSet<Prefix<u64>>) -> Vec<u64> {
         self.nodes
             .keys()
             .filter(|&name| prefixes.iter().any(|prefix| prefix.matches(name)))

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -42,7 +42,7 @@ use routing_message_filter::RoutingMessageFilter;
 use state_machine::Transition;
 use stats::Stats;
 use std::{fmt, iter};
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::fmt::{Debug, Formatter};
 use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant};
@@ -1694,7 +1694,7 @@ impl Node {
     }
 
     fn send_own_group_merge(&mut self,
-                            targets: Vec<Prefix<XorName>>,
+                            targets: BTreeSet<Prefix<XorName>>,
                             merge_details: OwnMergeDetails<XorName>,
                             src: Authority) {
         let mut groups = merge_details.groups
@@ -1724,7 +1724,7 @@ impl Node {
     }
 
     fn send_other_group_merge(&mut self,
-                              targets: Vec<Prefix<XorName>>,
+                              targets: BTreeSet<Prefix<XorName>>,
                               merge_details: OtherMergeDetails<XorName>,
                               src: Authority) {
         let group = self.peer_mgr.get_pub_ids(&merge_details.group).into_iter().collect_vec();


### PR DESCRIPTION
This resolves an issue where some lists of prefixes related to merging groups were not sorted,
causing the merge test to fail sporadically.