### PR TITLE
New Request/Response types & single entry mutation function

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -28,7 +28,7 @@ pub use self::pub_appendable_data::{MAX_PUB_APPENDABLE_DATA_SIZE_IN_BYTES, PubAp
 pub use self::priv_appendable_data::{MAX_PRIV_APPENDABLE_DATA_SIZE_IN_BYTES, PrivAppendableData,
                                      PrivAppendedData};
 pub use self::structured_data::{MAX_STRUCTURED_DATA_SIZE_IN_BYTES, StructuredData};
-pub use self::mutable_data::{MutableData, PermissionSet, User, Value};
+pub use self::mutable_data::{EntryAction, MutableData, PermissionSet, User, Value};
 
 use error::RoutingError;
 use rust_sodium::crypto::sign::{self, PublicKey, Signature};

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -28,7 +28,7 @@ pub use self::pub_appendable_data::{MAX_PUB_APPENDABLE_DATA_SIZE_IN_BYTES, PubAp
 pub use self::priv_appendable_data::{MAX_PRIV_APPENDABLE_DATA_SIZE_IN_BYTES, PrivAppendableData,
                                      PrivAppendedData};
 pub use self::structured_data::{MAX_STRUCTURED_DATA_SIZE_IN_BYTES, StructuredData};
-pub use self::mutable_data::MutableData;
+pub use self::mutable_data::{MutableData, PermissionSet, User, Value};
 
 use error::RoutingError;
 use rust_sodium::crypto::sign::{self, PublicKey, Signature};

--- a/src/data/mutable_data.rs
+++ b/src/data/mutable_data.rs
@@ -18,13 +18,14 @@
 use error::RoutingError;
 use maidsafe_utilities::serialisation::serialised_size;
 use rust_sodium::crypto::sign::PublicKey;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
+use std::collections::btree_map::{BTreeMap, Entry};
 use std::fmt::{self, Debug, Formatter};
 use super::DataIdentifier;
 use xor_name::XorName;
 
 /// Maximum allowed size for MutableData (1 MiB)
-pub const MAX_MUTABLE_DATA_SIZE_IN_BYTES: u64 = 1_048_576;
+pub const MAX_MUTABLE_DATA_SIZE_IN_BYTES: u64 = 1024 * 1024;
 
 /// Maximum allowed entries in MutableData
 pub const MAX_MUTABLE_DATA_ENTRIES: u64 = 100;
@@ -98,6 +99,16 @@ impl PermissionSet {
     }
 }
 
+#[derive(Hash, Eq, PartialEq, Clone, PartialOrd, Ord)]
+pub enum EntryAction {
+    /// Inserts a new entry
+    Ins(Value),
+    /// Updates an entry with a new value and version
+    Update(Value),
+    /// Deletes an entry by emptying its contents. Contains the version number
+    Del(u64),
+}
+
 impl MutableData {
     /// Creates a new MutableData
     pub fn new(name: XorName,
@@ -169,59 +180,117 @@ impl MutableData {
         &self.data
     }
 
-    /// Inserts a new entry (key + value pair)
-    pub fn ins_entry(&mut self,
-                     key: Vec<u8>,
-                     value: Value,
-                     requester: PublicKey)
-                     -> Result<(), RoutingError> {
-        if !self.is_action_allowed(requester, Action::Insert) {
+    fn rollback(&mut self,
+                inserted: BTreeSet<Vec<u8>>,
+                updated: BTreeMap<Vec<u8>, Value>,
+                deleted: BTreeMap<Vec<u8>, Value>) {
+        for (key, val) in deleted {
+            let _ = self.data.insert(key, val);
+        }
+        for (key, val) in updated {
+            let _ = self.data.insert(key, val);
+        }
+        for key in inserted {
+            let _ = self.data.remove(&key);
+        }
+    }
+
+    /// Mutates entries (key + value pairs) in bulk
+    pub fn mutate_entries(&mut self,
+                          actions: BTreeMap<Vec<u8>, EntryAction>,
+                          requester: PublicKey)
+                          -> Result<(), RoutingError> {
+        // Deconstruct actions into inserts, updates, and deletes
+        let (insert, update, delete) = actions.into_iter()
+            .fold((BTreeMap::new(), BTreeMap::new(), BTreeMap::new()),
+                  |(mut insert, mut update, mut delete), (key, item)| {
+                match item {
+                    EntryAction::Ins(value) => {
+                        let _ = insert.insert(key, value);
+                    }
+                    EntryAction::Update(value) => {
+                        let _ = update.insert(key, value);
+                    }
+                    EntryAction::Del(version) => {
+                        let _ = delete.insert(key, version);
+                    }
+                };
+                (insert, update, delete)
+            });
+
+        if (insert.len() > 0 && !self.is_action_allowed(requester, Action::Insert)) ||
+           (update.len() > 0 && !self.is_action_allowed(requester, Action::Update)) ||
+           (delete.len() > 0 && !self.is_action_allowed(requester, Action::Delete)) {
             return Err(RoutingError::AccessDenied);
         }
-        if self.data.contains_key(&key) {
-            return Err(RoutingError::EntryAlreadyExist);
-        }
-        if self.data.len() > MAX_MUTABLE_DATA_ENTRIES as usize {
+        if (insert.len() > 0 || update.len() > 0) &&
+           self.data.len() > MAX_MUTABLE_DATA_ENTRIES as usize {
             return Err(RoutingError::TooManyEntries);
         }
-        let _ = self.data.insert(key.clone(), value);
+
+        let mut inserted: BTreeSet<Vec<u8>> = BTreeSet::new();
+        let mut updated: BTreeMap<Vec<u8>, Value> = BTreeMap::new();
+        let mut deleted: BTreeMap<Vec<u8>, Value> = BTreeMap::new();
+
+        for (key, val) in insert {
+            if self.data.contains_key(&key) {
+                self.rollback(inserted, updated, deleted);
+                return Err(RoutingError::EntryAlreadyExist);
+            }
+            let _ = self.data.insert(key.clone(), val);
+            inserted.insert(key);
+        }
+
+        for (key, val) in update {
+            if !self.data.contains_key(&key) {
+                self.rollback(inserted, updated, deleted);
+                return Err(RoutingError::EntryNotFound);
+            }
+            let version_valid = if let Entry::Occupied(mut oe) = self.data.entry(key.clone()) {
+                if val.entry_version != oe.get().entry_version + 1 {
+                    false
+                } else {
+                    let prev = oe.insert(val);
+                    let _ = updated.insert(key, prev);
+                    true
+                }
+            } else {
+                false
+            };
+            if !version_valid {
+                self.rollback(inserted, updated, deleted);
+                return Err(RoutingError::InvalidSuccessor);
+            }
+        }
+
+        for (key, version) in delete {
+            if !self.data.contains_key(&key) {
+                self.rollback(inserted, updated, deleted);
+                return Err(RoutingError::EntryNotFound);
+            }
+            let version_valid = if let Entry::Occupied(oe) = self.data.entry(key.clone()) {
+                // let prev = oe.insert(Value { content: vec![], entry_version: version });
+                if version != oe.get().entry_version + 1 {
+                    false
+                } else {
+                    let (key, prev) = oe.remove_entry();
+                    let _ = deleted.insert(key, prev);
+                    true
+                }
+            } else {
+                false
+            };
+            if !version_valid {
+                self.rollback(inserted, updated, deleted);
+                return Err(RoutingError::InvalidSuccessor);
+            }
+        }
+
         if !self.validate_mut_size() {
-            let _ = self.data.remove(&key);
+            self.rollback(inserted, updated, deleted);
             return Err(RoutingError::ExceededSizeLimit);
         }
-        Ok(())
-    }
 
-    /// Updates an existing entry (key + value pair)
-    pub fn update_entry(&mut self,
-                        key: Vec<u8>,
-                        value: Value,
-                        requester: PublicKey)
-                        -> Result<(), RoutingError> {
-        if !self.is_action_allowed(requester, Action::Update) {
-            return Err(RoutingError::AccessDenied);
-        }
-        if !self.data.contains_key(&key) {
-            return Err(RoutingError::EntryNotFound);
-        }
-        let prev = self.data.insert(key.clone(), value);
-        if !self.validate_mut_size() {
-            // unwrap! would always succeed as we check that the key exists
-            let _ = self.data.insert(key, unwrap!(prev));
-            return Err(RoutingError::ExceededSizeLimit);
-        }
-        Ok(())
-    }
-
-    /// Deletes an existing entry (key + value pair)
-    pub fn del_entry(&mut self, key: &Vec<u8>, requester: PublicKey) -> Result<(), RoutingError> {
-        if !self.is_action_allowed(requester, Action::Delete) {
-            return Err(RoutingError::AccessDenied);
-        }
-        if !self.data.contains_key(key) {
-            return Err(RoutingError::EntryNotFound);
-        }
-        let _ = self.data.remove(key);
         Ok(())
     }
 
@@ -331,7 +400,11 @@ mod tests {
     macro_rules! assert_err {
         ($left: expr, $err: path) => {{
             let result = $left; // required to prevent multiple repeating expansions
-            assert!(if let Err($err) = result { true } else { false }, "Expected Err({:?}), found {:?}", $err, result);
+            assert!(if let Err($err) = result {
+                true
+            } else {
+                false
+            }, "Expected Err({:?}), found {:?}", $err, result);
         }}
     }
 
@@ -354,34 +427,55 @@ mod tests {
         let k1 = "123".as_bytes().to_owned();
         let k2 = "234".as_bytes().to_owned();
 
-        let v1 = Value {
-            content: "abc".as_bytes().to_owned(),
-            entry_version: 0,
-        };
-        let v2 = Value {
-            content: "def".as_bytes().to_owned(),
-            entry_version: 0,
-        };
+        let mut v1 = BTreeMap::new();
+        let _ = v1.insert(k1.clone(),
+                          EntryAction::Ins(Value {
+                              content: "abc".as_bytes().to_owned(),
+                              entry_version: 0,
+                          }));
+
+        let mut v2 = BTreeMap::new();
+        let _ = v2.insert(k2.clone(),
+                          EntryAction::Ins(Value {
+                              content: "def".as_bytes().to_owned(),
+                              entry_version: 0,
+                          }));
 
         let mut owners = BTreeSet::new();
         owners.insert(owner);
         let mut md = unwrap!(MutableData::new(rand::random(), 0, perms, BTreeMap::new(), owners));
 
         // Check insert permissions
-        assert!(md.ins_entry(k1.clone(), v1.clone(), pk1).is_ok());
-        assert_err!(md.ins_entry(k2.clone(), v2.clone(), pk2),
+        assert!(md.mutate_entries(v1.clone(), pk1).is_ok());
+        assert_err!(md.mutate_entries(v2.clone(), pk2),
                     RoutingError::AccessDenied);
+
+        assert!(md.get(&k1).is_some());
+        assert!(md.get(&k2).is_none()); // check that rollback is working
 
         // Check update permissions
-        assert_err!(md.update_entry(k1.clone(), v2.clone(), pk1),
+        let _ = v1.insert(k1.clone(),
+                          EntryAction::Update(Value {
+                              content: "def".as_bytes().to_owned(),
+                              entry_version: 1,
+                          }));
+        assert_err!(md.mutate_entries(v1.clone(), pk1),
                     RoutingError::AccessDenied);
-        assert!(md.update_entry(k1.clone(), v2.clone(), pk2).is_ok());
+        // check that rollback is working
+        assert_eq!(md.get(&k1).unwrap().content, "abc".as_bytes());
+
+        assert!(md.mutate_entries(v1.clone(), pk2).is_ok());
 
         // Check delete permissions (which should be implicitly forbidden)
-        assert_err!(md.del_entry(&k1, pk1), RoutingError::AccessDenied);
+        let mut del = BTreeMap::new();
+        let _ = del.insert(k1.clone(), EntryAction::Del(2));
+        assert_err!(md.mutate_entries(del.clone(), pk1),
+                    RoutingError::AccessDenied);
+        assert!(md.get(&k1).is_some());
 
         // Actions requested by owner should always be allowed
-        assert!(md.del_entry(&k1, owner).is_ok());
+        assert!(md.mutate_entries(del, owner).is_ok());
+        assert!(md.get(&k1).is_none());
     }
 
     #[test]
@@ -439,12 +533,20 @@ mod tests {
         assert_eq!(md.entries().len(), 100);
 
         // Try to get over the limit
-        assert!(md.ins_entry(vec![101u8], val.clone(), owner).is_ok());
-        assert_err!(md.ins_entry(vec![102u8], val.clone(), owner),
+        let mut v1 = BTreeMap::new();
+        let _ = v1.insert(vec![101u8], EntryAction::Ins(val.clone()));
+        assert!(md.mutate_entries(v1, owner).is_ok());
+
+        let mut v2 = BTreeMap::new();
+        let _ = v2.insert(vec![102u8], EntryAction::Ins(val.clone()));
+        assert_err!(md.mutate_entries(v2.clone(), owner),
                     RoutingError::TooManyEntries);
 
-        assert!(md.del_entry(&vec![101u8], owner).is_ok());
-        assert!(md.ins_entry(vec![102u8], val.clone(), owner).is_ok());
+        let mut del = BTreeMap::new();
+        let _ = del.insert(vec![101u8], EntryAction::Del(1));
+        assert!(md.mutate_entries(del, owner).is_ok());
+
+        assert!(md.mutate_entries(v2, owner).is_ok());
     }
 
     #[test]
@@ -479,11 +581,20 @@ mod tests {
         let mut md = unwrap!(MutableData::new(rand::random(), 0, BTreeMap::new(), data, owners));
 
         // Try to get over the mutation limit of 2 MiB
-        assert!(md.ins_entry(vec![1], big_val.clone(), owner).is_ok());
-        assert_err!(md.ins_entry(vec![2], small_val.clone(), owner),
+        let mut v1 = BTreeMap::new();
+        let _ = v1.insert(vec![1], EntryAction::Ins(big_val.clone()));
+        assert!(md.mutate_entries(v1, owner).is_ok());
+
+        let mut v2 = BTreeMap::new();
+        let _ = v2.insert(vec![2], EntryAction::Ins(small_val.clone()));
+        assert_err!(md.mutate_entries(v2.clone(), owner),
                     RoutingError::ExceededSizeLimit);
-        assert!(md.del_entry(&vec![0], owner).is_ok());
-        assert!(md.ins_entry(vec![0], small_val, owner).is_ok());
+
+        let mut del = BTreeMap::new();
+        let _ = del.insert(vec![0], EntryAction::Del(1));
+        assert!(md.mutate_entries(del, owner).is_ok());
+
+        assert!(md.mutate_entries(v2, owner).is_ok());
     }
 
     #[test]
@@ -506,6 +617,59 @@ mod tests {
     }
 
     #[test]
+    fn versions_succession() {
+        let (owner, _) = sign::gen_keypair();
+
+        let mut owners = BTreeSet::new();
+        owners.insert(owner);
+        let mut md =
+            unwrap!(MutableData::new(rand::random(), 0, BTreeMap::new(), BTreeMap::new(), owners));
+
+        let mut v1 = BTreeMap::new();
+        let _ = v1.insert(vec![1],
+                          EntryAction::Ins(Value {
+                              content: vec![100],
+                              entry_version: 0,
+                          }));
+        assert!(md.mutate_entries(v1, owner).is_ok());
+
+        // Check update with invalid versions
+        let mut v2 = BTreeMap::new();
+        let _ = v2.insert(vec![1],
+                          EntryAction::Update(Value {
+                              content: vec![105],
+                              entry_version: 0,
+                          }));
+        assert_err!(md.mutate_entries(v2.clone(), owner),
+                    RoutingError::InvalidSuccessor);
+
+        let _ = v2.insert(vec![1],
+                          EntryAction::Update(Value {
+                              content: vec![105],
+                              entry_version: 2,
+                          }));
+        assert_err!(md.mutate_entries(v2.clone(), owner),
+                    RoutingError::InvalidSuccessor);
+
+        // Check update with a valid version
+        let _ = v2.insert(vec![1],
+                          EntryAction::Update(Value {
+                              content: vec![105],
+                              entry_version: 1,
+                          }));
+        assert!(md.mutate_entries(v2, owner).is_ok());
+
+        // Check delete version
+        let mut del = BTreeMap::new();
+        let _ = del.insert(vec![1], EntryAction::Del(1));
+        assert_err!(md.mutate_entries(del.clone(), owner),
+                    RoutingError::InvalidSuccessor);
+
+        let _ = del.insert(vec![1], EntryAction::Del(2));
+        assert!(md.mutate_entries(del, owner).is_ok());
+    }
+
+    #[test]
     fn changing_permissions() {
         let (owner, _) = sign::gen_keypair();
         let (pk1, _) = sign::gen_keypair();
@@ -517,12 +681,13 @@ mod tests {
             unwrap!(MutableData::new(rand::random(), 0, BTreeMap::new(), BTreeMap::new(), owners));
 
         // Trying to do inserts without having a permission must fail
-        assert_err!(md.ins_entry(vec![0],
-                                 Value {
-                                     content: vec![1],
-                                     entry_version: 0,
-                                 },
-                                 pk1),
+        let mut v1 = BTreeMap::new();
+        let _ = v1.insert(vec![0],
+                          EntryAction::Ins(Value {
+                              content: vec![1],
+                              entry_version: 0,
+                          }));
+        assert_err!(md.mutate_entries(v1.clone(), pk1),
                     RoutingError::AccessDenied);
 
         // Now allow inserts for pk1
@@ -530,13 +695,7 @@ mod tests {
         let _ = ps1.allow(Action::Insert).allow(Action::ManagePermission);
         assert!(md.set_user_permissions(User::Key(pk1), ps1, owner).is_ok());
 
-        assert!(md.ins_entry(vec![0],
-                       Value {
-                           content: vec![1],
-                           entry_version: 0,
-                       },
-                       pk1)
-            .is_ok());
+        assert!(md.mutate_entries(v1, pk1).is_ok());
 
         // pk1 now can change permissions
         let mut ps2 = PermissionSet::new();
@@ -549,13 +708,13 @@ mod tests {
 
         assert!(md.del_user_permissions(&User::Key(pk1), owner).is_ok());
 
-        assert_err!(md.ins_entry(vec![1],
-                                 Value {
-                                     content: vec![2],
-                                     entry_version: 0,
-                                 },
-                                 pk1),
-                    RoutingError::AccessDenied);
+        let mut v2 = BTreeMap::new();
+        let _ = v2.insert(vec![1],
+                          EntryAction::Ins(Value {
+                              content: vec![1],
+                              entry_version: 0,
+                          }));
+        assert_err!(md.mutate_entries(v2, pk1), RoutingError::AccessDenied);
 
         // Revoking permissions for a non-existing user should return an error
         assert_err!(md.del_user_permissions(&User::Key(pk1), owner),

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,6 +119,8 @@ pub enum RoutingError {
     ExceededSizeLimit,
     /// Access is denied for a given requester
     AccessDenied,
+    /// Version check has failed
+    InvalidSuccessor,
 }
 
 impl From<RoutingTableError> for RoutingError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ mod event;
 mod id;
 mod message_filter;
 mod messages;
+mod messages_new;
 mod node;
 mod peer_manager;
 mod routing_message_filter;
@@ -192,6 +193,8 @@ pub use error::{InterfaceError, RoutingError};
 pub use event::Event;
 pub use id::{FullId, PublicId};
 pub use messages::{Request, Response};
+pub use messages_new::Request as Request2;
+pub use messages_new::Response as Response2;
 #[cfg(feature = "use-mock-crust")]
 pub use mock_crust::crust;
 pub use node::{Node, NodeBuilder};

--- a/src/messages_new.rs
+++ b/src/messages_new.rs
@@ -1,0 +1,236 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use data::{ImmutableData, MutableData, PermissionSet, User, Value};
+use rust_sodium::crypto::sign;
+use std::collections::{BTreeMap, BTreeSet};
+use types::MessageId as MsgId;
+use xor_name::XorName;
+
+pub enum EntryAction {
+    Update(Value),
+    Ins(Value),
+    Del(u64),
+}
+
+#[allow(missing_docs)]
+pub enum Request {
+    Refresh(Vec<u8>, MsgId),
+    GetAccountInfo(MsgId),
+
+    // --- ImmutableData ---
+    // ==========================
+    PutIData { data: ImmutableData, msg_id: MsgId },
+    GetIData { name: XorName, msg_id: MsgId },
+
+    // --- MutableData ---
+    // ==========================
+    /// Creates a new MutableData in the network
+    PutMData {
+        data: MutableData,
+        msg_id: MsgId,
+        requester: sign::PublicKey,
+    },
+    /// Fetches a latest version number of the provided MutableData
+    GetMDataVersion {
+        name: XorName,
+        tag: u64,
+        msg_id: MsgId,
+    },
+
+    // Data Actions
+    /// Fetches a list of entries (keys + values) of the provided MutableData
+    ListMDataEntries {
+        name: XorName,
+        tag: u64,
+        msg_id: MsgId,
+    },
+    /// Fetches a list of keys of the provided MutableData
+    ListMDataKeys {
+        name: XorName,
+        tag: u64,
+        msg_id: MsgId,
+    },
+    /// Fetches a list of values of the provided MutableData
+    ListMDataValues {
+        name: XorName,
+        tag: u64,
+        msg_id: MsgId,
+    },
+    /// Fetches a single value from the provided MutableData by the given key
+    GetMDataValue {
+        name: XorName,
+        tag: u64,
+        key: Vec<u8>,
+        msg_id: MsgId,
+    },
+    /// Updates MutableData entries in bulk
+    MutateMDataEntries {
+        name: XorName,
+        tag: u64,
+        actions: BTreeMap<Vec<u8>, EntryAction>,
+        msg_id: MsgId,
+        requester: sign::PublicKey,
+    },
+
+    // Permission Actions
+    ListMDataPermissions {
+        name: XorName,
+        tag: u64,
+        msg_id: MsgId,
+    },
+    ListMDataUserPermissions {
+        name: XorName,
+        tag: u64,
+        user: User,
+        msg_id: MsgId,
+    },
+    SetMDataUserPermissions {
+        name: XorName,
+        tag: u64,
+        user: User,
+        permissions: PermissionSet,
+        version: u64,
+        msg_id: MsgId,
+        requester: sign::PublicKey,
+    },
+    DelMDataUserPermissions {
+        name: XorName,
+        tag: u64,
+        user: User,
+        version: u64,
+        msg_id: MsgId,
+        requester: sign::PublicKey,
+    },
+
+    // Ownership Actions
+    ChangeMDataOwner {
+        name: XorName,
+        tag: u64,
+        new_owners: BTreeSet<sign::PublicKey>,
+        version: u64,
+        msg_id: MsgId,
+    },
+
+    // --- Client (Owner) to MM ---
+    // ==========================
+    ListAuthKeysAndVersion(MsgId),
+    InsAuthKey {
+        key: sign::PublicKey,
+        version: u64,
+        msg_id: MsgId,
+    },
+    DelAuthKey {
+        key: sign::PublicKey,
+        version: u64,
+        msg_id: MsgId,
+    },
+}
+
+#[allow(missing_docs)]
+pub enum Response {
+    GetAccountInfoFailure { reason: Vec<u8>, msg_id: MsgId },
+    GetAccountInfoSuccess {
+        data_stored: u64,
+        space_available: u64,
+        msg_id: MsgId,
+    },
+
+    // --- ImmutableData ---
+    // ==========================
+    PutIData {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+    GetIData {
+        res: Result<ImmutableData, Vec<u8>>,
+        msg_id: MsgId,
+    },
+
+    // --- MutableData ---
+    // ==========================
+    PutMData {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+
+    GetMDataVersion {
+        res: Result<u64, Vec<u8>>,
+        msg_id: MsgId,
+    },
+
+    // Data Actions
+    ListMDataEntries {
+        res: Result<BTreeMap<Vec<u8>, Value>, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    ListMDataKeys {
+        res: Result<BTreeSet<Vec<u8>>, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    ListMDataValues {
+        res: Result<Vec<Value>, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    GetMDataValue {
+        res: Result<Value, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    MutateMDataEntries {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+
+    // Permission Actions
+    ListMDataPermissions {
+        res: Result<BTreeMap<User, PermissionSet>, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    ListMDataUserPermissions {
+        res: Result<PermissionSet, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    SetMDataUserPermissions {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+    DelMDataUserPermissions {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+
+    // Ownership Actions
+    ChangeMDataOwner {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+
+    // --- Client (Owner) to MM ---
+    // ==========================
+    ListAuthKeysAndVersion {
+        res: Result<BTreeSet<sign::PublicKey>, Vec<u8>>,
+        msg_id: MsgId,
+    },
+    InsAuthKey {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+    DelAuthKey {
+        res: Result<(), Vec<u8>>,
+        msg_id: MsgId,
+    },
+}

--- a/src/messages_new.rs
+++ b/src/messages_new.rs
@@ -15,222 +15,355 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use data::{ImmutableData, MutableData, PermissionSet, User, Value};
+use data::{EntryAction, ImmutableData, MutableData, PermissionSet, User, Value};
 use rust_sodium::crypto::sign;
 use std::collections::{BTreeMap, BTreeSet};
 use types::MessageId as MsgId;
 use xor_name::XorName;
 
-pub enum EntryAction {
-    Update(Value),
-    Ins(Value),
-    Del(u64),
-}
-
-#[allow(missing_docs)]
+/// Request message types
 pub enum Request {
+    /// Represents a refresh message sent between vaults. Vec<u8> is the message content.
     Refresh(Vec<u8>, MsgId),
+    /// Gets MAID account information.
     GetAccountInfo(MsgId),
 
     // --- ImmutableData ---
     // ==========================
-    PutIData { data: ImmutableData, msg_id: MsgId },
-    GetIData { name: XorName, msg_id: MsgId },
+    /// Puts ImmutableData to the network.
+    PutIData {
+        /// ImmutableData to be stored
+        data: ImmutableData,
+        /// Unique message identifier
+        msg_id: MsgId
+    },
+    /// Fetches ImmutableData from the network by the given name.
+    GetIData {
+        /// Network identifier of ImmutableData
+        name: XorName,
+        /// Unique message identifier
+        msg_id: MsgId
+    },
 
     // --- MutableData ---
     // ==========================
-    /// Creates a new MutableData in the network
+    /// Creates a new MutableData in the network.
     PutMData {
+        /// MutableData to be stored
         data: MutableData,
+        /// Unique message identifier
         msg_id: MsgId,
+        /// Requester public key
         requester: sign::PublicKey,
     },
-    /// Fetches a latest version number of the provided MutableData
+    /// Fetches a latest version number.
     GetMDataVersion {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // Data Actions
-    /// Fetches a list of entries (keys + values) of the provided MutableData
+    /// Fetches a list of entries (keys + values).
     ListMDataEntries {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
-    /// Fetches a list of keys of the provided MutableData
+    /// Fetches a list of keys in MutableData.
     ListMDataKeys {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
-    /// Fetches a list of values of the provided MutableData
+    /// Fetches a list of values in MutableData.
     ListMDataValues {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
-    /// Fetches a single value from the provided MutableData by the given key
+    /// Fetches a single value from MutableData
     GetMDataValue {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// Key of an entry to be fetched
         key: Vec<u8>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
-    /// Updates MutableData entries in bulk
+    /// Updates MutableData entries in bulk.
     MutateMDataEntries {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// A list of mutations (inserts, updates, or deletes) to be performed
+        /// on MutableData in bulk.
         actions: BTreeMap<Vec<u8>, EntryAction>,
+        /// Unique message identifier
         msg_id: MsgId,
+        /// Requester public key
         requester: sign::PublicKey,
     },
 
     // Permission Actions
+    /// Fetches a complete list of permissions.
     ListMDataPermissions {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Fetches a list of permissions for a particular User.
     ListMDataUserPermissions {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// A user identifier used to fetch permissions
         user: User,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Updates or inserts a list of permissions for a particular User in the given MutableData.
     SetMDataUserPermissions {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// A user identifier used to set permissions
         user: User,
+        /// Permissions to be set for a user
         permissions: PermissionSet,
+        /// Incremented version of MutableData
         version: u64,
+        /// Unique message identifier
         msg_id: MsgId,
+        /// Requester public key
         requester: sign::PublicKey,
     },
+    /// Deletes a list of permissions for a particular User in the given MutableData.
     DelMDataUserPermissions {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// A user identifier used to delete permissions
         user: User,
+        /// Incremented version of MutableData
         version: u64,
+        /// Unique message identifier
         msg_id: MsgId,
+        /// Requester public key
         requester: sign::PublicKey,
     },
 
     // Ownership Actions
+    /// Changes an owner of the given MutableData. Only the current owner can perform this action.
     ChangeMDataOwner {
+        /// Network identifier of MutableData
         name: XorName,
+        /// Type tag
         tag: u64,
+        /// A list of new owners
         new_owners: BTreeSet<sign::PublicKey>,
+        /// Incremented version of MutableData
         version: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // --- Client (Owner) to MM ---
     // ==========================
+    /// Lists authorised keys and version stored in MaidManager.
     ListAuthKeysAndVersion(MsgId),
+    /// Inserts an autorised key (for an app, user, etc.) to MaidManager.
     InsAuthKey {
+        /// Authorised key to be inserted
         key: sign::PublicKey,
+        /// Incremented version
         version: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Deletes an authorised key from MaidManager.
     DelAuthKey {
+        /// Authorised key to be deleted
         key: sign::PublicKey,
+        /// Incremented version
         version: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 }
 
-#[allow(missing_docs)]
+/// Response message types
 pub enum Response {
-    GetAccountInfoFailure { reason: Vec<u8>, msg_id: MsgId },
+    /// Returns an error occurred during account information retrieval.
+    GetAccountInfoFailure {
+        /// Description of an occurred error
+        reason: Vec<u8>,
+        /// Unique message identifier
+        msg_id: MsgId
+    },
+    /// Returns an account information.
     GetAccountInfoSuccess {
+        /// Amount of data stored on the network by this Client
         data_stored: u64,
+        /// Amount of network space available to this Client
         space_available: u64,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // --- ImmutableData ---
     // ==========================
+    /// Returns a success or failure status of putting ImmutableData to the network.
     PutIData {
+        /// Result of putting ImmutableData to the network.
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a result of fetching ImmutableData from the network.
     GetIData {
+        /// Result of fetching ImmutableData from the network.
         res: Result<ImmutableData, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // --- MutableData ---
     // ==========================
+    /// Returns a success or failure status of putting MutableData to the network.
     PutMData {
+        /// Result of putting MutableData to the network.
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
+    /// Returns a current version of MutableData stored in the network.
     GetMDataVersion {
+        /// Result of getting a version of MutableData
         res: Result<u64, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // Data Actions
+    /// Returns a complete list of entries in MutableData or an error in case of failure.
     ListMDataEntries {
+        /// Result of getting a list of entries in MutableData
         res: Result<BTreeMap<Vec<u8>, Value>, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a list of keys in MutableData or an error in case of failure.
     ListMDataKeys {
+        /// Result of getting a list of keys in MutableData
         res: Result<BTreeSet<Vec<u8>>, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a list of values in MutableData or an error in case of failure.
     ListMDataValues {
+        /// Result of getting a list of values in MutableData
         res: Result<Vec<Value>, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a single entry from MutableData or an error in case of failure.
     GetMDataValue {
+        /// Result of getting a value from MutableData
         res: Result<Value, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a success or failure status of mutating MutableData in the network.
     MutateMDataEntries {
+        /// Result of mutating an entry in MutableData
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // Permission Actions
+    /// Returns a complete list of MutableData permissions stored on the network or an error in case of failure.
     ListMDataPermissions {
+        /// Result of getting a list of permissions in MutableData
         res: Result<BTreeMap<User, PermissionSet>, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a list of permissions for a particular User in MutableData or an error in case of failure.
     ListMDataUserPermissions {
+        /// Result of getting a list of user permissions in MutableData
         res: Result<PermissionSet, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a success or failure status of setting permissions for a particular User in MutableData.
     SetMDataUserPermissions {
+        /// Result of setting a list of user permissions in MutableData
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a success or failure status of deleting permissions for a particular User in MutableData.
     DelMDataUserPermissions {
+        /// Result of deleting a list of user permissions in MutableData
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // Ownership Actions
+    /// Returns a success or failure status of chaning an owner of MutableData.
     ChangeMDataOwner {
+        /// Result of chaning an owner of MutableData
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 
     // --- Client (Owner) to MM ---
     // ==========================
+    /// Returns a list of authorised keys from MaidManager.
     ListAuthKeysAndVersion {
+        /// Result of getting a list of authorised keys
         res: Result<BTreeSet<sign::PublicKey>, Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a success or failure status of inserting an authorised key into MaidManager.
     InsAuthKey {
+        /// Result of inserting an authorised key
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
+    /// Returns a success or failure status of deleting an authorised key from MaidManager.
     DelAuthKey {
+        /// Result of deleting an authorised key
         res: Result<(), Vec<u8>>,
+        /// Unique message identifier
         msg_id: MsgId,
     },
 }


### PR DESCRIPTION
Modify entry mutation procedures according to the message format in the RFC. Implement entry version checks.

This PR supersedes https://github.com/maidsafe/routing/pull/1232 and addresses the raised review comments.