### PR TITLE
MAID-1878 Fix routing via empty groups

### DIFF
--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -166,17 +166,28 @@ fn churn() {
         let auth_n1 = Authority::ManagedNode(nodes[index1].name());
         let auth_g0 = Authority::NaeManager(rng.gen());
         let auth_g1 = Authority::NaeManager(rng.gen());
+        let section_name: XorName = rng.gen();
+        let auth_s0 = Authority::Section(section_name);
+        // this makes sure we have two different sections if there exists more than one
+        let auth_s1 = Authority::Section(!section_name);
 
         let mut expected_gets = ExpectedGets::default();
 
-        // Test messages from a node to itself, another node and a group ...
+        // Test messages from a node to itself, another node, a group and a section...
         expected_gets.send_and_expect(data_id, auth_n0, auth_n0, &nodes, min_group_size);
         expected_gets.send_and_expect(data_id, auth_n0, auth_n1, &nodes, min_group_size);
         expected_gets.send_and_expect(data_id, auth_n0, auth_g0, &nodes, min_group_size);
-        // ... and from a group to itself, another group and a node.
+        expected_gets.send_and_expect(data_id, auth_n0, auth_s0, &nodes, min_group_size);
+        // ... and from a group to itself, another group, a section and a node...
         expected_gets.send_and_expect(data_id, auth_g0, auth_g0, &nodes, min_group_size);
         expected_gets.send_and_expect(data_id, auth_g0, auth_g1, &nodes, min_group_size);
+        expected_gets.send_and_expect(data_id, auth_g0, auth_s0, &nodes, min_group_size);
         expected_gets.send_and_expect(data_id, auth_g0, auth_n0, &nodes, min_group_size);
+        // ... and from a section to itself, another section, a group and a node...
+        expected_gets.send_and_expect(data_id, auth_s0, auth_s0, &nodes, min_group_size);
+        expected_gets.send_and_expect(data_id, auth_s0, auth_s1, &nodes, min_group_size);
+        expected_gets.send_and_expect(data_id, auth_s0, auth_g0, &nodes, min_group_size);
+        expected_gets.send_and_expect(data_id, auth_s0, auth_n0, &nodes, min_group_size);
 
         poll_and_resend(&mut nodes, &mut []);
 


### PR DESCRIPTION
Also extends the `churn` test by testing messages from and to `Section`s.