### PR TITLE
refactor/routing_table: use BTreeSet to hold section members

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -774,7 +774,7 @@ impl PeerManager {
 
         let sections_as_names = sections.into_iter()
             .map(|(prefix, members)| {
-                (prefix, members.into_iter().map(|pub_id| *pub_id.name()).collect::<HashSet<_>>())
+                (prefix, members.into_iter().map(|pub_id| *pub_id.name()).collect::<BTreeSet<_>>())
             })
             .collect();
 
@@ -1089,7 +1089,7 @@ impl PeerManager {
 
     /// Returns the PublicIds of nodes given their names; the result is filtered to the names we
     /// know about (i.e. unknown names are ignored).
-    pub fn get_pub_ids(&self, names: &HashSet<XorName>) -> BTreeSet<PublicId> {
+    pub fn get_pub_ids(&self, names: &BTreeSet<XorName>) -> BTreeSet<PublicId> {
         names.into_iter()
             .filter_map(|name| if name == self.our_public_id.name() {
                 Some(self.our_public_id)

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -24,7 +24,7 @@ use maidsafe_utilities::SeededRng;
 use rand::Rng;
 use routing_table::{Iter, OtherMergeDetails, OwnMergeDetails, OwnMergeState};
 use routing_table::xorable::Xorable;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Binary, Debug};
 use std::hash::Hash;
 use std::iter::IntoIterator;
@@ -309,7 +309,7 @@ pub fn verify_network_invariant<'a, T, U>(nodes: U)
     where T: Binary + Clone + Copy + Debug + Default + Hash + Xorable + 'a,
           U: IntoIterator<Item = &'a RoutingTable<T>>
 {
-    let mut sections: HashMap<Prefix<T>, (T, HashSet<T>)> = HashMap::new();
+    let mut sections: BTreeMap<Prefix<T>, (T, BTreeSet<T>)> = BTreeMap::new();
     // first, collect all sections in the network
     for node in nodes {
         node.verify_invariant();

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -603,7 +603,7 @@ impl Node {
         Ok(())
     }
 
-    fn get_section(&self, prefix: &Prefix<XorName>) -> Result<HashSet<XorName>, RoutingError> {
+    fn get_section(&self, prefix: &Prefix<XorName>) -> Result<BTreeSet<XorName>, RoutingError> {
         let section = self.peer_mgr
             .routing_table()
             .get_section(&prefix.lower_bound())

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -23,7 +23,7 @@ use routing::{Authority, Cache, Client, Data, DataIdentifier, Event, EventStream
 use routing::mock_crust::{self, Config, Endpoint, Network, ServiceHandle};
 use std::{cmp, thread};
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc::{RecvError, TryRecvError};
 
@@ -145,7 +145,7 @@ impl TestNode {
         unwrap!(self.inner.name())
     }
 
-    pub fn close_names(&self) -> HashSet<XorName> {
+    pub fn close_names(&self) -> BTreeSet<XorName> {
         unwrap!(unwrap!(self.inner.routing_table()).close_names(&self.name()))
     }
 


### PR DESCRIPTION
This is another step towards fully-deterministic tests, and also allows simpler debugging of logs
containing these section members.