### PR TITLE
MAID-1923: refactor/examples: allow examples to compile with 'use-mock-crust' enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,11 @@ script:
         cargo test  --verbose --features use-mock-crust
       );
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      cargo clippy -- -D clippy;
+      (
+        set -x;
+        cargo clippy &&
+        cargo clippy --features=use-mock-crust
+      );
     fi
 before_cache:
  - cargo prune

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -34,8 +34,7 @@
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations, variant_size_differences)]
 
-
-#![cfg(not(feature = "use-mock-crust"))]
+#![cfg_attr(feature = "use-mock-crust", allow(unused_extern_crates))]
 
 #[macro_use]
 extern crate log;
@@ -52,20 +51,31 @@ extern crate lru_time_cache;
 
 mod utils;
 
-use docopt::Docopt;
-use maidsafe_utilities::serialisation::{deserialise, serialise};
-use maidsafe_utilities::thread::{self, Joiner};
-use routing::{Data, DataIdentifier, StructuredData, XorName};
-use rust_sodium::crypto;
-use std::collections::BTreeSet;
-use std::io::{self, Write};
-use std::sync::mpsc;
-use std::sync::mpsc::{Receiver, Sender};
-use utils::{ExampleClient, ExampleNode};
+#[cfg(feature = "use-mock-crust")]
+fn main() {
+    println!("This example should be built without `--features=use-mock-crust`.");
+    // Return Linux sysexit code for "configuration error"
+    ::std::process::exit(78);
+}
 
-// ==========================   Program Options   =================================
-#[cfg_attr(rustfmt, rustfmt_skip)]
-static USAGE: &'static str = "
+#[cfg(not(feature = "use-mock-crust"))]
+mod unnamed {
+    use docopt::Docopt;
+    use maidsafe_utilities::log;
+    use maidsafe_utilities::serialisation::{deserialise, serialise};
+    use maidsafe_utilities::thread::{self, Joiner};
+    use routing::{Data, DataIdentifier, StructuredData, XorName};
+    use rust_sodium::crypto;
+    use std::collections::BTreeSet;
+    use std::io::{self, Write};
+    use std::sync::mpsc;
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::thread as std_thread;
+    use std::time::Duration;
+    use utils::{ExampleClient, ExampleNode};
+    // ==========================   Program Options   =================================
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    static USAGE: &'static str = "
 Usage:
   key_value_store
   key_value_store --node
@@ -87,153 +97,159 @@ Options:
   network discovery patterns to use, or which seed nodes to use.
 ";
 
-#[derive(RustcDecodable, Debug)]
-struct Args {
-    flag_first: bool,
-    flag_node: bool,
-    flag_help: bool,
-}
-
-#[derive(PartialEq, Eq, Debug, Clone)]
-enum UserCommand {
-    Exit,
-    Get(String),
-    Put(String, String),
-}
-
-fn read_user_commands(command_sender: Sender<UserCommand>) {
-    loop {
-        let mut command = String::new();
-        let stdin = io::stdin();
-
-        print!("Enter command (exit | put <key> <value> | get <key>)\n> ");
-        let _ = io::stdout().flush();
-        let _ = stdin.read_line(&mut command);
-
-        let parts = command.trim_right_matches(|c| c == '\r' || c == '\n')
-            .split(' ')
-            .collect::<Vec<_>>();
-
-        if parts.len() == 1 && parts[0] == "exit" {
-            let _ = command_sender.send(UserCommand::Exit);
-            return;
-        } else if parts.len() == 2 && parts[0] == "get" {
-            let _ = command_sender.send(UserCommand::Get(parts[1].to_string()));
-        } else if parts.len() == 3 && parts[0] == "put" {
-            let _ =
-                command_sender.send(UserCommand::Put(parts[1].to_string(), parts[2].to_string()));
-        } else {
-            println!("Unrecognised command");
-        }
-    }
-}
-
-struct KeyValueStore {
-    example_client: ExampleClient,
-    command_receiver: Receiver<UserCommand>,
-    exit: bool,
-    _joiner: Joiner,
-}
-
-impl KeyValueStore {
-    fn new() -> KeyValueStore {
-        let example_client = ExampleClient::new();
-        let (command_sender, command_receiver) = mpsc::channel::<UserCommand>();
-        KeyValueStore {
-            example_client: example_client,
-            command_receiver: command_receiver,
-            exit: false,
-            _joiner: thread::named("Command reader", move || read_user_commands(command_sender)),
-        }
+    #[derive(RustcDecodable, Debug)]
+    struct Args {
+        flag_first: bool,
+        flag_node: bool,
+        flag_help: bool,
     }
 
-    fn run(&mut self) {
-        // Need to do poll as Select is not yet stable in the current rust implementation.
+    #[derive(PartialEq, Eq, Debug, Clone)]
+    enum UserCommand {
+        Exit,
+        Get(String),
+        Put(String, String),
+    }
+
+    fn read_user_commands(command_sender: Sender<UserCommand>) {
         loop {
-            while let Ok(command) = self.command_receiver.try_recv() {
-                self.handle_user_command(command);
-            }
+            let mut command = String::new();
+            let stdin = io::stdin();
 
-            if self.exit {
-                break;
-            }
+            print!("Enter command (exit | put <key> <value> | get <key>)\n> ");
+            let _ = io::stdout().flush();
+            let _ = stdin.read_line(&mut command);
 
-            let interval = std::time::Duration::from_millis(10);
-            std::thread::sleep(interval);
-        }
-    }
+            let parts = command.trim_right_matches(|c| c == '\r' || c == '\n')
+                .split(' ')
+                .collect::<Vec<_>>();
 
-    fn handle_user_command(&mut self, cmd: UserCommand) {
-        match cmd {
-            UserCommand::Exit => {
-                self.exit = true;
-            }
-            UserCommand::Get(what) => {
-                self.get(what);
-            }
-            UserCommand::Put(put_where, put_what) => {
-                self.put(put_where, put_what);
+            if parts.len() == 1 && parts[0] == "exit" {
+                let _ = command_sender.send(UserCommand::Exit);
+                return;
+            } else if parts.len() == 2 && parts[0] == "get" {
+                let _ = command_sender.send(UserCommand::Get(parts[1].to_string()));
+            } else if parts.len() == 3 && parts[0] == "put" {
+                let _ =
+                command_sender.send(UserCommand::Put(parts[1].to_string(), parts[2].to_string()));
+            } else {
+                println!("Unrecognised command");
             }
         }
     }
 
-    /// Get data from the network.
-    pub fn get(&mut self, what: String) {
-        let name = KeyValueStore::calculate_key_name(&what);
-        let data = self.example_client.get(DataIdentifier::Structured(name, 10000));
-        match data {
-            Some(data) => {
-                let sd = if let Data::Structured(sd) = data {
-                    sd
-                } else {
-                    error!("KeyValueStore: Only storing structured data in this example");
-                    return;
-                };
-                if let Ok((key, value)) = deserialise::<(String, String)>(sd.get_data()) {
-                    println!("Got value {:?} on key {:?}", value, key);
-                } else {
-                    error!("Failed to decode get response.");
-                    return;
-                };
+    struct KeyValueStore {
+        example_client: ExampleClient,
+        command_receiver: Receiver<UserCommand>,
+        exit: bool,
+        _joiner: Joiner,
+    }
+
+    impl KeyValueStore {
+        fn new() -> KeyValueStore {
+            let example_client = ExampleClient::new();
+            let (command_sender, command_receiver) = mpsc::channel::<UserCommand>();
+            KeyValueStore {
+                example_client: example_client,
+                command_receiver: command_receiver,
+                exit: false,
+                _joiner: thread::named("Command reader",
+                                       move || read_user_commands(command_sender)),
             }
-            None => println!("Failed to get {:?}", what),
+        }
+
+        fn run(&mut self) {
+            // Need to do poll as Select is not yet stable in the current rust implementation.
+            loop {
+                while let Ok(command) = self.command_receiver.try_recv() {
+                    self.handle_user_command(command);
+                }
+
+                if self.exit {
+                    break;
+                }
+
+                let interval = Duration::from_millis(10);
+                std_thread::sleep(interval);
+            }
+        }
+
+        fn handle_user_command(&mut self, cmd: UserCommand) {
+            match cmd {
+                UserCommand::Exit => {
+                    self.exit = true;
+                }
+                UserCommand::Get(what) => {
+                    self.get(what);
+                }
+                UserCommand::Put(put_where, put_what) => {
+                    self.put(put_where, put_what);
+                }
+            }
+        }
+
+        /// Get data from the network.
+        pub fn get(&mut self, what: String) {
+            let name = KeyValueStore::calculate_key_name(&what);
+            let data = self.example_client.get(DataIdentifier::Structured(name, 10000));
+            match data {
+                Some(data) => {
+                    let sd = if let Data::Structured(sd) = data {
+                        sd
+                    } else {
+                        error!("KeyValueStore: Only storing structured data in this example");
+                        return;
+                    };
+                    if let Ok((key, value)) = deserialise::<(String, String)>(sd.get_data()) {
+                        println!("Got value {:?} on key {:?}", value, key);
+                    } else {
+                        error!("Failed to decode get response.");
+                        return;
+                    };
+                }
+                None => println!("Failed to get {:?}", what),
+            }
+        }
+
+        /// Put data onto the network.
+        pub fn put(&self, put_where: String, put_what: String) {
+            let name = KeyValueStore::calculate_key_name(&put_where);
+            let data = unwrap!(serialise(&(put_where, put_what)));
+            let sd = unwrap!(StructuredData::new(10000, name, 0, data, BTreeSet::new()));
+            if self.example_client.put(Data::Structured(sd)).is_err() {
+                error!("Failed to put data.");
+            }
+        }
+
+        fn calculate_key_name(key: &str) -> XorName {
+            XorName(crypto::hash::sha256::hash(key.as_bytes()).0)
         }
     }
 
-    /// Put data onto the network.
-    pub fn put(&self, put_where: String, put_what: String) {
-        let name = KeyValueStore::calculate_key_name(&put_where);
-        let data = unwrap!(serialise(&(put_where, put_what)));
-        let sd = unwrap!(StructuredData::new(10000, name, 0, data, BTreeSet::new()));
-        if self.example_client.put(Data::Structured(sd)).is_err() {
-            error!("Failed to put data.");
+    impl Default for KeyValueStore {
+        fn default() -> KeyValueStore {
+            KeyValueStore::new()
         }
     }
 
-    fn calculate_key_name(key: &str) -> XorName {
-        XorName(crypto::hash::sha256::hash(key.as_bytes()).0)
+    pub fn run_main() {
+        unwrap!(log::init(false));
+
+        let args: Args = Docopt::new(USAGE)
+            .and_then(|docopt| docopt.decode())
+            .unwrap_or_else(|error| error.exit());
+
+        if args.flag_first {
+            ExampleNode::new(true).run();
+        } else if args.flag_node {
+            ExampleNode::new(false).run();
+        } else {
+            KeyValueStore::new().run();
+        }
     }
 }
 
-impl Default for KeyValueStore {
-    fn default() -> KeyValueStore {
-        KeyValueStore::new()
-    }
-}
-
-/// /////////////////////////////////////////////////////////////////////////////
+#[cfg(not(feature = "use-mock-crust"))]
 fn main() {
-    unwrap!(maidsafe_utilities::log::init(false));
-
-    let args: Args = Docopt::new(USAGE)
-        .and_then(|docopt| docopt.decode())
-        .unwrap_or_else(|error| error.exit());
-
-    if args.flag_first {
-        ExampleNode::new(true).run();
-    } else if args.flag_node {
-        ExampleNode::new(false).run();
-    } else {
-        KeyValueStore::new().run();
-    }
+    unnamed::run_main()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations, variant_size_differences)]
 
-#![cfg_attr(feature="cargo-clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
+#![cfg_attr(feature="cargo-clippy", deny(unicode_not_nfc, wrong_pub_self_convention,
                                     option_unwrap_used))]
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
The examples will now build with 'use-mock-crust' enabled, but when run will print a warning and
return an error code.  Also, clippy with 'use-mock-crust' is now enabled in the Travis script.