### PR TITLE
MAID-1734: fix/node: add missing pending acks

### DIFF
--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -18,8 +18,8 @@
 use rand::Rng;
 use routing::{Authority, Data, DataIdentifier, Event, MIN_GROUP_SIZE, MessageId, Request, Response};
 use routing::mock_crust::{Config, Network};
-use super::{TestClient, TestNode, create_connected_nodes, gen_immutable_data, gen_range_except,
-            gen_two_range_except, poll_all, sort_nodes_by_distance_to,
+use super::{TestNode, create_connected_nodes, gen_immutable_data, gen_range_except,
+            gen_two_range_except, poll_and_resend, sort_nodes_by_distance_to,
             verify_invariant_for_all_nodes};
 
 // Randomly add or remove some nodes, causing churn.
@@ -86,21 +86,6 @@ fn did_receive_get_success(node: &TestNode,
                                  ref dst }) if expected(src, dst, data, message_id) => return true,
             Ok(_) => (),
             Err(_) => return false,
-        }
-    }
-}
-
-fn poll_and_resend(nodes: &mut [TestNode], clients: &mut [TestClient]) {
-    loop {
-        let mut state_changed = poll_all(nodes, clients);
-        for node in nodes.iter_mut() {
-            state_changed = state_changed || node.inner.resend_unacknowledged();
-        }
-        for client in clients.iter_mut() {
-            state_changed = state_changed || client.inner.resend_unacknowledged();
-        }
-        if !state_changed {
-            return;
         }
     }
 }

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -24,8 +24,8 @@ mod utils;
 
 pub use self::utils::{TestClient, TestNode, create_connected_clients, create_connected_nodes,
                       create_connected_nodes_with_cache_till_split, gen_bytes, gen_immutable_data,
-                      gen_range_except, gen_two_range_except, poll_all, sort_nodes_by_distance_to,
-                      verify_invariant_for_all_nodes};
+                      gen_range_except, gen_two_range_except, poll_all, poll_and_resend,
+                      sort_nodes_by_distance_to, verify_invariant_for_all_nodes};
 
 use routing::{Event, MIN_GROUP_SIZE};
 use routing::mock_crust::{Config, Endpoint, Network};

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -268,6 +268,21 @@ pub fn poll_all(nodes: &mut [TestNode], clients: &mut [TestClient]) -> bool {
     }
 }
 
+pub fn poll_and_resend(nodes: &mut [TestNode], clients: &mut [TestClient]) {
+    loop {
+        let mut state_changed = poll_all(nodes, clients);
+        for node in nodes.iter_mut() {
+            state_changed = state_changed || node.inner.resend_unacknowledged();
+        }
+        for client in clients.iter_mut() {
+            state_changed = state_changed || client.inner.resend_unacknowledged();
+        }
+        if !state_changed {
+            return;
+        }
+    }
+}
+
 pub fn create_connected_nodes(network: &Network, size: usize) -> Vec<TestNode> {
     create_connected_nodes_with_cache(network, size, false)
 }
@@ -335,7 +350,7 @@ pub fn create_connected_nodes_with_cache_till_split(network: &Network) -> Vec<Te
             .endpoint(Endpoint(len))
             .cache(use_cache)
             .create());
-        let _ = poll_all(&mut nodes, &mut []);
+        poll_and_resend(&mut nodes, &mut []);
         while let Ok(event) = nodes[len].event_rx.try_recv() {
             match event {
                 Event::NodeAdded(..) |


### PR DESCRIPTION
This adds to pending acks beofre sending a signature or accumulating a message at hop 0.  It also
fixes a hanging mock-crust test which curently depends on acks timing out.