### PR TITLE
Fix blocking behaviour of next_ev and propagate non-blocking errors.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -264,7 +264,7 @@ impl Client {
     }
 
     /// Step the underlying state machine if there are any events for it to process.
-    fn try_step(&self) -> Result<Vec<Event>, ()> {
+    fn try_step(&self) -> Result<Vec<Event>, TryRecvError> {
         self.machine.borrow_mut().try_step()
     }
 

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -1,20 +1,18 @@
-use std::sync::mpsc::TryRecvError;
+use std::sync::mpsc::{RecvError, TryRecvError};
 
 /// Trait to fake a channel.
 pub trait EventStream {
     /// Item produced by this stream.
     type Item;
-    /// Error type produced if something goes wrong or no items are available.
-    type Error;
 
     /// Read the next available event from the stream, blocking until one becomes available.
-    fn next_ev(&mut self) -> Result<Self::Item, Self::Error>;
+    fn next_ev(&mut self) -> Result<Self::Item, RecvError>;
 
     /// Try to read the next available event from the stream without blocking.
     ///
     /// Implementations should return an error if there are no items available, OR
     /// a real error occurs.
-    fn try_next_ev(&mut self) -> Result<Self::Item, Self::Error>;
+    fn try_next_ev(&mut self) -> Result<Self::Item, TryRecvError>;
 
     /// Process events, storing them on the internal buffer.
     ///
@@ -26,12 +24,11 @@ pub trait EventStream {
 pub trait EventStepper {
     type Item;
 
-    /// Produce multiple events and return them, or Err(()) if something goes wrong.
-    /// TODO: propagate actual errors better.
-    fn produce_events(&mut self) -> Result<Vec<Self::Item>, ()>;
+    /// Produce multiple events and return them, or a `RecvError` if something goes wrong.
+    fn produce_events(&mut self) -> Result<Vec<Self::Item>, RecvError>;
 
-    // As for produce_events but non-blocking.
-    fn try_produce_events(&mut self) -> Result<Vec<Self::Item>, ()>;
+    // Produce multiple events in a non-blocking fashion.
+    fn try_produce_events(&mut self) -> Result<Vec<Self::Item>, TryRecvError>;
 
     /// Pop an item from this type's internal buffer.
     fn pop_item(&mut self) -> Option<Self::Item>;
@@ -45,26 +42,34 @@ impl<S> EventStream for S
     where S: EventStepper
 {
     type Item = <S as EventStepper>::Item;
-    type Error = TryRecvError;
 
-    fn next_ev(&mut self) -> Result<Self::Item, Self::Error> {
+    fn next_ev(&mut self) -> Result<Self::Item, RecvError> {
         if let Some(cached_ev) = self.pop_item() {
             return Ok(cached_ev);
         }
-        if let Ok(new_events) = self.produce_events() {
-            self.buffer_items(new_events);
+        match self.produce_events() {
+            Ok(new_events) => {
+                self.buffer_items(new_events);
+                // Recursing here either returns one of the buffered events we just added,
+                // or in the case where `new_events` was empty, causes us to block again waiting
+                // on `produce_events`.
+                self.next_ev()
+            }
+            Err(RecvError) => Err(RecvError),
         }
-        self.pop_item().ok_or(TryRecvError::Disconnected)
     }
 
-    fn try_next_ev(&mut self) -> Result<Self::Item, Self::Error> {
+    fn try_next_ev(&mut self) -> Result<Self::Item, TryRecvError> {
         if let Some(cached_ev) = self.pop_item() {
             return Ok(cached_ev);
         }
-        if let Ok(new_events) = self.try_produce_events() {
-            self.buffer_items(new_events);
+        match self.try_produce_events() {
+            Ok(new_events) => {
+                self.buffer_items(new_events);
+                self.pop_item().ok_or(TryRecvError::Empty)
+            }
+            Err(err) => Err(err),
         }
-        self.pop_item().ok_or(TryRecvError::Empty)
     }
 
     fn poll(&mut self) -> bool {

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,7 +41,7 @@ use std::collections::BTreeMap;
 use std::collections::VecDeque;
 #[cfg(feature = "use-mock-crust")]
 use std::fmt::{self, Debug, Formatter};
-use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvError, Sender, TryRecvError, channel};
 use types::{MessageId, RoutingActionSender};
 use xor_name::XorName;
 
@@ -432,11 +432,11 @@ impl Node {
 impl EventStepper for Node {
     type Item = Event;
 
-    fn produce_events(&mut self) -> Result<Vec<Event>, ()> {
+    fn produce_events(&mut self) -> Result<Vec<Event>, RecvError> {
         self.machine.step()
     }
 
-    fn try_produce_events(&mut self) -> Result<Vec<Event>, ()> {
+    fn try_produce_events(&mut self) -> Result<Vec<Event>, TryRecvError> {
         self.machine.try_step()
     }
 

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -25,7 +25,7 @@ use std::{cmp, thread};
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
-use std::sync::mpsc::TryRecvError;
+use std::sync::mpsc::{RecvError, TryRecvError};
 
 // Various utilities. Since this is all internal stuff we're a bit lax about the doc.
 #[allow(missing_docs)]
@@ -91,9 +91,8 @@ impl DerefMut for Nodes {
 
 impl EventStream for TestNode {
     type Item = Event;
-    type Error = TryRecvError;
 
-    fn next_ev(&mut self) -> Result<Event, TryRecvError> {
+    fn next_ev(&mut self) -> Result<Event, RecvError> {
         self.inner.next_ev()
     }
 


### PR DESCRIPTION
This ensures that calling `next_ev` will continually block and process all
events, necessary for, e.g. `run` in safe_vault.

Additionally, using the mpsc error types allows users of `try_next_ev` to determine
if an error was returned because there were no events available, or because of a permanent failure.

This change (mainly the first part) is necessary for my refactor of `safe_vault`