### PR TITLE
refactor/client: expose `crust::Config`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ version = "0.25.1"
 
 [dependencies]
 clippy = {version = "=0.0.99", optional = true}
-crust = "~0.19.0"
+#crust = "~0.20.0"
+crust = { git = "https://github.com/maidsafe/crust.git", branch = "master" }
 itertools = "~0.5.5"
 log = "~0.3.6"
 lru_time_cache = "~0.5.0"

--- a/src/action.rs
+++ b/src/action.rs
@@ -16,6 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use authority::Authority;
+use crust::Config;
 use error::InterfaceError;
 use messages::{Request, UserMessage};
 use std::collections::HashSet;
@@ -49,6 +50,7 @@ pub enum Action {
         result_tx: Sender<Option<HashSet<XorName>>>,
     },
     Name { result_tx: Sender<XorName> },
+    Config { result_tx: Sender<Config> },
     Timeout(u64),
     Terminate,
 }
@@ -69,6 +71,7 @@ impl Debug for Action {
             }
             Action::CloseGroup { .. } => write!(formatter, "Action::CloseGroup"),
             Action::Name { .. } => write!(formatter, "Action::Name"),
+            Action::Config { .. } => write!(formatter, "Action::Config"),
             Action::Timeout(token) => write!(formatter, "Action::Timeout({})", token),
             Action::Terminate => write!(formatter, "Action::Terminate"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! let (sender, _receiver) = mpsc::channel::<Event>();
 //! let full_id = FullId::new(); // Generate new keys.
-//! let _ = Client::new(sender, Some(full_id.clone())).unwrap();
+//! let _ = Client::new(sender, Some(full_id.clone()), None).unwrap();
 //!
 //! let _ = full_id.public_id().name();
 //! ```
@@ -167,6 +167,9 @@ mod tunnels;
 mod types;
 mod utils;
 mod xor_name;
+
+/// Reexports `crust::Config`
+pub type BootstrapConfig = crust::Config;
 
 /// Mock crust
 #[cfg(feature = "use-mock-crust")]

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -25,6 +25,8 @@ use std::rc::Rc;
 
 use super::support::{self, Endpoint, Network, ServiceHandle, ServiceImpl};
 
+pub use super::support::Config;
+
 /// TCP listener port
 pub const LISTENER_PORT: u16 = 5485;
 
@@ -35,6 +37,14 @@ impl Service {
     /// Create new mock `Service` using the make_current/get_current mechanism to
     /// get the associated `ServiceHandle`.
     pub fn new(event_sender: CrustEventSender) -> Result<Self, CrustError> {
+        Self::with_handle(&support::get_current(), event_sender)
+    }
+
+    /// Create a new mock `Service` using the make_current/get_current mechanism to
+    /// get the associated `ServiceHandle`. Ignores configuration.
+    pub fn with_config(event_sender: CrustEventSender,
+                       _config: Config)
+                       -> Result<Self, CrustError> {
         Self::with_handle(&support::get_current(), event_sender)
     }
 
@@ -146,6 +156,11 @@ impl Service {
     /// Our `PeerId`.
     pub fn id(&self) -> PeerId {
         self.lock().peer_id
+    }
+
+    /// Returns the `Config` (which is unused anyway).
+    pub fn config(&self) -> Config {
+        Config::new()
     }
 
     fn lock(&self) -> RefMut<ServiceImpl> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -135,7 +135,8 @@ impl NodeBuilder {
                                                                 full_id,
                                                                 timer))
             }
-        })
+        },
+                          None)
     }
 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use action::Action;
-use crust::{CrustEventSender, PeerId, Service};
+use crust::{Config, CrustEventSender, PeerId, Service};
 use crust::Event as CrustEvent;
 use id::PublicId;
 use maidsafe_utilities::event_sender::MaidSafeEventCategory;
@@ -146,7 +146,7 @@ pub enum Transition {
 impl StateMachine {
     // Construct a new StateMachine by passing a function returning the initial
     // state.
-    pub fn new<F>(init_state: F) -> (RoutingActionSender, Self)
+    pub fn new<F>(init_state: F, config: Option<Config>) -> (RoutingActionSender, Self)
         where F: FnOnce(Service, Timer) -> State
     {
         let (category_tx, category_rx) = mpsc::channel();
@@ -160,7 +160,11 @@ impl StateMachine {
         let crust_sender =
             CrustEventSender::new(crust_tx, MaidSafeEventCategory::Crust, category_tx);
 
-        let mut crust_service = match Service::new(crust_sender) {
+        let crust_service = match config {
+            Some(c) => Service::with_config(crust_sender, c),
+            None => Service::new(crust_sender),
+        };
+        let mut crust_service = match crust_service {
             Ok(service) => service,
             Err(error) => panic!("Unable to start crust::Service {:?}", error),
         };
@@ -183,6 +187,17 @@ impl StateMachine {
         };
 
         (action_sender, machine)
+    }
+
+    /// Returns the `crust::Config` associated with the `Service` (if any).
+    #[cfg(feature = "use-mock-crust")]
+    pub fn bootstrap_config(&self) -> Option<Config> {
+        match self.state {
+            State::Bootstrapping(ref s) => Some(s.config()),
+            State::Client(ref s) => Some(s.config()),
+            State::Node(ref s) => Some(s.config()),
+            State::Terminated => None,
+        }
     }
 
     fn handle_event(&mut self, category: MaidSafeEventCategory) {

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -18,6 +18,8 @@
 use action::Action;
 use cache::Cache;
 use crust::{PeerId, Service};
+#[cfg(feature = "use-mock-crust")]
+use crust::Config;
 use crust::Event as CrustEvent;
 use error::RoutingError;
 use event::Event;
@@ -89,6 +91,9 @@ impl Bootstrapping {
             Action::Name { result_tx } => {
                 let _ = result_tx.send(*self.name());
             }
+            Action::Config { result_tx } => {
+                let _ = result_tx.send(self.crust_service.config());
+            }
             Action::Timeout(token) => self.handle_timeout(token),
             Action::Terminate => {
                 return Transition::Terminate;
@@ -149,6 +154,11 @@ impl Bootstrapping {
 
     pub fn client_restriction(&self) -> bool {
         self.client_restriction
+    }
+
+    #[cfg(feature = "use-mock-crust")]
+    pub fn config(&self) -> Config {
+        self.crust_service.config()
     }
 
     fn handle_timeout(&mut self, token: u64) {

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -19,6 +19,8 @@ use ack_manager::{Ack, AckManager};
 use action::Action;
 use authority::Authority;
 use crust::{PeerId, Service};
+#[cfg(feature = "use-mock-crust")]
+use crust::Config;
 use crust::Event as CrustEvent;
 use error::{InterfaceError, RoutingError};
 use event::Event;
@@ -109,6 +111,9 @@ impl Client {
             Action::Name { result_tx } => {
                 let _ = result_tx.send(*self.name());
             }
+            Action::Config { result_tx } => {
+                let _ = result_tx.send(self.crust_service.config());
+            }
             Action::Timeout(token) => self.handle_timeout(token),
             Action::Terminate => {
                 return Transition::Terminate;
@@ -127,6 +132,11 @@ impl Client {
                 Transition::Stay
             }
         }
+    }
+
+    #[cfg(feature = "use-mock-crust")]
+    pub fn config(&self) -> Config {
+        self.crust_service.config()
     }
 
     fn handle_ack_response(&mut self, ack: Ack) -> Transition {

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -21,6 +21,8 @@ use authority::Authority;
 use cache::Cache;
 use crust::{ConnectionInfoResult, CrustError, PeerId, PrivConnectionInfo, PubConnectionInfo,
             Service};
+#[cfg(feature = "use-mock-crust")]
+use crust::Config;
 use crust::Event as CrustEvent;
 use error::{InterfaceError, RoutingError};
 use event::Event;
@@ -232,6 +234,9 @@ impl Node {
             Action::Name { result_tx } => {
                 let _ = result_tx.send(*self.name());
             }
+            Action::Config { result_tx } => {
+                let _ = result_tx.send(self.crust_service.config());
+            }
             Action::Timeout(token) => {
                 if !self.handle_timeout(token) {
                     return Transition::Terminate;
@@ -292,6 +297,11 @@ impl Node {
         self.handle_routing_messages();
         self.update_stats();
         Transition::Stay
+    }
+
+    #[cfg(feature = "use-mock-crust")]
+    pub fn config(&self) -> Config {
+        self.crust_service.config()
     }
 
     fn handle_routing_messages(&mut self) {

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -144,7 +144,7 @@ impl TestClient {
         TestClient {
             index: index,
             full_id: full_id.clone(),
-            client: unwrap!(Client::new(sender, Some(full_id))),
+            client: unwrap!(Client::new(sender, Some(full_id)), None),
             _thread_joiner: joiner,
         }
     }

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -195,7 +195,7 @@ impl TestClient {
         let full_id = FullId::new();
         let handle = network.new_service_handle(config, endpoint);
         let client = mock_crust::make_current(&handle,
-                                              || unwrap!(Client::new(event_tx, Some(full_id))));
+                                              || unwrap!(Client::new(event_tx, Some(full_id), None)));
 
         TestClient {
             handle: handle,


### PR DESCRIPTION
**WARNING**: This PR needs this other one first: https://github.com/maidsafe/crust/pull/807

And then I need to change `Cargo.toml` to use upstream `crust` again