### PR TITLE
Remove unused #[macro_use] and extern crate decls

### DIFF
--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -35,7 +35,6 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate maidsafe_utilities;
 extern crate rand;
 extern crate rustc_serialize;

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -38,7 +38,6 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate maidsafe_utilities;
 #[macro_use]
 extern crate unwrap;

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -15,11 +15,6 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-extern crate log;
-extern crate routing;
-extern crate rust_sodium;
-extern crate maidsafe_utilities;
-
 use routing::{Authority, Client, Data, DataIdentifier, Event, FullId, MessageId, Response, XorName};
 use rust_sodium::crypto;
 use std::sync::mpsc::{self, Receiver, TryRecvError};

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -37,7 +37,6 @@
 extern crate itertools;
 #[cfg(target_os = "macos")]
 extern crate libc;
-#[macro_use]
 extern crate maidsafe_utilities;
 extern crate rand;
 extern crate routing;


### PR DESCRIPTION
I've been using the nightly compiler a bit (for incremental compilation), and it's smart enough to know that these declarations aren't used.