### PR TITLE
MAID-1892 MAID-1894 fix and simplify merging, fix pm::insert and enable tests

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -1013,6 +1013,8 @@ impl PeerManager {
         for name in remove_names {
             let _ = self.peer_map.remove_by_name(&name);
         }
+
+        self.expected_peers.clear();
     }
 }
 

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -222,11 +222,10 @@ impl PeerMap {
     }
 
     fn insert(&mut self, peer: Peer) -> Option<Peer> {
-        if let Some(peer_id) = peer.peer_id {
-            let _ = self.names.insert(peer_id, *peer.name());
-        }
-
-        self.peers.insert(*peer.name(), peer)
+        let old_peer = peer.peer_id
+            .and_then(|peer_id| self.names.insert(peer_id, *peer.name()))
+            .and_then(|old_name| self.peers.remove(&old_name));
+        self.peers.insert(*peer.name(), peer).or(old_peer)
     }
 
     fn remove(&mut self, peer_id: &PeerId) -> Option<Peer> {

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -159,11 +159,6 @@ impl Network {
                         node_expected.extend(group.1.iter().filter(|name| !target_node.has(name)));
                     }
                     match target_node.merge_own_group(merge_own_details.clone()) {
-                        OwnMergeState::Initialised { merge_details } => {
-                            Network::store_merge_info(&mut merge_own_info,
-                                                      *target_node.our_group_prefix(),
-                                                      merge_details);
-                        }
                         OwnMergeState::Ongoing |
                         OwnMergeState::AlreadyMerged => (),
                         OwnMergeState::Completed { targets, merge_details } => {

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1337,9 +1337,6 @@ impl Node {
         let (merge_state, needed_peers) = self.peer_mgr
             .merge_own_group(sender_prefix, merge_prefix, groups);
         match merge_state {
-            OwnMergeState::Initialised { merge_details } => {
-                self.send_own_group_merge(merge_details)
-            }
             OwnMergeState::Ongoing |
             OwnMergeState::AlreadyMerged => (),
             OwnMergeState::Completed { targets, merge_details } => {
@@ -1421,6 +1418,7 @@ impl Node {
                 debug!("{:?} Disconnecting from timed out peer {:?}", self, peer_id);
                 let _ = self.crust_service.disconnect(peer_id);
             }
+            self.merge_if_necessary();
 
             return true;
         }
@@ -2021,6 +2019,7 @@ impl Node {
         self.peer_mgr.remove_connecting_peers();
         self.routing_msg_filter.clear();
         self.sent_network_name_to = None;
+        self.merge_if_necessary();
     }
 
     pub fn set_next_node_name(&mut self, relocation_name: Option<XorName>) {

--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -193,12 +193,5 @@ fn churn() {
 
         expected_gets.verify(&nodes);
         verify_invariant_for_all_nodes(&nodes);
-
-        // Every few iterations, clear the nodes' caches, simulating a longer time between events.
-        if rng.gen_weighted_bool(5) {
-            for node in &mut nodes {
-                node.inner.clear_state();
-            }
-        }
     }
 }

--- a/tests/mock_crust/merge.rs
+++ b/tests/mock_crust/merge.rs
@@ -84,13 +84,11 @@ fn merge_four_unbalanced_groups_into_one() {
 }
 
 #[test]
-#[ignore]
 fn merge_four_balanced_groups_into_one() {
     merge(vec![2, 2, 2, 2])
 }
 
 #[test]
-#[ignore]
 fn merge_five_groups_into_one() {
     merge(vec![1, 3, 3, 3, 3])
 }


### PR DESCRIPTION
Don't respond to `OwnGroupMerge` messages, as there might still be
entries left in `expected_peers`. Instead, always wait until the own
group is also ready for merging, and check for merging after expected
peers time out.

Adapt the tests so that they simulate the expected peers timing out.