### PR TITLE
MAID-1729: fix/mock-crust: fix bug in teardown of mock-crust network

### DIFF
--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -118,7 +118,7 @@ impl Network {
             .push_back(packet);
     }
 
-    // Drop any pending messages on a specific route (does not automatically
+    // Drops any pending messages on a specific route (does not automatically
     // drop packets going the other way).
     fn drop_pending(&self, sender: Endpoint, receiver: Endpoint) {
         if let Some(deque) = self.0
@@ -127,6 +127,11 @@ impl Network {
             .get_mut(&(sender, receiver)) {
             deque.clear();
         }
+    }
+
+    // Drops all pending messages across the entire network.
+    fn drop_all_pending(&self) {
+        self.0.borrow_mut().queue.clear();
     }
 
     fn pop_packet(&self) -> Option<(Endpoint, Endpoint, Packet)> {
@@ -470,6 +475,7 @@ impl ServiceImpl {
     }
 
     pub fn disconnect_all(&mut self) {
+        self.network.drop_all_pending();
         let endpoints = self.connections
             .drain(..)
             .map(|(_, ep)| ep)

--- a/tests/mock_crust/requests.rs
+++ b/tests/mock_crust/requests.rs
@@ -196,7 +196,6 @@ fn failed_get_request() {
 }
 
 #[test]
-#[ignore]
 fn disconnect_on_get_request() {
     let network = Network::new(None);
     let mut rng = network.new_rng();


### PR DESCRIPTION
Also re-enabled test which was particularly affected by this bug.