### PR TITLE
MAID-1836: Make min group size configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
 language: rust
 rust:
   - stable
-  - nightly
+  - nightly-2016-11-17
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ repository = "https://github.com/maidsafe/routing"
 version = "0.25.1"
 
 [dependencies]
-clippy = {version = "~0.0.100", optional = true}
+# Recommended nightly version (also see .travis.yml):
+# rustc 1.15.0-nightly (ba872f270 2016-11-17)
+clippy = {version = "=0.0.99", optional = true}
 crust = "~0.19.0"
 itertools = "~0.5.6"
 log = "~0.3.6"

--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -70,7 +70,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 use term::color;
-use utils::{ExampleClient, ExampleNode};
+use utils::{ExampleClient, ExampleNode, MIN_GROUP_SIZE};
 
 const CHURN_MIN_WAIT_SEC: u64 = 20;
 const CHURN_MAX_WAIT_SEC: u64 = 30;
@@ -167,8 +167,7 @@ fn simulate_churn(mut nodes: Vec<NodeProcess>,
     })
 }
 
-fn simulate_churn_impl(min_group_size: usize,
-                       nodes: &mut Vec<NodeProcess>,
+fn simulate_churn_impl(nodes: &mut Vec<NodeProcess>,
                        rng: &mut ThreadRng,
                        network_size: usize,
                        node_count: &mut usize)
@@ -177,7 +176,7 @@ fn simulate_churn_impl(min_group_size: usize,
     io::stdout().flush().expect("Could not flush stdout");
 
     let kill_node = match nodes.len() {
-        size if size == min_group_size => false,
+        size if size == MIN_GROUP_SIZE => false,
         size if size == network_size => true,
         _ => random(),
     };
@@ -304,9 +303,6 @@ struct Args {
 
 #[cfg_attr(feature="clippy", allow(mutex_atomic))] // AtomicBool cannot be used with Condvar.
 fn main() {
-    // TODO: make size a run-time argument?
-    let min_group_size = 8;
-
     let args: Args = Docopt::new(USAGE)
         .and_then(|docopt| docopt.decode())
         .unwrap_or_else(|error| error.exit());
@@ -321,8 +317,8 @@ fn main() {
         unwrap!(maidsafe_utilities::log::init(false));
         let node_count = match args.arg_nodes {
             Some(number) => {
-                if number <= min_group_size {
-                    panic!("The number of nodes should be > {}.", min_group_size);
+                if number <= MIN_GROUP_SIZE {
+                    panic!("The number of nodes should be > {}.", MIN_GROUP_SIZE);
                 }
 
                 number

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -25,6 +25,7 @@ use rust_sodium::crypto;
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
+use super::MIN_GROUP_SIZE;
 
 const RESPONSE_TIMEOUT_SECS: u64 = 10;
 
@@ -54,7 +55,8 @@ impl ExampleClient {
         // Try to connect the client to the network. If it fails, it probably means
         // the network isn't fully formed yet, so we restart and try again.
         'outer: loop {
-            routing_client = unwrap!(Client::new(sender.clone(), Some(full_id.clone())));
+            routing_client =
+                unwrap!(Client::new(sender.clone(), Some(full_id.clone()), MIN_GROUP_SIZE));
 
             for event in receiver.iter() {
                 match event {

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -22,6 +22,7 @@ use routing::{Authority, Data, DataIdentifier, Event, MessageId, Node, Prefix, R
 use std::collections::HashMap;
 use std::sync::mpsc;
 use std::time::Duration;
+use super::MIN_GROUP_SIZE;
 
 /// A simple example node implementation for a network based on the Routing library.
 pub struct ExampleNode {
@@ -42,7 +43,7 @@ impl ExampleNode {
     /// Creates a new node and attempts to establish a connection to the network.
     pub fn new(first: bool) -> ExampleNode {
         let (sender, receiver) = mpsc::channel::<Event>();
-        let node = unwrap!(Node::builder().first(first).create(sender.clone()));
+        let node = unwrap!(Node::builder().first(first).create(sender.clone(), MIN_GROUP_SIZE));
 
         ExampleNode {
             node: node,
@@ -83,7 +84,8 @@ impl ExampleNode {
                 }
                 Event::RestartRequired => {
                     info!("{} Received RestartRequired event", self.get_debug_name());
-                    self.node = unwrap!(Node::builder().create(self.sender.clone()));
+                    self.node = unwrap!(Node::builder()
+                        .create(self.sender.clone(), MIN_GROUP_SIZE));
                 }
                 Event::GroupSplit(prefix) => {
                     trace!("{} Received GroupSplit event {:?}",

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -20,5 +20,7 @@
 mod example_node;
 mod example_client;
 
+pub const MIN_GROUP_SIZE: usize = 8;
+
 pub use self::example_client::ExampleClient;
 pub use self::example_node::ExampleNode;

--- a/src/client.rs
+++ b/src/client.rs
@@ -67,11 +67,15 @@ impl Client {
     /// cryptographically secure and uses group consensus. The restriction for the client name
     /// exists to ensure that the client cannot choose its `ClientAuthority`.
     #[cfg(not(feature = "use-mock-crust"))]
-    pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
+    pub fn new(event_sender: Sender<Event>,
+               keys: Option<FullId>,
+               min_group_size: usize)
+               -> Result<Client, RoutingError> {
         rust_sodium::init();  // enable shared global (i.e. safe to multithread now)
 
         // start the handler for routing with a restriction to become a full node
-        let (action_sender, mut machine) = Self::make_state_machine(event_sender, keys);
+        let (action_sender, mut machine) =
+            Self::make_state_machine(event_sender, keys, min_group_size);
         let (tx, rx) = channel();
 
         let raii_joiner = thread::named("Client thread", move || machine.run());
@@ -85,7 +89,8 @@ impl Client {
     }
 
     fn make_state_machine(event_sender: Sender<Event>,
-                          keys: Option<FullId>)
+                          keys: Option<FullId>,
+                          min_group_size: usize)
                           -> (RoutingActionSender, StateMachine) {
         let cache = Box::new(NullCache);
         let full_id = keys.unwrap_or_else(FullId::new);
@@ -96,6 +101,7 @@ impl Client {
                                                             crust_service,
                                                             event_sender,
                                                             full_id,
+                                                            min_group_size,
                                                             timer))
         })
     }
@@ -189,9 +195,12 @@ impl Client {
 #[cfg(feature = "use-mock-crust")]
 impl Client {
     /// Create a new `Client` for unit testing.
-    pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
+    pub fn new(event_sender: Sender<Event>,
+               keys: Option<FullId>,
+               min_group_size: usize)
+               -> Result<Client, RoutingError> {
         // start the handler for routing with a restriction to become a full node
-        let (action_sender, machine) = Self::make_state_machine(event_sender, keys);
+        let (action_sender, machine) = Self::make_state_machine(event_sender, keys, min_group_size);
         let (tx, rx) = channel();
 
         Ok(Client {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! use routing::{Client, Event, FullId};
 //!
 //! let min_group_size = 8;
-//! 
+//!
 //! let (sender, _receiver) = mpsc::channel::<Event>();
 //! let full_id = FullId::new(); // Generate new keys.
 //! let _ = Client::new(sender, Some(full_id.clone()), min_group_size).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,11 @@
 //! use std::sync::mpsc;
 //! use routing::{Client, Event, FullId};
 //!
+//! let min_group_size = 8;
+//! 
 //! let (sender, _receiver) = mpsc::channel::<Event>();
 //! let full_id = FullId::new(); // Generate new keys.
-//! let _ = Client::new(sender, Some(full_id.clone())).unwrap();
+//! let _ = Client::new(sender, Some(full_id.clone()), min_group_size).unwrap();
 //!
 //! let _ = full_id.public_id().name();
 //! ```
@@ -77,8 +79,10 @@
 //! use std::sync::mpsc;
 //! use routing::{Node, Event};
 //!
+//! let min_group_size = 8;
+//!
 //! let (sender, _receiver) = mpsc::channel::<Event>();
-//! let _ = Node::builder().create(sender).unwrap();
+//! let _ = Node::builder().create(sender, min_group_size).unwrap();
 //! ```
 //!
 //! Upon creation, the node will first connect to the network as a client. Once it has client
@@ -198,7 +202,6 @@ pub use messages::{Request, Response};
 #[cfg(feature = "use-mock-crust")]
 pub use mock_crust::crust;
 pub use node::{Node, NodeBuilder};
-pub use peer_manager::MIN_GROUP_SIZE;
 #[cfg(any(test, feature = "use-mock-crust"))]
 pub use routing_table::{Destination, RoutingTable, verify_network_invariant};
 pub use routing_table::{Prefix, Xorable};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -36,7 +36,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::iter;
 use std::time::Duration;
-use super::{MIN_GROUP_SIZE, QUORUM};
+use super::QUORUM;
 use types::MessageId;
 use utils;
 use xor_name::XorName;
@@ -299,7 +299,7 @@ impl SignedMessage {
 
     /// Returns whether there are enough signatures from the sender. NOTE: to ensure only validated
     /// signatures are counted, first call `remove_invalid_signatures()`.
-    pub fn is_fully_signed(&self) -> bool {
+    pub fn is_fully_signed(&self, min_group_size: usize) -> bool {
         if self.content.src.is_client() {
             return self.signatures.len() == 1;
         }
@@ -310,7 +310,7 @@ impl SignedMessage {
                     .map(PublicId::name)
                     .sorted_by(|lhs, rhs| self.content.src.name().cmp_distance(lhs, rhs))
                     .into_iter()
-                    .take(MIN_GROUP_SIZE)
+                    .take(min_group_size)
                     .collect();
                 let valid_sigs = self.signatures
                     .keys()
@@ -1065,6 +1065,8 @@ mod tests {
 
     #[test]
     fn msg_signatures() {
+        let min_group_size = 8;
+
         let full_id_0 = FullId::new();
         let full_id_1 = FullId::new();
         let full_id_2 = FullId::new();
@@ -1104,7 +1106,7 @@ mod tests {
         });
         assert_eq!(signed_msg.signatures.len(), 1);
         assert!(!signed_msg.signatures.contains_key(irrelevant_full_id.public_id()));
-        assert!(!signed_msg.is_fully_signed());
+        assert!(!signed_msg.is_fully_signed(min_group_size));
 
         // Add a valid signature for ID 1 and an invalid one for ID 2
         match unwrap!(signed_msg.routing_message().to_signature(full_id_1.signing_private_key())) {
@@ -1118,7 +1120,7 @@ mod tests {
         let bad_sig = sign::Signature([0; sign::SIGNATUREBYTES]);
         signed_msg.add_signature(*full_id_2.public_id(), bad_sig);
         assert_eq!(signed_msg.signatures.len(), 3);
-        assert!(signed_msg.is_fully_signed());
+        assert!(signed_msg.is_fully_signed(min_group_size));
 
         // Check the bad signature gets removed properly.
         signed_msg.remove_invalid_signatures();

--- a/src/mock_crust/tests.rs
+++ b/src/mock_crust/tests.rs
@@ -52,7 +52,8 @@ macro_rules! expect_event {
 
 #[test]
 fn start_two_services_bootstrap_communicate_exit() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let endpoint0 = network.gen_endpoint(None);
     let endpoint1 = network.gen_endpoint(None);
     let config = Config::with_contacts(&[endpoint0, endpoint1]);
@@ -108,7 +109,8 @@ fn start_two_services_bootstrap_communicate_exit() {
 fn start_two_services_rendezvous_connect() {
     const PREPARE_CI_TOKEN: u32 = 1;
 
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let handle0 = network.new_service_handle(None, None);
     let handle1 = network.new_service_handle(None, None);
 
@@ -166,7 +168,8 @@ fn start_two_services_rendezvous_connect() {
 fn unidirectional_rendezvous_connect() {
     const PREPARE_CI_TOKEN: u32 = 1;
 
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let handle0 = network.new_service_handle(None, None);
     let handle1 = network.new_service_handle(None, None);
 
@@ -198,7 +201,8 @@ fn unidirectional_rendezvous_connect() {
 fn drop() {
     use std::mem;
 
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let handle0 = network.new_service_handle(None, None);
 
     let config = Config::with_contacts(&[handle0.endpoint()]);

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -342,6 +342,11 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         self.our_group.is_empty() && self.groups.values().all(HashSet::is_empty)
     }
 
+    /// Get the minimum group size
+    pub fn min_group_size(&self) -> usize {
+        self.min_group_size
+    }
+
     /// Returns whether the table contains the given `name`
     pub fn has(&self, name: &T) -> bool {
         self.get_group(name).map_or(false, |group| group.contains(name))

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -210,8 +210,12 @@ mod tests {
                 .foreach(|(signature_msg, full_id)| {
                     match *signature_msg {
                         DirectMessage::MessageSignature(ref hash, ref sig) => {
-                            assert!(sig_accumulator.add_signature(min_group_size, *hash, *sig, *full_id.public_id())
-                                .is_none());
+                            let result =
+                                sig_accumulator.add_signature(min_group_size,
+                                                              *hash,
+                                                              *sig,
+                                                              *full_id.public_id());
+                            assert!(result.is_none());
                         }
                         ref unexpected_msg => panic!("Unexpected message: {:?}", unexpected_msg),
                     }
@@ -258,7 +262,9 @@ mod tests {
         env.msgs_and_sigs.iter().enumerate().foreach(|(route, msg_and_sigs)| {
             let mut signed_msg = msg_and_sigs.signed_msg.clone();
             signed_msg.add_group_list(env.group_list.clone());
-            assert!(sig_accumulator.add_message(signed_msg.clone(), min_group_size, route as u8).is_none());
+            let result =
+                sig_accumulator.add_message(signed_msg.clone(), min_group_size, route as u8);
+            assert!(result.is_none());
         });
         let mut expected_msgs_count = env.msgs_and_sigs.len();
         assert_eq!(sig_accumulator.msgs.len(), expected_msgs_count);
@@ -272,7 +278,8 @@ mod tests {
                 .foreach(|(signature_msg, full_id)| {
                     let result = match *signature_msg {
                         DirectMessage::MessageSignature(hash, sig) => {
-                            sig_accumulator.add_signature(min_group_size, hash, sig, *full_id.public_id())
+                            sig_accumulator.add_signature(min_group_size, hash, sig,
+                                *full_id.public_id())
                         }
                         ref unexpected_msg => panic!("Unexpected message: {:?}", unexpected_msg),
                     };

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -39,6 +39,7 @@ impl SignatureAccumulator {
     /// Adds the given signature to the list of pending signatures or to the appropriate
     /// `SignedMessage`. Returns the message, if it has enough signatures now.
     pub fn add_signature(&mut self,
+                         min_group_size: usize,
                          hash: sha256::Digest,
                          sig: sign::Signature,
                          pub_id: PublicId)
@@ -51,16 +52,17 @@ impl SignatureAccumulator {
             sigs_vec.0.push((pub_id, sig));
             return None;
         }
-        self.remove_if_complete(&hash)
+        self.remove_if_complete(min_group_size, &hash)
     }
 
     /// Adds the given message to the list of pending messages. Returns it if it has enough
     /// signatures.
     pub fn add_message(&mut self,
                        mut msg: SignedMessage,
+                       min_group_size: usize,
                        route: u8)
                        -> Option<(SignedMessage, u8)> {
-        if msg.is_fully_signed() {
+        if msg.is_fully_signed(min_group_size) {
             return Some((msg, route));
         }
         self.remove_expired();
@@ -84,7 +86,7 @@ impl SignatureAccumulator {
                 let _ = entry.insert((msg, route, Instant::now()));
             }
         }
-        self.remove_if_complete(&hash)
+        self.remove_if_complete(min_group_size, &hash)
     }
 
     fn remove_expired(&mut self) {
@@ -106,15 +108,18 @@ impl SignatureAccumulator {
         }
     }
 
-    fn remove_if_complete(&mut self, hash: &sha256::Digest) -> Option<(SignedMessage, u8)> {
+    fn remove_if_complete(&mut self,
+                          min_group_size: usize,
+                          hash: &sha256::Digest)
+                          -> Option<(SignedMessage, u8)> {
         match self.msgs.get_mut(hash) {
             None => return None,
             Some(&mut (ref mut msg, _, _)) => {
-                if !msg.is_fully_signed() {
+                if !msg.is_fully_signed(min_group_size) {
                     return None;
                 }
                 msg.remove_invalid_signatures();
-                if !msg.is_fully_signed() {
+                if !msg.is_fully_signed(min_group_size) {
                     return None;
                 }
             }
@@ -193,6 +198,7 @@ mod tests {
 
     #[test]
     fn group_src_add_message_last() {
+        let min_group_size = 8;
         let mut sig_accumulator = SignatureAccumulator::default();
         let env = Env::new();
 
@@ -204,7 +210,7 @@ mod tests {
                 .foreach(|(signature_msg, full_id)| {
                     match *signature_msg {
                         DirectMessage::MessageSignature(ref hash, ref sig) => {
-                            assert!(sig_accumulator.add_signature(*hash, *sig, *full_id.public_id())
+                            assert!(sig_accumulator.add_signature(min_group_size, *hash, *sig, *full_id.public_id())
                                 .is_none());
                         }
                         ref unexpected_msg => panic!("Unexpected message: {:?}", unexpected_msg),
@@ -228,13 +234,13 @@ mod tests {
             signed_msg.add_group_list(env.group_list.clone());
             let route = rand::random();
             let (returned_msg, returned_route) =
-                unwrap!(sig_accumulator.add_message(signed_msg.clone(), route));
+                unwrap!(sig_accumulator.add_message(signed_msg.clone(), min_group_size, route));
             assert_eq!(sig_accumulator.sigs.len(), expected_sigs_count);
             assert!(sig_accumulator.msgs.is_empty());
             assert_eq!(route, returned_route);
             assert_eq!(signed_msg.routing_message(), returned_msg.routing_message());
             unwrap!(returned_msg.check_integrity());
-            assert!(returned_msg.is_fully_signed());
+            assert!(returned_msg.is_fully_signed(min_group_size));
             env.group_list
                 .pub_ids
                 .iter()
@@ -244,6 +250,7 @@ mod tests {
 
     #[test]
     fn group_src_add_signature_last() {
+        let min_group_size = 8;
         let mut sig_accumulator = SignatureAccumulator::default();
         let env = Env::new();
 
@@ -251,7 +258,7 @@ mod tests {
         env.msgs_and_sigs.iter().enumerate().foreach(|(route, msg_and_sigs)| {
             let mut signed_msg = msg_and_sigs.signed_msg.clone();
             signed_msg.add_group_list(env.group_list.clone());
-            assert!(sig_accumulator.add_message(signed_msg.clone(), route as u8).is_none());
+            assert!(sig_accumulator.add_message(signed_msg.clone(), min_group_size, route as u8).is_none());
         });
         let mut expected_msgs_count = env.msgs_and_sigs.len();
         assert_eq!(sig_accumulator.msgs.len(), expected_msgs_count);
@@ -265,7 +272,7 @@ mod tests {
                 .foreach(|(signature_msg, full_id)| {
                     let result = match *signature_msg {
                         DirectMessage::MessageSignature(hash, sig) => {
-                            sig_accumulator.add_signature(hash, sig, *full_id.public_id())
+                            sig_accumulator.add_signature(min_group_size, hash, sig, *full_id.public_id())
                         }
                         ref unexpected_msg => panic!("Unexpected message: {:?}", unexpected_msg),
                     };
@@ -277,7 +284,7 @@ mod tests {
                         assert_eq!(msg_and_sigs.signed_msg.routing_message(),
                                    returned_msg.routing_message());
                         unwrap!(returned_msg.check_integrity());
-                        assert!(returned_msg.is_fully_signed());
+                        assert!(returned_msg.is_fully_signed(min_group_size));
                     }
                 });
         });

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -50,6 +50,7 @@ pub struct Bootstrapping {
     crust_service: Service,
     event_sender: Sender<Event>,
     full_id: FullId,
+    min_group_size: usize,
     stats: Stats,
     timer: Timer,
 }
@@ -60,6 +61,7 @@ impl Bootstrapping {
                mut crust_service: Service,
                event_sender: Sender<Event>,
                full_id: FullId,
+               min_group_size: usize,
                timer: Timer)
                -> Self {
         let _ = crust_service.start_bootstrap(HashSet::new());
@@ -72,7 +74,8 @@ impl Bootstrapping {
             crust_service: crust_service,
             event_sender: event_sender,
             full_id: full_id,
-            stats: Default::default(),
+            min_group_size: min_group_size,
+            stats: Stats::new(min_group_size),
             timer: timer,
         }
     }
@@ -130,6 +133,7 @@ impl Bootstrapping {
         Client::from_bootstrapping(self.crust_service,
                                    self.event_sender,
                                    self.full_id,
+                                   self.min_group_size,
                                    proxy_peer_id,
                                    proxy_public_id,
                                    self.stats,
@@ -141,6 +145,7 @@ impl Bootstrapping {
                                  self.crust_service,
                                  self.event_sender,
                                  self.full_id,
+                                 self.min_group_size,
                                  proxy_peer_id,
                                  proxy_public_id,
                                  self.stats,

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -75,7 +75,7 @@ impl Bootstrapping {
             event_sender: event_sender,
             full_id: full_id,
             min_group_size: min_group_size,
-            stats: Stats::new(min_group_size),
+            stats: Stats::new(),
             timer: timer,
         }
     }

--- a/src/states/common/bootstrapped.rs
+++ b/src/states/common/bootstrapped.rs
@@ -21,7 +21,6 @@ use crust::PeerId;
 use error::RoutingError;
 use maidsafe_utilities::serialisation;
 use messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedMessage};
-use peer_manager::MIN_GROUP_SIZE;
 use routing_message_filter::RoutingMessageFilter;
 use std::time::Duration;
 use super::Base;
@@ -33,6 +32,7 @@ use xor_name::XorName;
 pub trait Bootstrapped: Base {
     fn ack_mgr(&self) -> &AckManager;
     fn ack_mgr_mut(&mut self) -> &mut AckManager;
+    fn min_group_size(&self) -> usize;
 
     fn send_routing_message_via_route(&mut self,
                                       routing_msg: RoutingMessage,
@@ -104,7 +104,7 @@ pub trait Bootstrapped: Base {
                    ack,
                    unacked_msg);
 
-            if unacked_msg.route as usize == MIN_GROUP_SIZE {
+            if unacked_msg.route as usize == self.min_group_size() {
                 debug!("{:?} - Message unable to be acknowledged - giving up. {:?}",
                        self,
                        unacked_msg);

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -103,7 +103,7 @@ impl Node {
                   true,
                   full_id,
                   min_group_size,
-                  Stats::new(min_group_size),
+                  Stats::new(),
                   timer)
     }
 
@@ -1462,7 +1462,8 @@ impl Node {
         let our_name = *self.name();
         let min_group_size = self.min_group_size();
         if let Some((msg, route)) =
-            self.sig_accumulator.add_message(signed_msg, min_group_size, route) {
+            self.sig_accumulator
+                .add_message(signed_msg, min_group_size, route) {
             if self.in_authority(&msg.routing_message().dst) {
                 self.handle_signed_message(msg, route, our_name, &[])?;
             } else {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -16,13 +16,12 @@
 // relating to use of the SAFE Network Software.
 
 use messages::{DirectMessage, MessageContent, Request, Response, RoutingMessage, UserMessage};
-use peer_manager::MIN_GROUP_SIZE;
+use std::iter;
 
 /// The number of messages after which the message statistics should be printed.
 const MSG_LOG_COUNT: usize = 1000;
 
 /// A collection of counters to gather Routing statistics.
-#[derive(Default)]
 pub struct Stats {
     // TODO: Make these private and move the logic here.
     pub cur_routing_table_size: usize,
@@ -32,7 +31,7 @@ pub struct Stats {
     pub tunnel_connections: usize,
 
     /// Messages sent by us on different routes.
-    routes: [usize; MIN_GROUP_SIZE],
+    routes: Vec<usize>,
     /// Messages we sent unsuccessfully: unacknowledged on all routes.
     unacked_msgs: usize,
 
@@ -76,6 +75,53 @@ pub struct Stats {
 }
 
 impl Stats {
+    // Create a new instance, with the given number of routes
+    pub fn new(num_routes: usize) -> Self {
+        Stats {
+            cur_routing_table_size: 0,
+            cur_client_num: 0,
+            cumulative_client_num: 0,
+            tunnel_client_pairs: 0,
+            tunnel_connections: 0,
+            routes: iter::repeat(0).take(num_routes).collect(),
+            unacked_msgs: 0,
+            msg_direct_node_identify: 0,
+            msg_direct_sig: 0,
+            msg_get: 0,
+            msg_put: 0,
+            msg_post: 0,
+            msg_delete: 0,
+            msg_append: 0,
+            msg_get_account_info: 0,
+            msg_get_close_group: 0,
+            msg_get_node_name: 0,
+            msg_expect_close_node: 0,
+            msg_refresh: 0,
+            msg_connection_info: 0,
+            msg_get_success: 0,
+            msg_get_failure: 0,
+            msg_put_success: 0,
+            msg_put_failure: 0,
+            msg_post_success: 0,
+            msg_post_failure: 0,
+            msg_delete_success: 0,
+            msg_delete_failure: 0,
+            msg_append_success: 0,
+            msg_append_failure: 0,
+            msg_get_account_info_success: 0,
+            msg_get_account_info_failure: 0,
+            msg_get_close_group_rsp: 0,
+            msg_group_split: 0,
+            msg_own_group_merge: 0,
+            msg_other_group_merge: 0,
+            msg_get_node_name_rsp: 0,
+            msg_ack: 0,
+            msg_other: 0,
+            msg_total: 0,
+            msg_total_bytes: 0,
+        }
+    }
+
     pub fn count_unacked(&mut self) {
         self.unacked_msgs += 1;
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -16,12 +16,12 @@
 // relating to use of the SAFE Network Software.
 
 use messages::{DirectMessage, MessageContent, Request, Response, RoutingMessage, UserMessage};
-use std::iter;
 
 /// The number of messages after which the message statistics should be printed.
 const MSG_LOG_COUNT: usize = 1000;
 
 /// A collection of counters to gather Routing statistics.
+#[derive(Default)]
 pub struct Stats {
     // TODO: Make these private and move the logic here.
     pub cur_routing_table_size: usize,
@@ -76,50 +76,8 @@ pub struct Stats {
 
 impl Stats {
     // Create a new instance, with the given number of routes
-    pub fn new(num_routes: usize) -> Self {
-        Stats {
-            cur_routing_table_size: 0,
-            cur_client_num: 0,
-            cumulative_client_num: 0,
-            tunnel_client_pairs: 0,
-            tunnel_connections: 0,
-            routes: iter::repeat(0).take(num_routes).collect(),
-            unacked_msgs: 0,
-            msg_direct_node_identify: 0,
-            msg_direct_sig: 0,
-            msg_get: 0,
-            msg_put: 0,
-            msg_post: 0,
-            msg_delete: 0,
-            msg_append: 0,
-            msg_get_account_info: 0,
-            msg_get_close_group: 0,
-            msg_get_node_name: 0,
-            msg_expect_close_node: 0,
-            msg_refresh: 0,
-            msg_connection_info: 0,
-            msg_get_success: 0,
-            msg_get_failure: 0,
-            msg_put_success: 0,
-            msg_put_failure: 0,
-            msg_post_success: 0,
-            msg_post_failure: 0,
-            msg_delete_success: 0,
-            msg_delete_failure: 0,
-            msg_append_success: 0,
-            msg_append_failure: 0,
-            msg_get_account_info_success: 0,
-            msg_get_account_info_failure: 0,
-            msg_get_close_group_rsp: 0,
-            msg_group_split: 0,
-            msg_own_group_merge: 0,
-            msg_other_group_merge: 0,
-            msg_get_node_name_rsp: 0,
-            msg_ack: 0,
-            msg_other: 0,
-            msg_total: 0,
-            msg_total_bytes: 0,
-        }
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn count_unacked(&mut self) {
@@ -127,10 +85,11 @@ impl Stats {
     }
 
     pub fn count_route(&mut self, route: u8) {
-        match self.routes.get_mut(route as usize) {
-            Some(count) => *count += 1,
-            None => error!("Unexpected route number {}", route),
+        let route = route as usize;
+        if route >= self.routes.len() {
+            self.routes.resize(route + 1, 0);
         }
+        self.routes[route] += 1;
     }
 
     /// Increments the counter for the given request.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,7 +70,6 @@ pub fn calculate_relocated_name(mut close_nodes: Vec<XorName>, original_name: &X
 
 #[cfg(test)]
 mod tests {
-    use peer_manager::MIN_GROUP_SIZE;
     use rand;
     use routing_table::Xorable;
     use rust_sodium::crypto::hash::sha256;
@@ -78,6 +77,7 @@ mod tests {
 
     #[test]
     fn calculate_relocated_name() {
+        let min_group_size = 8;
         let original_name: XorName = rand::random();
 
         // one entry
@@ -103,9 +103,10 @@ mod tests {
         assert_eq!(actual_relocated_name_one_entry,
                    expected_relocated_name_one_node);
 
+        // TODO: we're not using fixed sizes any more: this code should possibly change!
         // populated closed nodes
         let mut close_nodes: Vec<XorName> = Vec::new();
-        for _ in 0..MIN_GROUP_SIZE {
+        for _ in 0..min_group_size {
             close_nodes.push(rand::random());
         }
         let actual_relocated_name = super::calculate_relocated_name(close_nodes.clone(),

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -55,8 +55,8 @@ use itertools::Itertools;
 use maidsafe_utilities::SeededRng;
 use maidsafe_utilities::thread::{self, Joiner};
 use rand::Rng;
-use routing::{Authority, Client, Data, Event, FullId, MIN_GROUP_SIZE, MessageId, Node, Request,
-              Response, StructuredData, XorName, Xorable};
+use routing::{Authority, Client, Data, Event, FullId, MessageId, Node, Request, Response,
+              StructuredData, XorName, Xorable};
 use rust_sodium::crypto;
 use std::collections::{BTreeSet, HashSet};
 #[cfg(target_os = "macos")]
@@ -104,12 +104,12 @@ struct TestNode {
 
 impl TestNode {
     // If `index` is `0`, this will be treated as the first node of the network.
-    fn new(index: usize, main_sender: Sender<TestEvent>) -> Self {
+    fn new(index: usize, main_sender: Sender<TestEvent>, min_group_size: usize) -> Self {
         let thread_name = format!("TestNode {} event sender", index);
         let (sender, joiner) = spawn_select_thread(index, main_sender, thread_name);
 
         TestNode {
-            node: unwrap!(Node::builder().first(index == 0).create(sender)),
+            node: unwrap!(Node::builder().first(index == 0).create(sender, min_group_size)),
             _thread_joiner: joiner,
         }
     }
@@ -127,7 +127,7 @@ struct TestClient {
 }
 
 impl TestClient {
-    fn new(index: usize, main_sender: Sender<TestEvent>) -> Self {
+    fn new(index: usize, main_sender: Sender<TestEvent>, min_group_size: usize) -> Self {
         let thread_name = format!("TestClient {} event sender", index);
         let (sender, joiner) = spawn_select_thread(index, main_sender, thread_name);
 
@@ -138,7 +138,7 @@ impl TestClient {
         TestClient {
             index: index,
             full_id: full_id.clone(),
-            client: unwrap!(Client::new(sender, Some(full_id))),
+            client: unwrap!(Client::new(sender, Some(full_id), min_group_size)),
             _thread_joiner: joiner,
         }
     }
@@ -211,7 +211,8 @@ fn spawn_select_thread(index: usize,
 
 fn wait_for_nodes_to_connect(nodes: &[TestNode],
                              connection_counts: &mut [usize],
-                             event_receiver: &Receiver<TestEvent>) {
+                             event_receiver: &Receiver<TestEvent>,
+                             min_group_size: usize) {
     // Wait for each node to connect to all the other nodes by counting churns.
     loop {
         if let Ok(test_event) = recv_with_timeout(event_receiver, Duration::from_secs(30)) {
@@ -221,7 +222,7 @@ fn wait_for_nodes_to_connect(nodes: &[TestNode],
                 let k = nodes.len();
                 let all_events_received = (0..k)
                     .map(|i| connection_counts[i])
-                    .all(|n| n >= k - 1 || n >= MIN_GROUP_SIZE);
+                    .all(|n| n >= k - 1 || n >= min_group_size);
                 if all_events_received {
                     break;
                 }
@@ -234,13 +235,14 @@ fn wait_for_nodes_to_connect(nodes: &[TestNode],
 
 fn create_connected_nodes(count: usize,
                           event_sender: Sender<TestEvent>,
-                          event_receiver: &Receiver<TestEvent>)
+                          event_receiver: &Receiver<TestEvent>,
+                          min_group_size: usize)
                           -> Vec<TestNode> {
     let mut nodes = Vec::with_capacity(count);
     let mut connection_counts = iter::repeat(0).take(count).collect::<Vec<usize>>();
 
     // Bootstrap node
-    nodes.push(TestNode::new(0, event_sender.clone()));
+    nodes.push(TestNode::new(0, event_sender.clone(), min_group_size));
 
     // HACK: wait until the above node switches to accepting mode. Would be
     // nice to know exactly when it happens instead of having to thread::sleep...
@@ -250,8 +252,11 @@ fn create_connected_nodes(count: usize,
     // continuing.
     for _ in 1..count {
         let index = nodes.len();
-        nodes.push(TestNode::new(index, event_sender.clone()));
-        wait_for_nodes_to_connect(&nodes, &mut connection_counts, event_receiver);
+        nodes.push(TestNode::new(index, event_sender.clone(), min_group_size));
+        wait_for_nodes_to_connect(&nodes,
+                                  &mut connection_counts,
+                                  event_receiver,
+                                  min_group_size);
     }
 
     nodes
@@ -271,11 +276,11 @@ fn gen_structured_data<R: Rng>(full_id: &FullId, rng: &mut R) -> Data {
     Data::Structured(sd)
 }
 
-fn closest_nodes(node_names: &[XorName], target: &XorName) -> Vec<XorName> {
+fn closest_nodes(node_names: &[XorName], target: &XorName, min_group_size: usize) -> Vec<XorName> {
     node_names.iter()
         .sorted_by(|a, b| target.cmp_distance(a, b))
         .into_iter()
-        .take(MIN_GROUP_SIZE)
+        .take(min_group_size)
         .cloned()
         .collect()
 }
@@ -283,14 +288,17 @@ fn closest_nodes(node_names: &[XorName], target: &XorName) -> Vec<XorName> {
 // TODO: Extract the individual tests into their own functions.
 #[cfg_attr(feature="clippy", allow(cyclomatic_complexity))]
 fn core() {
+    let min_group_size = 8;
     let (event_sender, event_receiver) = mpsc::channel();
-    let mut nodes =
-        create_connected_nodes(MIN_GROUP_SIZE + 1, event_sender.clone(), &event_receiver);
+    let mut nodes = create_connected_nodes(min_group_size + 1,
+                                           event_sender.clone(),
+                                           &event_receiver,
+                                           min_group_size);
     let mut rng = SeededRng::new();
 
     {
         // request and response
-        let client = TestClient::new(nodes.len(), event_sender.clone());
+        let client = TestClient::new(nodes.len(), event_sender.clone(), min_group_size);
         let data = gen_structured_data(client.full_id(), &mut rng);
         let message_id = MessageId::new();
 
@@ -332,9 +340,9 @@ fn core() {
     {
         // request to group authority
         let node_names = nodes.iter().map(|node| node.name()).collect_vec();
-        let client = TestClient::new(nodes.len(), event_sender.clone());
+        let client = TestClient::new(nodes.len(), event_sender.clone(), min_group_size);
         let data = gen_structured_data(client.full_id(), &mut rng);
-        let mut close_group = closest_nodes(&node_names, client.name());
+        let mut close_group = closest_nodes(&node_names, client.name(), min_group_size);
 
         loop {
             if let Ok(test_event) = recv_with_timeout(&event_receiver, Duration::from_secs(20)) {
@@ -366,9 +374,9 @@ fn core() {
     {
         // response from group authority
         let node_names = nodes.iter().map(|node| node.name()).collect_vec();
-        let client = TestClient::new(nodes.len(), event_sender.clone());
+        let client = TestClient::new(nodes.len(), event_sender.clone(), min_group_size);
         let data = gen_structured_data(client.full_id(), &mut rng);
-        let mut close_group = closest_nodes(&node_names, client.name());
+        let mut close_group = closest_nodes(&node_names, client.name(), min_group_size);
 
         loop {
             if let Ok(test_event) = recv_with_timeout(&event_receiver, Duration::from_secs(20)) {
@@ -447,7 +455,7 @@ fn core() {
         let nodes_len = nodes.len();
         let mut churns = iter::repeat(false).take(nodes_len + 1).collect::<Vec<_>>();
         // a node joins...
-        nodes.push(TestNode::new(nodes_len, event_sender.clone()));
+        nodes.push(TestNode::new(nodes_len, event_sender.clone(), min_group_size));
 
         loop {
             if let Ok(test_event) = recv_with_timeout(&event_receiver, Duration::from_secs(20)) {
@@ -469,7 +477,7 @@ fn core() {
 
     {
         // message from quorum - 1 group members
-        let client = TestClient::new(nodes.len(), event_sender.clone());
+        let client = TestClient::new(nodes.len(), event_sender.clone(), min_group_size);
         let data = gen_structured_data(client.full_id(), &mut rng);
 
         while let Ok(test_event) = recv_with_timeout(&event_receiver, Duration::from_secs(5)) {
@@ -493,7 +501,7 @@ fn core() {
                 }
                 TestEvent(index, Event::Request { request, src, dst }) => {
                     if let Request::Put(data, id) = request {
-                        if 2 * (index + 1) < MIN_GROUP_SIZE {
+                        if 2 * (index + 1) < min_group_size {
                             unwrap!(nodes[index]
                                 .node
                                 .send_put_failure(dst, src, data.identifier(), vec![], id));
@@ -512,7 +520,7 @@ fn core() {
 
     {
         // message from more than quorum group members
-        let client = TestClient::new(nodes.len(), event_sender.clone());
+        let client = TestClient::new(nodes.len(), event_sender.clone(), min_group_size);
         let data = gen_structured_data(client.full_id(), &mut rng);
         let mut sent_ids = HashSet::new();
         let mut received_ids = HashSet::new();

--- a/tests/mock_crust/accumulate.rs
+++ b/tests/mock_crust/accumulate.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use routing::{Authority, Event, MIN_GROUP_SIZE, MessageId, QUORUM, Response};
+use routing::{Authority, Event, MessageId, QUORUM, Response};
 use routing::mock_crust::Network;
 use std::sync::mpsc;
 use super::{TestNode, create_connected_nodes, gen_immutable_data, poll_all,
@@ -23,7 +23,8 @@ use super::{TestNode, create_connected_nodes, gen_immutable_data, poll_all,
 
 #[test]
 fn messages_accumulate_with_quorum() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes(&network, 15);
 
@@ -39,7 +40,7 @@ fn messages_accumulate_with_quorum() {
 
     let dst = Authority::ManagedNode(nodes[0].name()); // The closest node.
     // The smallest number such that `quorum * 100 >= len * QUORUM`:
-    let quorum = (MIN_GROUP_SIZE * QUORUM - 1) / 100 + 1;
+    let quorum = (min_group_size * QUORUM - 1) / 100 + 1;
 
     // Send a message from the group `src` to the node `dst`.
     // Only the `quorum`-th sender should cause accumulation and a

--- a/tests/mock_crust/cache.rs
+++ b/tests/mock_crust/cache.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use rand::Rng;
-use routing::{Authority, Data, Event, MIN_GROUP_SIZE, MessageId, Prefix, Request, Response};
+use routing::{Authority, Data, Event, MessageId, Prefix, Request, Response};
 use routing::mock_crust::Network;
 use std::sync::mpsc;
 use super::{TestNode, create_connected_clients, create_connected_nodes_with_cache_until_split,
@@ -41,7 +41,8 @@ fn gen_immutable_data_not_in_first_node_group<T: Rng>(rng: &mut T, nodes: &[Test
 
 #[test]
 fn response_caching() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
 
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes_with_cache_until_split(&network, 1);
@@ -126,7 +127,7 @@ fn response_caching() {
 
     // The request should not be relayed to any other node, so no node should
     // raise Event::Request.
-    for node in nodes.iter().take(MIN_GROUP_SIZE) {
+    for node in nodes.iter().take(min_group_size) {
         expect_no_event!(node);
     }
 }

--- a/tests/mock_crust/drop.rs
+++ b/tests/mock_crust/drop.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use rand::Rng;
-use routing::{Event, MIN_GROUP_SIZE};
+use routing::Event;
 use routing::mock_crust::{Config, Endpoint, Network};
 use super::{TestNode, create_connected_nodes, poll_all, verify_invariant_for_all_nodes};
 
@@ -43,7 +43,8 @@ fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {
 
 #[test]
 fn failing_connections_group_of_three() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
 
     network.block_connection(Endpoint(1), Endpoint(2));
     network.block_connection(Endpoint(2), Endpoint(1));
@@ -64,8 +65,9 @@ fn failing_connections_group_of_three() {
 
 #[test]
 fn node_drops() {
-    let network = Network::new(None);
-    let mut nodes = create_connected_nodes(&network, MIN_GROUP_SIZE + 2);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
+    let mut nodes = create_connected_nodes(&network, min_group_size + 2);
     drop_node(&mut nodes, 0);
 
     verify_invariant_for_all_nodes(&nodes);
@@ -74,9 +76,10 @@ fn node_drops() {
 #[test]
 #[cfg_attr(feature = "clippy", allow(needless_range_loop))]
 fn node_restart() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, MIN_GROUP_SIZE);
+    let mut nodes = create_connected_nodes(&network, min_group_size);
 
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
 

--- a/tests/mock_crust/merge.rs
+++ b/tests/mock_crust/merge.rs
@@ -25,7 +25,8 @@ use super::{create_connected_nodes_with_cache_until_split, poll_and_resend,
 fn merge_three_groups_into_one() {
     // Create a network comprising three groups, one with a prefix `bit_count` of 1 and two with
     // prefix `bit_count`s of 2.
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes_with_cache_until_split(&network, 3);
     verify_invariant_for_all_nodes(&nodes);

--- a/tests/mock_crust/requests.rs
+++ b/tests/mock_crust/requests.rs
@@ -15,17 +15,18 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use routing::{Authority, Data, DataIdentifier, Destination, Event, ImmutableData, MIN_GROUP_SIZE,
-              MessageId, Request, Response};
+use routing::{Authority, Data, DataIdentifier, Destination, Event, ImmutableData, MessageId,
+              Request, Response};
 use routing::mock_crust::Network;
 use super::{create_connected_clients, create_connected_nodes, gen_bytes, gen_immutable_data,
             poll_all};
 
 #[test]
 fn successful_put_request() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, MIN_GROUP_SIZE + 1);
+    let mut nodes = create_connected_nodes(&network, min_group_size + 1);
     let mut clients = create_connected_clients(&network, &mut nodes, 1);
 
     let dst = Authority::ClientManager(clients[0].name());
@@ -57,14 +58,15 @@ fn successful_put_request() {
     }
 
     // TODO: Assert a quorum here.
-    assert!(2 * request_received_count > MIN_GROUP_SIZE);
+    assert!(2 * request_received_count > min_group_size);
 }
 
 #[test]
 fn successful_get_request() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, MIN_GROUP_SIZE + 1);
+    let mut nodes = create_connected_nodes(&network, min_group_size + 1);
     let mut clients = create_connected_clients(&network, &mut nodes, 1);
 
     let data = gen_immutable_data(&mut rng, 1024);
@@ -102,7 +104,7 @@ fn successful_get_request() {
     }
 
     // TODO: Assert a quorum here.
-    assert!(2 * request_received_count > MIN_GROUP_SIZE);
+    assert!(2 * request_received_count > min_group_size);
 
     let _ = poll_all(&mut nodes, &mut clients);
 
@@ -131,9 +133,10 @@ fn successful_get_request() {
 
 #[test]
 fn failed_get_request() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, MIN_GROUP_SIZE + 1);
+    let mut nodes = create_connected_nodes(&network, min_group_size + 1);
     let mut clients = create_connected_clients(&network, &mut nodes, 1);
 
     let data = gen_immutable_data(&mut rng, 1024);
@@ -171,7 +174,7 @@ fn failed_get_request() {
     }
 
     // TODO: Assert a quorum here.
-    assert!(2 * request_received_count > MIN_GROUP_SIZE);
+    assert!(2 * request_received_count > min_group_size);
 
     let _ = poll_all(&mut nodes, &mut clients);
 
@@ -197,9 +200,10 @@ fn failed_get_request() {
 
 #[test]
 fn disconnect_on_get_request() {
-    let network = Network::new(None);
+    let min_group_size = 8;
+    let network = Network::new(min_group_size, None);
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, 2 * MIN_GROUP_SIZE);
+    let mut nodes = create_connected_nodes(&network, 2 * min_group_size);
     let mut clients = create_connected_clients(&network, &mut nodes, 1);
 
     let immutable_data = ImmutableData::new(gen_bytes(&mut rng, 1024));
@@ -238,7 +242,7 @@ fn disconnect_on_get_request() {
     }
 
     // TODO: Assert a quorum here.
-    assert!(2 * request_received_count > MIN_GROUP_SIZE);
+    assert!(2 * request_received_count > min_group_size);
 
     clients[0].handle.0.borrow_mut().disconnect(&nodes[0].handle.0.borrow().peer_id);
     nodes[0].handle.0.borrow_mut().disconnect(&clients[0].handle.0.borrow().peer_id);


### PR DESCRIPTION
This doesn't actually change it anywhere, but makes it easy to change in tests.

See commit comments: there is a doc failure.

There are also two TODOs: one a minor item related to this change, one not related to this change (but to disjoint groups).