### PR TITLE
MAID-1706 fix/core_tests: don't fail on early GroupSplit events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/elfutils
 script:
   - curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/build_and_run_tests.sh
-  - travis_wait 40 . build_and_run_tests.sh
+  - travis_wait 60 . build_and_run_tests.sh
   - cd $TRAVIS_BUILD_DIR && cargo build --release --example key_value_store
   - cd $TRAVIS_BUILD_DIR && cargo build --release --example ci_test
   # - cd $TRAVIS_BUILD_DIR && cargo run --release --example ci_test > output.log

--- a/src/core_tests.rs
+++ b/src/core_tests.rs
@@ -313,18 +313,18 @@ fn create_connected_nodes_with_cache(network: &Network,
     for node in &nodes {
         expect_next_event!(node, Event::Connected);
 
-        for _ in 0..n {
-            expect_next_event!(node, Event::NodeAdded(..))
-        }
+        let mut node_added_count = 0;
 
         while let Ok(event) = node.event_rx.try_recv() {
             match event {
-                Event::NodeAdded(..) |
+                Event::NodeAdded(..) => node_added_count += 1,
                 Event::GroupSplit(..) |
                 Event::Tick => (),
                 event => panic!("Got unexpected event: {:?}", event),
             }
         }
+
+        assert!(node_added_count >= n, "Got only {} NodeAdded events.");
     }
 
     nodes
@@ -566,7 +566,7 @@ fn equal_group_size_nodes() {
 
 #[test]
 fn more_than_group_size_nodes() {
-    test_nodes(MIN_GROUP_SIZE * 2);
+    test_nodes(MIN_GROUP_SIZE * 6);
 }
 
 #[test]


### PR DESCRIPTION
The joining node can legitimately receive a `GroupSplit` message as soon as it has connected to a quorum of its new group.