### PR TITLE
Display estimation of total number of nodes

### DIFF
--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -278,14 +278,14 @@ impl Node {
                 // Result is exact when the whole xor space is covered by sections in our RT
                 // and is the sum of the sections size
                 let exact = map.iter()
-                               .fold(0usize, |sum, (_, map)| sum + map.len());
+                    .fold(0usize, |sum, (_, map)| sum + map.len());
                 (exact, (exact, exact))
             } else {
                 // When RT contains a subset of sections, result is the mean of local estimations
                 // made for each section.
                 let count_vec = map.iter()
-                                   .map(|(pfx, map)| map.len() * (1 << pfx.bit_count()))
-                                   .collect::<Vec<usize>>();
+                    .map(|(pfx, map)| map.len() * (1 << pfx.bit_count()))
+                    .collect::<Vec<usize>>();
                 let average = count_vec.iter().fold(0usize, |sum, i| sum + *i) / count_vec.len();
                 (average,
                  (count_vec.iter().fold((average, average),

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -274,22 +274,28 @@ impl Node {
                                      self.stats.cur_routing_table_size);
             // Estimation of total number of nodes
             let map = self.peer_mgr.pub_ids_by_section();
-            let count_vec = map.iter()
-                .map(|(pfx, map)| map.len() * (1 << pfx.bit_count()))
-                .collect::<Vec<usize>>();
-            let average = count_vec.iter().fold(0usize, |sum, i| sum + *i) / count_vec.len();
-            let (min, max) = if Prefix::default().is_covered_by(map.keys()) {
-                // Result is exact when the whole xor space is covered, even if sections are unbalanced.
-                (average, average)
+            let (average, (min, max)) = if Prefix::default().is_covered_by(map.keys()) {
+                // Result is exact when the whole xor space is covered by sections in our RT
+                // and is the sum of the sections size
+                let exact = map.iter()
+                               .fold(0usize, |sum, (_, map)| sum + map.len());
+                (exact, (exact, exact))
             } else {
-                (count_vec.iter().fold((average, average),
-                                       |mm, i| (cmp::min(mm.0, *i), cmp::max(mm.1, *i))))
+                // When RT contains a subset of sections, result is the mean of local estimations
+                // made for each section.
+                let count_vec = map.iter()
+                                   .map(|(pfx, map)| map.len() * (1 << pfx.bit_count()))
+                                   .collect::<Vec<usize>>();
+                let average = count_vec.iter().fold(0usize, |sum, i| sum + *i) / count_vec.len();
+                (average,
+                 (count_vec.iter().fold((average, average),
+                                        |mm, i| (cmp::min(mm.0, *i), cmp::max(mm.1, *i)))))
             };
             let deviation = cmp::max(average - min, max - average);
             let count_str = format!("Estimated vault count: {} ± {} (evaluated over {} sections)",
                                     average,
                                     deviation,
-                                    count_vec.iter().len());
+                                    map.len());
             let sep_len = cmp::max(status_str.len(), count_str.len());
             let sep_str = iter::repeat('-').take(sep_len).collect::<String>();
             log!(target: "routing_stats", TABLE_LVL, " -{}- ", sep_str);

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -282,7 +282,8 @@ impl Node {
                 // Result is exact when the whole xor space is covered, even if sections are unbalanced.
                 (average, average)
             } else {
-                (count_vec.iter().fold((average, average), |mm, i| (cmp::min(mm.0, *i), cmp::max(mm.1, *i))))
+                (count_vec.iter().fold((average, average),
+                                       |mm, i| (cmp::min(mm.0, *i), cmp::max(mm.1, *i))))
             };
             let deviation = cmp::max(average - min, max - average);
             let count_str = format!("Estimated vault count: {} ± {} (evaluated over {} sections)",


### PR DESCRIPTION
In RT print routine, compute average of section length multiplied by 2 ^ section prefix length.
This gives an estimation of the total number of nodes in the network.
Display also the potential deviation given by max and min values.

This implements this idea proposed in [this post in safe forum](https://safenetforum.org/t/safe-network-test-12b/12452/74?u=tfa).