### PR TITLE
MAID-1774: fix/test: fix mock crust test utility function

### DIFF
--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -737,7 +737,7 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         where I: IntoIterator,
               I::Item: Borrow<T>
     {
-        // Count the number of names which will end up in our group if it is split.
+        // Count the number of names which will end up in each new group if our group is split.
         let mut new_group_size_0 = 0;
         let mut new_group_size_1 = 0;
         for name in our_group {
@@ -747,8 +747,7 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
                 new_group_size_1 += 1;
             }
         }
-        // If either of the two new groups will not contain enough entries, return `false` (add 1
-        // when considering our own group to also count ourself as a member of this group).
+        // If either of the two new groups will not contain enough entries, return `false`.
         let min_size = self.min_split_size();
         new_group_size_0 >= min_size && new_group_size_1 >= min_size
     }

--- a/tests/mock_crust/cache.rs
+++ b/tests/mock_crust/cache.rs
@@ -40,7 +40,6 @@ fn gen_immutable_data_not_in_first_node_group<T: Rng>(rng: &mut T, nodes: &[Test
 }
 
 #[test]
-#[ignore]
 fn response_caching() {
     let network = Network::new(None);
 

--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -91,7 +91,6 @@ fn did_receive_get_success(node: &TestNode,
 }
 
 #[test]
-#[ignore]
 fn churn() {
     let network = Network::new(None);
 

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -351,13 +351,15 @@ pub fn create_connected_nodes_with_cache_till_split(network: &Network) -> Vec<Te
             .cache(use_cache)
             .create());
         poll_and_resend(&mut nodes, &mut []);
-        while let Ok(event) = nodes[len].event_rx.try_recv() {
-            match event {
-                Event::NodeAdded(..) |
-                Event::Connected |
-                Event::Tick => (),
-                Event::GroupSplit(..) => break 'outer,
-                event => panic!("Got unexpected event: {:?}", event),
+        for node in &nodes {
+            while let Ok(event) = node.event_rx.try_recv() {
+                match event {
+                    Event::NodeAdded(..) |
+                    Event::Connected |
+                    Event::Tick => (),
+                    Event::GroupSplit(..) => break 'outer,
+                    event => panic!("Got unexpected event: {:?}", event),
+                }
             }
         }
     }


### PR DESCRIPTION
This updates the test setup which waits for a 'GroupSplit' event to not rely on that event being
triggered by the newest node.  The new node doesn't trigger that event since it now gets constructed
with post-split groups.  This commit also re-enables a couple of tests.