### PR TITLE
Exclusive matching in dispatch_routing_message and cleanup of handle_timeout

### DIFF
--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -808,14 +808,22 @@ impl Node {
                 ConnectionInfoRequest { .. } |
                 SectionUpdate { .. } |
                 RoutingTableRequest(..) |
-                RoutingTableResponse { .. } => {
+                RoutingTableResponse { .. } |
+                UserMessagePart { .. } => {
+                    // These messages should not be handled before node approval
                     trace!("{:?} Not approved yet. Delaying message handling: {:?}",
                            self,
                            routing_msg);
                     self.routing_msg_backlog.push(routing_msg);
                     return Ok(());
                 }
-                _ => (),
+                GetNodeName { .. } |
+                ConnectionInfoResponse { .. } |
+                GetNodeNameResponse { .. } |
+                Ack(..) |
+                NodeApproval { .. } => {
+                    // Handle like normal
+                }
             }
         }
 
@@ -1152,7 +1160,7 @@ impl Node {
                       Self::format(elapsed),
                       self.our_prefix());
                 self.candidate_timer_token = None;
-                let _ = self.send_candidate_approval();
+                self.send_candidate_approval();
             }
             Ok(Some((_, _, elapsed))) => {
                 info!("{:?} Candidate {} passed our challenge in {}. Waiting to send approval to \
@@ -2245,14 +2253,10 @@ impl Node {
                    self,
                    self.rt_timeout.as_secs());
             self.rt_timer_token = Some(self.timer.schedule(self.rt_timeout));
-            if self.send_rt_request().is_err() {
-                return Transition::Stay;
-            }
+            self.send_rt_request();
         } else if self.candidate_timer_token == Some(token) {
             self.candidate_timer_token = None;
-            if self.send_candidate_approval().is_err() {
-                return Transition::Stay;
-            }
+            self.send_candidate_approval();
         } else if self.candidate_status_token == Some(token) {
             self.candidate_status_token = Some(self.timer
                 .schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
@@ -2276,9 +2280,11 @@ impl Node {
                   self.resource_proof_response_progress(),
                   remaining_duration,
                   APPROVAL_TIMEOUT_SECS);
+        } else {
+            // Each token has only one purpose, so we only need to call this if none of the above
+            // matched:
+            self.resend_unacknowledged_timed_out_msgs(token);
         }
-
-        self.resend_unacknowledged_timed_out_msgs(token);
 
         Transition::Stay
     }
@@ -2365,13 +2371,19 @@ impl Node {
         transition
     }
 
-    fn send_rt_request(&mut self) -> Result<(), RoutingError> {
+    fn send_rt_request(&mut self) {
         if self.is_approved {
             let msg_id = MessageId::new();
             self.rt_msg_id = Some(msg_id);
             let sections = self.peer_mgr.pub_ids_by_section();
             let prefixes = self.peer_mgr.routing_table().prefixes();
-            let digest = sha256::hash(&serialisation::serialise(&(sections, prefixes))?);
+            let digest = sha256::hash(&match serialisation::serialise(&(sections, prefixes)) {
+                Ok(serialised) => serialised,
+                Err(e) => {
+                    warn!("{:?} Serialisation failed: {:?}", self, e);
+                    return;
+                }
+            });
             trace!("{:?} Sending RT request {:?} with digest {:?}",
                    self,
                    msg_id,
@@ -2384,15 +2396,14 @@ impl Node {
                 debug!("{:?} Failed to send RoutingTableRequest: {:?}.", self, err);
             }
         }
-        Ok(())
     }
 
-    fn send_candidate_approval(&mut self) -> Result<(), RoutingError> {
+    fn send_candidate_approval(&mut self) {
         let (candidate_id, client_auth, sections) = match self.peer_mgr.verified_candidate_info() {
             Err(_) => {
                 trace!("{:?} No candidate for which to send CandidateApproval.",
                        self);
-                return Err(RoutingError::UnknownCandidate);
+                return;
             }
             Ok(info) => info,
         };
@@ -2402,7 +2413,7 @@ impl Node {
                    candidate {} since our section is currently merging.",
                    self,
                    candidate_id.name());
-            return Ok(());
+            return;
         }
 
         let src = Authority::Section(*candidate_id.name());
@@ -2419,7 +2430,6 @@ impl Node {
         if let Err(error) = self.send_routing_message(src, src, response_content) {
             debug!("{:?} Failed sending CandidateApproval: {:?}", self, error);
         }
-        Ok(())
     }
 
     fn decrypt_connection_info(&self,


### PR DESCRIPTION
There is one change to behaviour: reject UserMessageParts while a candidate. Not 100% sure on this.

r? @afck 