### PR TITLE
feat/node: log prefixes and connected nodes

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -351,14 +351,14 @@ impl PeerManager {
     /// remain connected.
     pub fn split_group(&mut self,
                        prefix: Prefix<XorName>)
-                       -> (Vec<PeerId>, Option<Prefix<XorName>>) {
+                       -> (Vec<(XorName, PeerId)>, Option<Prefix<XorName>>) {
         let (names_to_drop, our_new_prefix) = self.routing_table.split(prefix);
         let mut ids_to_drop = vec![];
         for name in &names_to_drop {
             if let Some(peer) = self.peer_map.remove_by_name(name) {
                 self.cleanup_proxy_peer_id();
                 if let Some(peer_id) = peer.peer_id {
-                    ids_to_drop.push(peer_id);
+                    ids_to_drop.push((*name, peer_id));
                 }
             }
         }

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1192,6 +1192,9 @@ impl Node {
 
         self.full_id.public_id_mut().set_name(*relocated_id.name());
         self.peer_mgr.reset_routing_table(*self.full_id.public_id(), &groups);
+        trace!("{:?} GetNodeName completed. Prefixes: {:?}",
+               self,
+               self.peer_mgr.routing_table().prefixes());
 
         for pub_id in groups.into_iter().flat_map(|(_, group)| group.into_iter()) {
             debug!("{:?} Sending connection info to {:?} on GetNodeName response.",
@@ -1324,8 +1327,9 @@ impl Node {
             }
         }
 
-        for peer_id in peers_to_drop {
+        for (name, peer_id) in peers_to_drop {
             self.disconnect_peer(&peer_id);
+            info!("{:?} Dropped {:?} from the routing table.", self, name);
         }
         trace!("{:?} Split completed. Prefixes: {:?}",
                self,
@@ -1397,6 +1401,9 @@ impl Node {
                 debug!("{:?} - Failed to send connection info: {:?}", self, error);
             }
         }
+        trace!("{:?} Other merge completed. Prefixes: {:?}",
+               self,
+               self.peer_mgr.routing_table().prefixes());
         self.merge_if_necessary();
         Ok(())
     }


### PR DESCRIPTION
Add the necessary log statements to make it possible to compute a node's
current routing table from the logs, i.e. log every time a node is added
to or removed from the routing table, or when the prefixes change.