### PR TITLE
MAID-1908 perform missed splits on SectionUpdates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
 language: rust
 rust:
   - stable
-  - nightly-2016-11-17
+  - nightly-2016-12-19
 sudo: false
 cache:
   cargo: true
@@ -23,7 +23,7 @@ before_script:
   - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
       (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt;
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      clippy_vers=0.0.99;
+      clippy_vers=0.0.104;
       if ! cargo clippy --version | grep -q $clippy_vers; then
         cargo install clippy --vers=$clippy_vers --force;
       fi
@@ -40,7 +40,7 @@ script:
         cargo test  --verbose --features use-mock-crust
       );
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-       cargo clippy;
+      cargo clippy -- -D clippy;
     fi
 before_cache:
  - cargo prune

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -127,17 +127,21 @@ fn multiple_joining_nodes() {
     let mut nodes = create_connected_nodes(&network, min_group_size);
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
 
-    // Try adding three nodes at once, to the same section. This makes sure one section can handle
-    // this (probably by rejecting some of the nodes).
-    nodes.push(TestNode::builder(&network).config(config.clone()).create());
-    nodes.push(TestNode::builder(&network).config(config.clone()).create());
-    nodes.push(TestNode::builder(&network).config(config.clone()).create());
+    while nodes.len() < 40 {
+        info!("Size {}", nodes.len());
 
-    let _ = poll_all(&mut nodes, &mut []);
-    nodes.retain(|node| !node.routing_table().is_empty());
-    let _ = poll_all(&mut nodes, &mut []);
+        // Try adding five nodes at once, possibly to the same section. This makes sure one section
+        // can handle this, either by adding the nodes in sequence or by rejecting some.
+        for _ in 0..5 {
+            nodes.push(TestNode::builder(&network).config(config.clone()).create());
+        }
 
-    verify_invariant_for_all_nodes(&nodes);
+        poll_and_resend(&mut nodes, &mut []);
+        nodes.retain(|node| !node.routing_table().is_empty());
+        poll_and_resend(&mut nodes, &mut []);
+
+        verify_invariant_for_all_nodes(&nodes);
+    }
 }
 
 #[test]


### PR DESCRIPTION
A joining node could miss a split event in a neighbouring section if it
happens between the `GetNodeNameResponse` and the first connection.