### PR TITLE
MAID-1787 merge at most two groups at once, and fix group messages while merging

### DIFF
--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -18,7 +18,7 @@
 use error::RoutingError;
 use maidsafe_utilities::{self, serialisation};
 use message_filter::MessageFilter;
-use messages::{GroupList, RoutingMessage};
+use messages::RoutingMessage;
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
@@ -32,7 +32,6 @@ const EXPIRY_DURATION_SECS: u64 = 4 * 60;
 #[derive(Clone, Debug)]
 pub struct UnacknowledgedMessage {
     pub routing_msg: RoutingMessage,
-    pub group_list: Option<GroupList>,
     pub route: u8,
     pub timer_token: u64,
 }

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -221,10 +221,6 @@ pub struct RemovalDetails<T: Binary + Clone + Copy + Default + Hash + Xorable> {
     pub name: T,
     // True if the removed peer was in our group.
     pub was_in_our_group: bool,
-    // If, after removal, our group needs to merge, this is set to `Some`. It contains the
-    // appropriate targets (all members of the merging groups) and the merge details they each need
-    // to receive (the new prefix and all groups in the table).
-    pub targets_and_merge_details: Option<(BTreeSet<Prefix<T>>, OwnMergeDetails<T>)>,
 }
 
 
@@ -232,12 +228,9 @@ pub struct RemovalDetails<T: Binary + Clone + Copy + Default + Hash + Xorable> {
 // Details returned by `RoutingTable::merge_own_group()`.
 pub enum OwnMergeState<T: Binary + Clone + Copy + Default + Hash + Xorable> {
     // If no ongoing merge is happening when `merge_own_group()` is called, `Initialised` is
-    // returned, containing the appropriate targets (all the merging groups' `Prefix`es) and the
-    // merge details they each need to receive (the new prefix and all groups in the table).
-    Initialised {
-        targets: BTreeSet<Prefix<T>>,
-        merge_details: OwnMergeDetails<T>,
-    },
+    // returned, containing the merge details they each need to receive (the new prefix and all
+    // groups in the table).
+    Initialised { merge_details: OwnMergeDetails<T> },
     // If an ongoing merge is happening, and this call to `merge_own_group()` doesn't complete the
     // merge (i.e. at least one of the merging groups hasn't yet sent us its merge details), then
     // `Ongoing` is returned, implying that no further action by the caller is required.
@@ -518,19 +511,14 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
     /// entry is removed from the routing table and `RemovalDetails` is returned.  See that struct's
     /// docs for further info.
     pub fn remove(&mut self, name: &T) -> Result<RemovalDetails<T>, Error> {
-        let mut should_merge = false;
-        let mut removal_details = RemovalDetails {
+        let removal_details = RemovalDetails {
             name: *name,
             was_in_our_group: self.our_group_prefix.matches(name),
-            targets_and_merge_details: None,
         };
         if removal_details.was_in_our_group {
             if !self.our_group.remove(name) {
                 return Err(Error::NoSuchPeer);
             }
-            should_merge = self.our_group.len() + 1 < self.min_group_size &&
-                           self.our_group_prefix.bit_count() != 0 &&
-                           self.merging.is_empty();
         } else if let Some(prefix) = self.find_group_prefix(name) {
             if let Some(group) = self.groups.get_mut(&prefix) {
                 if !group.remove(name) {
@@ -540,21 +528,41 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         } else {
             return Err(Error::NoSuchPeer);
         }
-        if should_merge {
-            let merge_prefix = self.our_group_prefix.popped();
-            let mut groups = self.groups.clone();
-            let mut our_group = self.our_group.clone();
-            let _ = our_group.insert(self.our_name);
-            let _ = groups.insert(self.our_group_prefix, our_group);
-            removal_details.targets_and_merge_details =
-                Some((self.prefixes_within_merge(&merge_prefix),
-                      OwnMergeDetails {
-                          sender_prefix: self.our_group_prefix,
-                          merge_prefix: merge_prefix,
-                          groups: groups,
-                      }));
-        }
         Ok(removal_details)
+    }
+
+    /// If our group is required to merge, returns the details to initiate merging.
+    ///
+    /// Merging is required if any group has dropped below the minimum size and can only restore it
+    /// by ultimately merging with us.
+    ///
+    /// However, merging happens in simple steps, each of which involves only two groups. If. e.g.
+    /// group `1` drops below the minimum size, and the other groups are `01`, `001` and `000`,
+    /// then this will return `true` only in the latter two. Once they are merged and have
+    /// established all their new connections, it will return `true` in `01` and `00`. Only after
+    /// that, the group `0` will merge with group `1`.
+    pub fn should_merge(&self) -> Option<OwnMergeDetails<T>> {
+        let bit_count = self.our_group_prefix.bit_count();
+        let needs_to_merge_with_us = |(prefix, group): (&Prefix<T>, &HashSet<T>)| {
+            !prefix.popped().is_compatible(&self.our_group_prefix) ||
+            group.len() >= self.min_group_size
+        };
+        if bit_count == 0 || !self.needed.is_empty() || !self.merging.is_empty() ||
+           !self.groups.contains_key(&self.our_group_prefix.with_flipped_bit(bit_count - 1)) ||
+           (self.our_group.len() + 1 >= self.min_group_size &&
+            self.groups.iter().all(needs_to_merge_with_us)) {
+            return None;
+        }
+        let merge_prefix = self.our_group_prefix.popped();
+        let mut groups = self.groups.clone();
+        let mut our_group = self.our_group.clone();
+        let _ = our_group.insert(self.our_name);
+        let _ = groups.insert(self.our_group_prefix, our_group);
+        Some(OwnMergeDetails {
+            sender_prefix: self.our_group_prefix,
+            merge_prefix: merge_prefix,
+            groups: groups,
+        })
     }
 
     /// When a merge of our own group is triggered (either from our own group or a neighbouring one)
@@ -786,10 +794,7 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         let mut our_group = self.our_group.clone();
         our_group.insert(self.our_name);
         let _ = merge_details.groups.insert(self.our_group_prefix, our_group);
-        OwnMergeState::Initialised {
-            targets: self.prefixes_within_merge(&merge_details.merge_prefix),
-            merge_details: merge_details,
-        }
+        OwnMergeState::Initialised { merge_details: merge_details }
     }
 
     fn finish_merging_own_group(&mut self, merge_details: OwnMergeDetails<T>) -> OwnMergeState<T> {
@@ -860,17 +865,6 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
 
     fn min_split_size(&self) -> usize {
         self.min_group_size + SPLIT_BUFFER
-    }
-
-    // Returns prefixes of all groups we're connected to (i.e. non-empty groups from `self.groups`,
-    // and our own) which are merging into a new group defined by `merge_prefix`.
-    fn prefixes_within_merge(&self, merge_prefix: &Prefix<T>) -> BTreeSet<Prefix<T>> {
-        self.groups
-            .iter()
-            .chain(iter::once((&self.our_group_prefix, &self.our_group)))
-            .filter(|&(prefix, names)| merge_prefix.is_compatible(prefix) && !names.is_empty())
-            .map(|(prefix, _)| *prefix)
-            .collect()
     }
 
     fn check_invariant(&self) -> Result<(), Error> {

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -334,6 +334,11 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         &self.our_group_prefix
     }
 
+    /// Returns our own group, excluding our own name.
+    pub fn our_group(&self) -> &HashSet<T> {
+        &self.our_group
+    }
+
     /// Returns the total number of entries in the routing table.
     pub fn len(&self) -> usize {
         self.groups.values().fold(0, |acc, group| acc + group.len()) + self.our_group.len()

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -148,8 +148,7 @@ mod tests {
             let routing_msg = RoutingMessage {
                 src: Authority::ClientManager(rand::random()),
                 dst: Authority::ClientManager(rand::random()),
-                content: MessageContent::GroupSplit(Prefix::new(rand::random::<u8>() as usize,
-                                                                rand::random())),
+                content: MessageContent::GroupSplit(Prefix::new(0, rand::random()), rand::random()),
             };
             let signed_msg = unwrap!(SignedMessage::new(routing_msg, msg_sender_id));
             let signature_msgs = other_ids.map(|id| {

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -24,8 +24,8 @@ use error::{InterfaceError, RoutingError};
 use event::Event;
 use id::{FullId, PublicId};
 use maidsafe_utilities::serialisation;
-use messages::{GroupList, HopMessage, Message, MessageContent, RoutingMessage, SignedMessage,
-               UserMessage, UserMessageCache};
+use messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedMessage, UserMessage,
+               UserMessageCache};
 use peer_manager::MIN_GROUP_SIZE;
 use routing_message_filter::RoutingMessageFilter;
 use state_machine::Transition;
@@ -312,15 +312,6 @@ impl Bootstrapped for Client {
                 debug!("{:?} Failed to send message: {:?}", self, error);
             }
         }
-    }
-
-    fn send_routing_message_via_route_with_group_list(&mut self,
-                                                      routing_msg: RoutingMessage,
-                                                      route: u8,
-                                                      _group_list: GroupList)
-                                                      -> Result<(), RoutingError> {
-        // clients have no group lists
-        self.send_routing_message_via_route(routing_msg, route)
     }
 
     fn send_routing_message_via_route(&mut self,

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1644,16 +1644,16 @@ impl Node {
                 .into_iter()
                 .filter(|target| !sent_to.contains(target))
                 .collect();
-            let new_sent_to =
-                if self.peer_mgr.routing_table()
-                                .our_group_prefix()
-                                .matches(routing_msg.dst.name()) {
-                    sent_to.iter()
-                        .chain(targets.iter())
-                        .cloned()
-                        .collect_vec()
+            let new_sent_to = if self.peer_mgr
+                .routing_table()
+                .our_group_prefix()
+                .matches(routing_msg.dst.name()) {
+                sent_to.iter()
+                    .chain(targets.iter())
+                    .cloned()
+                    .collect_vec()
             } else {
-              vec![]
+                vec![]
             };
             Ok((new_sent_to, self.peer_mgr.get_peer_ids(&targets)))
         } else if let Authority::Client { ref proxy_node_name, .. } = routing_msg.src {

--- a/tests/mock_crust/accumulate.rs
+++ b/tests/mock_crust/accumulate.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use routing::{Authority, Event, MessageId, QUORUM, Response};
+use routing::{Authority, Event, MIN_GROUP_SIZE, MessageId, QUORUM, Response};
 use routing::mock_crust::Network;
 use std::sync::mpsc;
 use super::{TestNode, create_connected_nodes, gen_immutable_data, poll_all,
@@ -39,7 +39,7 @@ fn messages_accumulate_with_quorum() {
 
     let dst = Authority::ManagedNode(nodes[0].name()); // The closest node.
     // The smallest number such that `quorum * 100 >= len * QUORUM`:
-    let quorum = (nodes.len() * QUORUM - 1) / 100 + 1;
+    let quorum = (MIN_GROUP_SIZE * QUORUM - 1) / 100 + 1;
 
     // Send a message from the group `src` to the node `dst`.
     // Only the `quorum`-th sender should cause accumulation and a

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -147,11 +147,11 @@ fn whitelist() {
     for node in &mut nodes {
         node.handle.0.borrow_mut().whitelist_peer(PeerId(MIN_GROUP_SIZE));
     }
-    // The next node has peer ID `GROUP_SIZE`: It should be able to join.
+    // The next node has peer ID `MIN_GROUP_SIZE`: It should be able to join.
     nodes.push(TestNode::builder(&network).config(config.clone()).create());
     let _ = poll_all(&mut nodes, &mut []);
     verify_invariant_for_all_nodes(&nodes);
-    // The next node has peer ID `GROUP_SIZE + 1`: It is not whitelisted.
+    // The next node has peer ID `MIN_GROUP_SIZE + 1`: It is not whitelisted.
     nodes.push(TestNode::builder(&network).config(config.clone()).create());
     let _ = poll_all(&mut nodes, &mut []);
     assert!(!unwrap!(nodes.pop()).inner.is_node());


### PR DESCRIPTION
This is a - probably temporary - workaround for the problems with
sending a group message while merging or splitting. If we require only
the `MIN_GROUP_SIZE` nodes closest to the source address to sign the
message, it works in both cases, and replaces the other workarounds: we
don't need to store group lists in the ack manager anymore, and we can
stop resending messages when we moved out of the sending group.