### PR TITLE
Add RT request/response messages.

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -608,38 +608,31 @@ impl MessageContent {
 
 impl Debug for DirectMessage {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        use self::DirectMessage::*;
         match *self {
-            DirectMessage::MessageSignature(ref digest, _) => {
+            MessageSignature(ref digest, _) => {
                 write!(formatter,
                        "MessageSignature ({}, ..)",
                        utils::format_binary_array(&digest.0))
             }
-            DirectMessage::SectionListSignature(ref prefix, _, _) => {
+            SectionListSignature(ref prefix, _, _) => {
                 write!(formatter, "SectionListSignature({:?}, ..)", prefix)
             }
-            DirectMessage::BootstrapIdentify { ref public_id } => {
+            BootstrapIdentify { ref public_id } => {
                 write!(formatter, "BootstrapIdentify {{ {:?} }}", public_id)
             }
-            DirectMessage::BootstrapDeny => write!(formatter, "BootstrapDeny"),
-            DirectMessage::ClientIdentify { client_restriction: true, .. } => {
+            BootstrapDeny => write!(formatter, "BootstrapDeny"),
+            ClientIdentify { client_restriction: true, .. } => {
                 write!(formatter, "ClientIdentify (client only)")
             }
-            DirectMessage::ClientIdentify { client_restriction: false, .. } => {
+            ClientIdentify { client_restriction: false, .. } => {
                 write!(formatter, "ClientIdentify (joining node)")
             }
-            DirectMessage::NodeIdentify { .. } => write!(formatter, "NodeIdentify {{ .. }}"),
-            DirectMessage::TunnelRequest(peer_id) => {
-                write!(formatter, "TunnelRequest({:?})", peer_id)
-            }
-            DirectMessage::TunnelSuccess(peer_id) => {
-                write!(formatter, "TunnelSuccess({:?})", peer_id)
-            }
-            DirectMessage::TunnelClosed(peer_id) => {
-                write!(formatter, "TunnelClosed({:?})", peer_id)
-            }
-            DirectMessage::TunnelDisconnect(peer_id) => {
-                write!(formatter, "TunnelDisconnect({:?})", peer_id)
-            }
+            NodeIdentify { .. } => write!(formatter, "NodeIdentify {{ .. }}"),
+            TunnelRequest(peer_id) => write!(formatter, "TunnelRequest({:?})", peer_id),
+            TunnelSuccess(peer_id) => write!(formatter, "TunnelSuccess({:?})", peer_id),
+            TunnelClosed(peer_id) => write!(formatter, "TunnelClosed({:?})", peer_id),
+            TunnelDisconnect(peer_id) => write!(formatter, "TunnelDisconnect({:?})", peer_id),
         }
     }
 }
@@ -665,82 +658,74 @@ impl Debug for SignedMessage {
 
 impl Debug for MessageContent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        use self::MessageContent::*;
         match *self {
-            MessageContent::GetNodeName { ref current_id, ref message_id } => {
+            GetNodeName { ref current_id, ref message_id } => {
                 write!(formatter,
                        "GetNodeName {{ {:?}, {:?} }}",
                        current_id,
                        message_id)
             }
-            MessageContent::ExpectCloseNode { ref expect_id, ref client_auth, ref message_id } => {
+            ExpectCloseNode { ref expect_id, ref client_auth, ref message_id } => {
                 write!(formatter,
                        "ExpectCloseNode {{ {:?}, {:?}, {:?} }}",
                        expect_id,
                        client_auth,
                        message_id)
             }
-            MessageContent::ConnectionInfoRequest { ref pub_id, ref msg_id, .. } => {
+            ConnectionInfoRequest { ref pub_id, ref msg_id, .. } => {
                 write!(formatter,
                        "ConnectionInfoRequest {{ {:?}, {:?}, .. }}",
                        pub_id,
                        msg_id)
             }
-            MessageContent::ConnectionInfoResponse { ref pub_id, ref msg_id, .. } => {
+            ConnectionInfoResponse { ref pub_id, ref msg_id, .. } => {
                 write!(formatter,
                        "ConnectionInfoResponse {{ {:?}, {:?}, .. }}",
                        pub_id,
                        msg_id)
             }
-            MessageContent::GetNodeNameResponse { ref relocated_id,
-                                                  ref sections,
-                                                  ref message_id } => {
+            GetNodeNameResponse { ref relocated_id, ref sections, ref message_id } => {
                 write!(formatter,
                        "GetNodeNameResponse {{ {:?}, {:?}, {:?} }}",
                        relocated_id,
                        sections,
                        message_id)
             }
-            MessageContent::SectionUpdate { ref prefix, ref members } => {
+            SectionUpdate { ref prefix, ref members } => {
                 write!(formatter, "SectionUpdate {{ {:?}, {:?} }}", prefix, members)
             }
-            MessageContent::RoutingTableRequest(ref msg_id, ref digest) => {
+            RoutingTableRequest(ref msg_id, ref digest) => {
                 write!(formatter,
                        "RoutingTableRequest({:?}, {})",
                        msg_id,
                        utils::format_binary_array(&digest.0))
             }
-            MessageContent::RoutingTableResponse { ref prefix, ref members, ref message_id } => {
+            RoutingTableResponse { ref prefix, ref members, ref message_id } => {
                 write!(formatter,
                        "RoutingTableResponse {{ {:?}, {:?}, {:?} }}",
                        prefix,
                        members,
                        message_id)
             }
-            MessageContent::SectionSplit(ref prefix, ref joining_node) => {
+            SectionSplit(ref prefix, ref joining_node) => {
                 write!(formatter, "SectionSplit({:?}, {:?})", prefix, joining_node)
             }
-            MessageContent::OwnSectionMerge { ref sender_prefix,
-                                              ref merge_prefix,
-                                              ref sections } => {
+            OwnSectionMerge { ref sender_prefix, ref merge_prefix, ref sections } => {
                 write!(formatter,
                        "OwnSectionMerge {{ {:?}, {:?}, {:?} }}",
                        sender_prefix,
                        merge_prefix,
                        sections)
             }
-            MessageContent::OtherSectionMerge { ref prefix, ref section } => {
+            OtherSectionMerge { ref prefix, ref section } => {
                 write!(formatter,
                        "OtherSectionMerge {{ {:?}, {:?} }}",
                        prefix,
                        section)
             }
-            MessageContent::Ack(ack, priority) => write!(formatter, "Ack({}, {})", ack, priority),
-            MessageContent::UserMessagePart { hash,
-                                              part_count,
-                                              part_index,
-                                              priority,
-                                              cacheable,
-                                              .. } => {
+            Ack(ack, priority) => write!(formatter, "Ack({}, {})", ack, priority),
+            UserMessagePart { hash, part_count, part_index, priority, cacheable, .. } => {
                 write!(formatter,
                        "UserMessagePart {{ {}/{}, priority: {}, cacheable: {}, {:x} }}",
                        part_index + 1,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -549,7 +549,7 @@ pub enum MessageContent {
         members: Vec<PublicId>,
     },
     /// Sent from a node to its own section to request their current routing table.
-    RoutingTableRequest(MessageId),
+    RoutingTableRequest(MessageId, sha256::Digest),
     /// Sent from a section to a node to update it about its prefix and its member list.
     RoutingTableResponse {
         /// The section's current prefix.
@@ -702,8 +702,11 @@ impl Debug for MessageContent {
             MessageContent::SectionUpdate { ref prefix, ref members } => {
                 write!(formatter, "SectionUpdate {{ {:?}, {:?} }}", prefix, members)
             }
-            MessageContent::RoutingTableRequest(ref msg_id) => {
-                write!(formatter, "RoutingTableRequest({:?})", msg_id)
+            MessageContent::RoutingTableRequest(ref msg_id, ref digest) => {
+                write!(formatter,
+                       "RoutingTableRequest({:?}, {})",
+                       msg_id,
+                       utils::format_binary_array(&digest.0))
             }
             MessageContent::RoutingTableResponse { ref prefix, ref members, ref message_id } => {
                 write!(formatter,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -548,6 +548,17 @@ pub enum MessageContent {
         /// Members of the section
         members: Vec<PublicId>,
     },
+    /// Sent from a node to its own section to request their current routing table.
+    RoutingTableRequest(MessageId),
+    /// Sent from a section to a node to update it about its prefix and its member list.
+    RoutingTableResponse {
+        /// The section's current prefix.
+        prefix: Prefix<XorName>,
+        /// Members of the section.
+        members: BTreeSet<PublicId>,
+        /// The message's unique identifier.
+        message_id: MessageId,
+    },
     /// Sent to all connected peers when our own section splits
     SectionSplit(Prefix<XorName>, XorName),
     /// Sent amongst members of a newly-merged section to allow synchronisation of their routing
@@ -690,6 +701,16 @@ impl Debug for MessageContent {
             }
             MessageContent::SectionUpdate { ref prefix, ref members } => {
                 write!(formatter, "SectionUpdate {{ {:?}, {:?} }}", prefix, members)
+            }
+            MessageContent::RoutingTableRequest(ref msg_id) => {
+                write!(formatter, "RoutingTableRequest({:?})", msg_id)
+            }
+            MessageContent::RoutingTableResponse { ref prefix, ref members, ref message_id } => {
+                write!(formatter,
+                       "RoutingTableResponse {{ {:?}, {:?}, {:?} }}",
+                       prefix,
+                       members,
+                       message_id)
             }
             MessageContent::SectionSplit(ref prefix, ref joining_node) => {
                 write!(formatter, "SectionSplit({:?}, {:?})", prefix, joining_node)

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -28,6 +28,7 @@ use maidsafe_utilities;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 #[cfg(feature = "use-mock-crust")]
 use mock_crust::crust::PeerId;
+use peer_manager::SectionMap;
 use routing_table::{Prefix, Xorable};
 use routing_table::Authority;
 use rust_sodium::crypto::{box_, sign};
@@ -535,7 +536,7 @@ pub enum MessageContent {
         relocated_id: PublicId,
         /// The routing table shared by the nodes in our section, including the `PublicId`s of our
         /// contacts.
-        sections: Vec<(Prefix<XorName>, Vec<PublicId>)>,
+        sections: SectionMap,
         /// The message's unique identifier.
         message_id: MessageId,
     },
@@ -566,7 +567,7 @@ pub enum MessageContent {
     OwnSectionMerge {
         sender_prefix: Prefix<XorName>,
         merge_prefix: Prefix<XorName>,
-        sections: Vec<(Prefix<XorName>, Vec<PublicId>)>,
+        sections: SectionMap,
     },
     /// Sent by members of a newly-merged section to peers outwith the merged section to notify them
     /// of the merge.

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -550,7 +550,11 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
             let (dropped_nodes, _opt_our_pfx) = self.split(shorter_pfx);
             result.extend(dropped_nodes);
         }
-        // Merge if necessary, then add empty sections to satisfy the invariant.
+        // Merge if necessary, then add empty sections to satisfy the requirement that for each
+        // `i`, the own prefix with the `i`-th bit flipped must be covered. To do this, split each
+        // such prefix recursively until all its parts are either covered or incompatible with the
+        // existing ones. Insert the incompatible ones to cover the required part of the name
+        // space.
         if self.our_prefix.is_neighbour(&prefix) || self.our_prefix.is_compatible(&prefix) {
             self.merge(&prefix);
             let mut missing_pfxs = (0..self.our_prefix.bit_count())

--- a/src/routing_table/prefix.rs
+++ b/src/routing_table/prefix.rs
@@ -209,13 +209,9 @@ impl<T: Clone + Copy + Default + Binary + Xorable> Debug for Prefix<T> {
     }
 }
 
-
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn str_to_prefix(bits: &[u8]) -> Prefix<u8> {
+impl Prefix<u8> {
+    pub fn from_str(bits: &[u8]) -> Prefix<u8> {
         let mut name = 0u8;
         for (i, bit) in bits.iter().enumerate() {
             if *bit == b'1' {
@@ -224,24 +220,32 @@ mod tests {
         }
         Prefix::new(bits.len(), name)
     }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
 
     #[test]
     fn prefix() {
-        assert_eq!(str_to_prefix(b"101").pushed(true), str_to_prefix(b"1011"));
-        assert_eq!(str_to_prefix(b"101").pushed(false), str_to_prefix(b"1010"));
-        assert_eq!(str_to_prefix(b"1011").popped(), str_to_prefix(b"101"));
-        assert!(str_to_prefix(b"101").is_compatible(&str_to_prefix(b"1010")));
-        assert!(str_to_prefix(b"1010").is_compatible(&str_to_prefix(b"101")));
-        assert!(!str_to_prefix(b"1010").is_compatible(&str_to_prefix(b"1011")));
-        assert!(str_to_prefix(b"101").is_neighbour(&str_to_prefix(b"1111")));
-        assert!(!str_to_prefix(b"1010").is_neighbour(&str_to_prefix(b"1111")));
-        assert!(str_to_prefix(b"1010").is_neighbour(&str_to_prefix(b"10111")));
-        assert!(!str_to_prefix(b"101").is_neighbour(&str_to_prefix(b"10111")));
-        assert!(str_to_prefix(b"101").matches(&0b10101100));
-        assert!(!str_to_prefix(b"1011").matches(&0b10101100));
+        assert_eq!(Prefix::from_str(b"101").pushed(true),
+                   Prefix::from_str(b"1011"));
+        assert_eq!(Prefix::from_str(b"101").pushed(false),
+                   Prefix::from_str(b"1010"));
+        assert_eq!(Prefix::from_str(b"1011").popped(), Prefix::from_str(b"101"));
+        assert!(Prefix::from_str(b"101").is_compatible(&Prefix::from_str(b"1010")));
+        assert!(Prefix::from_str(b"1010").is_compatible(&Prefix::from_str(b"101")));
+        assert!(!Prefix::from_str(b"1010").is_compatible(&Prefix::from_str(b"1011")));
+        assert!(Prefix::from_str(b"101").is_neighbour(&Prefix::from_str(b"1111")));
+        assert!(!Prefix::from_str(b"1010").is_neighbour(&Prefix::from_str(b"1111")));
+        assert!(Prefix::from_str(b"1010").is_neighbour(&Prefix::from_str(b"10111")));
+        assert!(!Prefix::from_str(b"101").is_neighbour(&Prefix::from_str(b"10111")));
+        assert!(Prefix::from_str(b"101").matches(&0b10101100));
+        assert!(!Prefix::from_str(b"1011").matches(&0b10101100));
 
-        assert_eq!(str_to_prefix(b"0101").lower_bound(), 0b01010000);
-        assert_eq!(str_to_prefix(b"0101").upper_bound(), 0b01011111);
+        assert_eq!(Prefix::from_str(b"0101").lower_bound(), 0b01010000);
+        assert_eq!(Prefix::from_str(b"0101").upper_bound(), 0b01011111);
 
         // Check we handle passing an excessive `bit_count` to `new()`.
         assert_eq!(Prefix::<u64>::new(64, 0).bit_count(), 64);

--- a/src/routing_table/prefix.rs
+++ b/src/routing_table/prefix.rs
@@ -211,11 +211,14 @@ impl<T: Clone + Copy + Default + Binary + Xorable> Debug for Prefix<T> {
 
 #[cfg(test)]
 impl Prefix<u8> {
-    pub fn from_str(bits: &[u8]) -> Prefix<u8> {
+    pub fn from_str(bits: &str) -> Prefix<u8> {
         let mut name = 0u8;
-        for (i, bit) in bits.iter().enumerate() {
-            if *bit == b'1' {
+        for (i, bit) in bits.chars().enumerate() {
+            if bit == '1' {
                 name |= 1 << (7 - i);
+            } else if bit != '0' {
+                panic!("'{}' not allowed - the string must represent a binary number.",
+                       bit);
             }
         }
         Prefix::new(bits.len(), name)
@@ -229,23 +232,23 @@ mod tests {
 
     #[test]
     fn prefix() {
-        assert_eq!(Prefix::from_str(b"101").pushed(true),
-                   Prefix::from_str(b"1011"));
-        assert_eq!(Prefix::from_str(b"101").pushed(false),
-                   Prefix::from_str(b"1010"));
-        assert_eq!(Prefix::from_str(b"1011").popped(), Prefix::from_str(b"101"));
-        assert!(Prefix::from_str(b"101").is_compatible(&Prefix::from_str(b"1010")));
-        assert!(Prefix::from_str(b"1010").is_compatible(&Prefix::from_str(b"101")));
-        assert!(!Prefix::from_str(b"1010").is_compatible(&Prefix::from_str(b"1011")));
-        assert!(Prefix::from_str(b"101").is_neighbour(&Prefix::from_str(b"1111")));
-        assert!(!Prefix::from_str(b"1010").is_neighbour(&Prefix::from_str(b"1111")));
-        assert!(Prefix::from_str(b"1010").is_neighbour(&Prefix::from_str(b"10111")));
-        assert!(!Prefix::from_str(b"101").is_neighbour(&Prefix::from_str(b"10111")));
-        assert!(Prefix::from_str(b"101").matches(&0b10101100));
-        assert!(!Prefix::from_str(b"1011").matches(&0b10101100));
+        assert_eq!(Prefix::from_str("101").pushed(true),
+                   Prefix::from_str("1011"));
+        assert_eq!(Prefix::from_str("101").pushed(false),
+                   Prefix::from_str("1010"));
+        assert_eq!(Prefix::from_str("1011").popped(), Prefix::from_str("101"));
+        assert!(Prefix::from_str("101").is_compatible(&Prefix::from_str("1010")));
+        assert!(Prefix::from_str("1010").is_compatible(&Prefix::from_str("101")));
+        assert!(!Prefix::from_str("1010").is_compatible(&Prefix::from_str("1011")));
+        assert!(Prefix::from_str("101").is_neighbour(&Prefix::from_str("1111")));
+        assert!(!Prefix::from_str("1010").is_neighbour(&Prefix::from_str("1111")));
+        assert!(Prefix::from_str("1010").is_neighbour(&Prefix::from_str("10111")));
+        assert!(!Prefix::from_str("101").is_neighbour(&Prefix::from_str("10111")));
+        assert!(Prefix::from_str("101").matches(&0b10101100));
+        assert!(!Prefix::from_str("1011").matches(&0b10101100));
 
-        assert_eq!(Prefix::from_str(b"0101").lower_bound(), 0b01010000);
-        assert_eq!(Prefix::from_str(b"0101").upper_bound(), 0b01011111);
+        assert_eq!(Prefix::from_str("0101").lower_bound(), 0b01010000);
+        assert_eq!(Prefix::from_str("0101").upper_bound(), 0b01011111);
 
         // Check we handle passing an excessive `bit_count` to `new()`.
         assert_eq!(Prefix::<u64>::new(64, 0).bit_count(), 64);

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -65,7 +65,7 @@ const GET_NODE_NAME_TIMEOUT_SECS: u64 = 60;
 const SENT_NETWORK_NAME_TIMEOUT_SECS: u64 = 30;
 /// Initial delay between a routing table change and sending a `RoutingTableRequest`, in seconds.
 const RT_MIN_TIMEOUT_SECS: u64 = 30;
-/// Maximal delay two subsequent `RoutingTableRequest`s, in seconds.
+/// Maximal delay between two subsequent `RoutingTableRequest`s, in seconds.
 const RT_MAX_TIMEOUT_SECS: u64 = 300;
 
 pub struct Node {
@@ -95,7 +95,7 @@ pub struct Node {
     next_node_name: Option<XorName>,
     /// The message ID of the current `RoutingTableRequest` we sent to our section.
     rt_msg_id: Option<MessageId>,
-    /// The current duration between `RoutingTableRequest` we send. Doubles with every message.
+    /// The current duration between `RoutingTableRequest`s we send. Doubles with every message.
     rt_timeout: Duration,
     /// The timer token for sending the next `RoutingTableRequest`.
     rt_timer_token: Option<u64>,

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1633,6 +1633,9 @@ impl Node {
         } else if old_prefix.bit_count() > new_prefix.bit_count() {
             result.add_event(Event::SectionMerge(new_prefix));
         }
+        trace!("{:?} Update on RoutingTableResponse completed. Prefixes: {:?}",
+               self,
+               self.peer_mgr.routing_table().prefixes());
         let src = Authority::ManagedNode(*self.name());
         for member in members {
             if self.peer_mgr.routing_table().need_to_add(member.name()).is_ok() {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -66,6 +66,8 @@ pub struct Stats {
     msg_section_split: usize,
     msg_own_section_merge: usize,
     msg_other_section_merge: usize,
+    msg_rt_req: usize,
+    msg_rt_rsp: usize,
     msg_get_node_name_rsp: usize,
     msg_ack: usize,
 
@@ -142,6 +144,8 @@ impl Stats {
             MessageContent::SectionSplit(..) => self.msg_section_split += 1,
             MessageContent::OwnSectionMerge { .. } => self.msg_own_section_merge += 1,
             MessageContent::OtherSectionMerge { .. } => self.msg_other_section_merge += 1,
+            MessageContent::RoutingTableRequest(_) => self.msg_rt_req += 1,
+            MessageContent::RoutingTableResponse { .. } => self.msg_rt_rsp += 1,
             MessageContent::GetNodeNameResponse { .. } => self.msg_get_node_name_rsp += 1,
             MessageContent::Ack(..) => self.msg_ack += 1,
             MessageContent::UserMessagePart { .. } => return, // Counted as request/response.
@@ -193,7 +197,7 @@ impl Stats {
             info!(target: "routing_stats",
                   "Stats - Hops (Request/Response) - GetNodeName: {}/{}, ExpectCloseNode: {}, \
                    SectionUpdate: {}, SectionSplit: {}, OwnSectionMerge: {}, \
-                   OtherSectionMerge: {}, ConnectionInfo: {}/{}, Ack: {}",
+                   OtherSectionMerge: {}, RoutingTable: {}/{}, ConnectionInfo: {}/{}, Ack: {}",
                   self.msg_get_node_name,
                   self.msg_get_node_name_rsp,
                   self.msg_expect_close_node,
@@ -201,6 +205,8 @@ impl Stats {
                   self.msg_section_split,
                   self.msg_own_section_merge,
                   self.msg_other_section_merge,
+                  self.msg_rt_req,
+                  self.msg_rt_rsp,
                   self.msg_connection_info_req,
                   self.msg_connection_info_rsp,
                   self.msg_ack);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -144,7 +144,7 @@ impl Stats {
             MessageContent::SectionSplit(..) => self.msg_section_split += 1,
             MessageContent::OwnSectionMerge { .. } => self.msg_own_section_merge += 1,
             MessageContent::OtherSectionMerge { .. } => self.msg_other_section_merge += 1,
-            MessageContent::RoutingTableRequest(_) => self.msg_rt_req += 1,
+            MessageContent::RoutingTableRequest(..) => self.msg_rt_req += 1,
             MessageContent::RoutingTableResponse { .. } => self.msg_rt_rsp += 1,
             MessageContent::GetNodeNameResponse { .. } => self.msg_get_node_name_rsp += 1,
             MessageContent::Ack(..) => self.msg_ack += 1,


### PR DESCRIPTION
To fix nodes' routing tables if they went out of sync with their section,
periodically request the section's routing table and update accordingly.