### PR TITLE
Use SHA-3 everywhere instead of SipHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ lru_time_cache = "~0.5.0"
 maidsafe_utilities = "~0.10.0"
 quick-error = "~1.1.0"
 rand = "~0.3.15"
-resource_proof = "0.3.0-pre"
+resource_proof = "~0.3.1"
 rust_sodium = "~0.1.2"
 rustc-serialize = "~0.3.22"
 term = "~0.4.4"
-tiny-keccak = "~1.1.1"
+tiny-keccak = "~1.2.0"
 unwrap = "~1.1.0"
 
 [dev-dependencies]

--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -23,6 +23,7 @@ use sha3;
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
+use tiny_keccak::sha3_256;
 
 /// Time (in seconds) after which a message is resent due to being unacknowledged by recipient.
 pub const ACK_TIMEOUT_SECS: u64 = 20;
@@ -45,7 +46,7 @@ pub struct AckManager {
 /// An identifier for a waiting-to-be-acknowledged message (a hash of the message).
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, RustcDecodable, RustcEncodable)]
 pub struct Ack {
-    m_hash: [u8; 32],
+    m_hash: sha3::Digest256,
 }
 
 impl AckManager {
@@ -126,7 +127,7 @@ impl Ack {
     /// Compute an `Ack` from a message.
     pub fn compute(routing_msg: &RoutingMessage) -> Result<Ack, RoutingError> {
         let hash_msg = serialisation::serialise(routing_msg)?;
-        Ok(Ack { m_hash: sha3::hash(&hash_msg) })
+        Ok(Ack { m_hash: sha3_256(&hash_msg) })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,6 @@
 #[macro_use]
 extern crate log;
 extern crate maidsafe_utilities;
-#[cfg_attr(feature="cargo-clippy", allow(useless_attribute))]
-#[allow(unused_extern_crates)]
 #[macro_use]
 extern crate quick_error;
 #[macro_use]
@@ -166,11 +164,13 @@ mod tunnels;
 mod types;
 mod utils;
 mod xor_name;
-mod sha3;
 
 /// Mock crust
 #[cfg(feature = "use-mock-crust")]
 pub mod mock_crust;
+
+/// SHA-3 type alias.
+pub mod sha3;
 
 /// Messaging infrastructure
 pub mod messaging;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -813,13 +813,15 @@ impl Debug for MessageContent {
             Ack(ack, priority) => write!(formatter, "Ack({:?}, {})", ack, priority),
             UserMessagePart { hash, part_count, part_index, priority, cacheable, .. } => {
                 write!(formatter,
-                       "UserMessagePart {{ {}/{}, priority: {}, cacheable: {}, {:02x}{:02x}.. }}",
+                       "UserMessagePart {{ {}/{}, priority: {}, cacheable: {}, \
+                        {:02x}{:02x}{:02x}.. }}",
                        part_index + 1,
                        part_count,
                        priority,
                        cacheable,
                        hash[0],
-                       hash[1])
+                       hash[1],
+                       hash[2])
             }
             AcceptAsCandidate { ref expect_id, ref client_auth, ref message_id } => {
                 write!(formatter,
@@ -1175,11 +1177,13 @@ impl UserMessageCache {
         {
             let entry = self.0.entry((hash, part_count)).or_insert_with(BTreeMap::new);
             if entry.insert(part_index, payload).is_some() {
-                debug!("Duplicate UserMessagePart {}/{} with hash {:02x}{:02x}.. added to cache.",
+                debug!("Duplicate UserMessagePart {}/{} with hash {:02x}{:02x}{:02x}.. \
+                        added to cache.",
                        part_index + 1,
                        part_count,
                        hash[0],
-                       hash[1]);
+                       hash[1],
+                       hash[2]);
             }
 
             if entry.len() != part_count as usize {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -24,7 +24,6 @@ use event::Event;
 use id::{FullId, PublicId};
 use itertools::Itertools;
 use lru_time_cache::LruCache;
-use maidsafe_utilities;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 #[cfg(feature = "use-mock-crust")]
 use mock_crust::crust::PeerId;
@@ -33,11 +32,13 @@ use routing_table::{Prefix, Xorable};
 use routing_table::Authority;
 use rust_sodium::crypto::{box_, sign};
 use rust_sodium::crypto::hash::sha256;
+use sha3;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::iter;
 use std::time::Duration;
 use super::QUORUM;
+use tiny_keccak::sha3_256;
 use types::MessageId;
 use utils;
 use xor_name::XorName;
@@ -631,7 +632,7 @@ pub enum MessageContent {
     /// Part of a user-facing message
     UserMessagePart {
         /// The hash of this user message.
-        hash: u64,
+        hash: sha3::Digest256,
         /// The number of parts.
         part_count: u32,
         /// The index of this part.
@@ -812,12 +813,13 @@ impl Debug for MessageContent {
             Ack(ack, priority) => write!(formatter, "Ack({:?}, {})", ack, priority),
             UserMessagePart { hash, part_count, part_index, priority, cacheable, .. } => {
                 write!(formatter,
-                       "UserMessagePart {{ {}/{}, priority: {}, cacheable: {}, {:x} }}",
+                       "UserMessagePart {{ {}/{}, priority: {}, cacheable: {}, {:02x}{:02x}.. }}",
                        part_index + 1,
                        part_count,
                        priority,
                        cacheable,
-                       hash)
+                       hash[0],
+                       hash[1])
             }
             AcceptAsCandidate { ref expect_id, ref client_auth, ref message_id } => {
                 write!(formatter,
@@ -852,9 +854,8 @@ impl UserMessage {
     /// Splits up the message into smaller `MessageContent` parts, which can individually be sent
     /// and routed, and then be put back together by the receiver.
     pub fn to_parts(&self, priority: u8) -> Result<Vec<MessageContent>, RoutingError> {
-        // TODO: This internally serialises the message - remove that duplicated work!
-        let hash = maidsafe_utilities::big_endian_sip_hash(self);
         let payload = serialise(self)?;
+        let hash = sha3_256(&payload);
         let len = payload.len();
         let part_count = (len + MAX_PART_LEN - 1) / MAX_PART_LEN;
 
@@ -874,7 +875,7 @@ impl UserMessage {
 
     /// Puts the given parts of a serialised message together and verifies that it matches the
     /// given hash code. If it does, returns the `UserMessage`.
-    pub fn from_parts<'a, I: Iterator<Item = &'a Vec<u8>>>(hash: u64,
+    pub fn from_parts<'a, I: Iterator<Item = &'a Vec<u8>>>(hash: sha3::Digest256,
                                                            parts: I)
                                                            -> Result<UserMessage, RoutingError> {
         let mut payload = Vec::new();
@@ -882,7 +883,7 @@ impl UserMessage {
             payload.extend_from_slice(part);
         }
         let user_msg = deserialise(&payload[..])?;
-        if hash != maidsafe_utilities::big_endian_sip_hash(&user_msg) {
+        if hash != sha3_256(&payload) {
             Err(RoutingError::HashMismatch)
         } else {
             Ok(user_msg)
@@ -1156,7 +1157,7 @@ impl Debug for Response {
 /// This assembles `UserMessage`s from `UserMessagePart`s.
 /// It maps `(hash, part_count)` of an incoming `UserMessage` to the map containing
 /// all `UserMessagePart`s that have already arrived, by `part_index`.
-pub struct UserMessageCache(LruCache<(u64, u32), BTreeMap<u32, Vec<u8>>>);
+pub struct UserMessageCache(LruCache<(sha3::Digest256, u32), BTreeMap<u32, Vec<u8>>>);
 
 impl UserMessageCache {
     pub fn with_expiry_duration(duration: Duration) -> Self {
@@ -1166,7 +1167,7 @@ impl UserMessageCache {
     /// Adds the given one to the cache of received message parts, returning a `UserMessage` if the
     /// given part was the last missing piece of it.
     pub fn add(&mut self,
-               hash: u64,
+               hash: sha3::Digest256,
                part_count: u32,
                part_index: u32,
                payload: Vec<u8>)
@@ -1174,10 +1175,11 @@ impl UserMessageCache {
         {
             let entry = self.0.entry((hash, part_count)).or_insert_with(BTreeMap::new);
             if entry.insert(part_index, payload).is_some() {
-                debug!("Duplicate UserMessagePart {}/{} with hash {:x} added to cache.",
+                debug!("Duplicate UserMessagePart {}/{} with hash {:02x}{:02x}.. added to cache.",
                        part_index + 1,
                        part_count,
-                       hash);
+                       hash[0],
+                       hash[1]);
             }
 
             if entry.len() != part_count as usize {
@@ -1198,7 +1200,6 @@ mod tests {
     use crust::PeerId;
     use data::{Data, ImmutableData};
     use id::FullId;
-    use maidsafe_utilities;
     use maidsafe_utilities::serialisation::serialise;
     #[cfg(feature = "use-mock-crust")]
     use mock_crust::crust::PeerId;
@@ -1209,6 +1210,7 @@ mod tests {
     use std::collections::BTreeSet;
     use std::iter;
     use super::*;
+    use tiny_keccak::sha3_256;
     use types::MessageId;
     use xor_name::XorName;
 
@@ -1359,7 +1361,7 @@ mod tests {
         let data_bytes: Vec<u8> = (0..(MAX_PART_LEN * 2)).map(|i| i as u8).collect();
         let data = Data::Immutable(ImmutableData::new(data_bytes));
         let user_msg = UserMessage::Request(Request::Put(data, MessageId::new()));
-        let msg_hash = maidsafe_utilities::big_endian_sip_hash(&user_msg);
+        let msg_hash = sha3_256(&unwrap!(serialise(&user_msg)));
         let parts = unwrap!(user_msg.to_parts(42));
         assert_eq!(parts.len(), 3);
         let payloads: Vec<Vec<u8>> = parts.into_iter()

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -17,10 +17,12 @@
 
 use crust::PeerId;
 use lru_time_cache::LruCache;
-use maidsafe_utilities;
+use maidsafe_utilities::serialisation::serialise;
 use message_filter::MessageFilter;
 use messages::RoutingMessage;
+use sha3;
 use std::time::Duration;
+use tiny_keccak::sha3_256;
 
 const INCOMING_EXPIRY_DURATION_SECS: u64 = 60 * 20;
 const OUTGOING_EXPIRY_DURATION_SECS: u64 = 60 * 10;
@@ -40,7 +42,7 @@ pub enum FilteringResult {
 pub struct RoutingMessageFilter {
     incoming: MessageFilter<RoutingMessage>,
     incoming_route: MessageFilter<(RoutingMessage, u8)>,
-    outgoing: LruCache<(u64, PeerId, u8), ()>,
+    outgoing: LruCache<(sha3::Digest256, PeerId, u8), ()>,
 }
 
 impl RoutingMessageFilter {
@@ -70,9 +72,15 @@ impl RoutingMessageFilter {
 
     // Filter outgoing `RoutingMessage`. Return whether this specific message has been seen recently
     // (and thus should not be sent, due to deduplication).
+    //
+    // Return `false` if serialisation of the message fails - that can be handled elsewhere.
     pub fn filter_outgoing(&mut self, msg: &RoutingMessage, peer_id: &PeerId, route: u8) -> bool {
-        let hash = maidsafe_utilities::big_endian_sip_hash(msg);
-        self.outgoing.insert((hash, *peer_id, route), ()).is_some()
+        if let Ok(msg_bytes) = serialise(msg) {
+            let hash = sha3_256(&msg_bytes);
+            self.outgoing.insert((hash, *peer_id, route), ()).is_some()
+        } else {
+            false
+        }
     }
 
     #[cfg(feature = "use-mock-crust")]

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -79,6 +79,7 @@ impl RoutingMessageFilter {
             let hash = sha3_256(&msg_bytes);
             self.outgoing.insert((hash, *peer_id, route), ()).is_some()
         } else {
+            trace!("Tried to filter oversized routing message: {:?}", msg);
             false
         }
     }

--- a/src/sha3.rs
+++ b/src/sha3.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 MaidSafe.net limited.
+// Copyright 2017 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
 // version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
@@ -15,57 +15,5 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use tiny_keccak::Keccak;
-
-/// Simple wrapper around tiny-keccak
-pub fn hash(data: &[u8]) -> [u8; 32] {
-    let mut sha3 = Keccak::new_sha3_256();
-    sha3.update(data);
-    let mut res = [0u8; 32];
-    sha3.finalize(&mut res);
-    res
-}
-
-
-#[cfg(test)]
-mod tests {
-    use super::hash;
-
-    #[test]
-    fn empty() {
-        let res = [];
-        let empty_hash = hash(&res);
-
-        let expected = vec![0xa7, 0xff, 0xc6, 0xf8, 0xbf, 0x1e, 0xd7, 0x66, 0x51, 0xc1, 0x47,
-                            0x56, 0xa0, 0x61, 0xd6, 0x62, 0xf5, 0x80, 0xff, 0x4d, 0xe4, 0x3b,
-                            0x49, 0xfa, 0x82, 0xd8, 0x0a, 0x4b, 0x80, 0xf8, 0x43, 0x4a];
-
-        assert_eq!(expected, empty_hash);
-    }
-    // http://www.di-mgt.com.au/sha_testvectors.html
-    #[test]
-    fn abc_string() {
-        let data: Vec<u8> = From::from("abc");
-        let res = hash(&data);
-
-        let expected = vec![0x3a, 0x98, 0x5d, 0xa7, 0x4f, 0xe2, 0x25, 0xb2, 0x04, 0x5c, 0x17,
-                            0x2d, 0x6b, 0xd3, 0x90, 0xbd, 0x85, 0x5f, 0x08, 0x6e, 0x3e, 0x9d,
-                            0x52, 0x5b, 0x46, 0xbf, 0xe2, 0x45, 0x11, 0x43, 0x15, 0x32];
-
-
-        assert_eq!(expected, res);
-    }
-
-    #[test]
-    fn string() {
-        let data: Vec<u8> = From::from("hello");
-        let res = hash(&data);
-
-        let expected = vec![0x33, 0x38, 0xbe, 0x69, 0x4f, 0x50, 0xc5, 0xf3, 0x38, 0x81, 0x49,
-                            0x86, 0xcd, 0xf0, 0x68, 0x64, 0x53, 0xa8, 0x88, 0xb8, 0x4f, 0x42,
-                            0x4d, 0x79, 0x2a, 0xf4, 0xb9, 0x20, 0x23, 0x98, 0xf3, 0x92];
-
-        assert_eq!(expected, res);
-    }
-
-}
+/// SHA3-256 hash digest.
+pub type Digest256 = [u8; 32];

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -206,9 +206,10 @@ impl Client {
         match routing_msg.content {
             MessageContent::Ack(ack, _) => self.handle_ack_response(ack),
             MessageContent::UserMessagePart { hash, part_count, part_index, payload, .. } => {
-                trace!("{:?} Got UserMessagePart {:x}, {}/{} from {:?} to {:?}.",
+                trace!("{:?} Got UserMessagePart {:02x}{:02x}, {}/{} from {:?} to {:?}.",
                        self,
-                       hash,
+                       hash[0],
+                       hash[1],
                        part_count,
                        part_index,
                        routing_msg.src,

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -206,10 +206,11 @@ impl Client {
         match routing_msg.content {
             MessageContent::Ack(ack, _) => self.handle_ack_response(ack),
             MessageContent::UserMessagePart { hash, part_count, part_index, payload, .. } => {
-                trace!("{:?} Got UserMessagePart {:02x}{:02x}, {}/{} from {:?} to {:?}.",
+                trace!("{:?} Got UserMessagePart {:02x}{:02x}{:02x}.., {}/{} from {:?} to {:?}.",
                        self,
                        hash[0],
                        hash[1],
+                       hash[2],
                        part_count,
                        part_index,
                        routing_msg.src,


### PR DESCRIPTION
Main changes:

* `UserMessagePart`s now include the SHA3-256 hash of the full message, rather than just a SipHash.
* Outgoing routing messages are now de-duplicated using SHA3-256 instead of SipHash.