### PR TITLE
feat/bootstrapper-kind: keep hold of the bootstrapper kind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/maidsafe/routing"
 version = "0.28.2"
 
 [dependencies]
-crust = "~0.22.0"
+#crust = "~0.22.0"
+crust = { git = "https://github.com/maidsafe/crust" }
 itertools = "~0.5.9"
 log = "~0.3.6"
 lru_time_cache = "~0.5.0"

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -191,7 +191,7 @@ impl fmt::Debug for PeerId {
 #[derive(Debug)]
 pub enum Event {
     /// Invoked when a bootstrap peer connects to us
-    BootstrapAccept(PeerId),
+    BootstrapAccept(PeerId, CrustUser),
     /// Invoked when we get a bootstrap connection to a new peer.
     BootstrapConnect(PeerId, SocketAddr),
     /// Invoked when we failed to connect to all bootstrap contacts.

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -278,12 +278,12 @@ impl ServiceImpl {
         self.start(event_sender)
     }
 
-    pub fn start_bootstrap(&mut self, blacklist: HashSet<SocketAddr>, _: CrustUser) {
+    pub fn start_bootstrap(&mut self, blacklist: HashSet<SocketAddr>, kind: CrustUser) {
         let mut pending_bootstraps = 0;
 
         for endpoint in &self.config.hard_coded_contacts {
             if *endpoint != self.endpoint && !blacklist.contains(&to_socket_addr(endpoint)) {
-                self.send_packet(*endpoint, Packet::BootstrapRequest(self.peer_id));
+                self.send_packet(*endpoint, Packet::BootstrapRequest(self.peer_id, kind));
                 pending_bootstraps += 1;
             }
         }
@@ -353,7 +353,9 @@ impl ServiceImpl {
 
     fn receive_packet(&mut self, sender: Endpoint, packet: Packet) {
         match packet {
-            Packet::BootstrapRequest(peer_id) => self.handle_bootstrap_request(sender, peer_id),
+            Packet::BootstrapRequest(peer_id, kind) => {
+                self.handle_bootstrap_request(sender, peer_id, kind)
+            }
             Packet::BootstrapSuccess(peer_id) => self.handle_bootstrap_success(sender, peer_id),
             Packet::BootstrapFailure => self.handle_bootstrap_failure(sender),
             Packet::ConnectRequest(their_id, _) => self.handle_connect_request(sender, their_id),
@@ -364,18 +366,24 @@ impl ServiceImpl {
         }
     }
 
-    fn handle_bootstrap_request(&mut self, peer_endpoint: Endpoint, peer_id: PeerId) {
+    fn handle_bootstrap_request(&mut self,
+                                peer_endpoint: Endpoint,
+                                peer_id: PeerId,
+                                kind: CrustUser) {
         if self.is_listening() {
-            self.handle_bootstrap_accept(peer_endpoint, peer_id);
+            self.handle_bootstrap_accept(peer_endpoint, peer_id, kind);
             self.send_packet(peer_endpoint, Packet::BootstrapSuccess(self.peer_id));
         } else {
             self.send_packet(peer_endpoint, Packet::BootstrapFailure);
         }
     }
 
-    fn handle_bootstrap_accept(&mut self, peer_endpoint: Endpoint, peer_id: PeerId) {
+    fn handle_bootstrap_accept(&mut self,
+                               peer_endpoint: Endpoint,
+                               peer_id: PeerId,
+                               kind: CrustUser) {
         self.add_connection(peer_id, peer_endpoint);
-        self.send_event(Event::BootstrapAccept(peer_id));
+        self.send_event(Event::BootstrapAccept(peer_id, kind));
     }
 
     fn handle_bootstrap_success(&mut self, peer_endpoint: Endpoint, peer_id: PeerId) {
@@ -571,7 +579,7 @@ pub struct Endpoint(pub usize);
 
 #[derive(Clone, Debug)]
 enum Packet {
-    BootstrapRequest(PeerId),
+    BootstrapRequest(PeerId, CrustUser),
     BootstrapSuccess(PeerId),
     BootstrapFailure,
 

--- a/src/mock_crust/tests.rs
+++ b/src/mock_crust/tests.rs
@@ -75,7 +75,7 @@ fn start_two_services_bootstrap_communicate_exit() {
 
     unwrap!(service_1.start_bootstrap(HashSet::new(), CrustUser::Node));
     let id_0 = expect_event!(event_rx_1, Event::BootstrapConnect(id, _) => id);
-    let id_1 = expect_event!(event_rx_0, Event::BootstrapAccept(id) => id);
+    let id_1 = expect_event!(event_rx_0, Event::BootstrapAccept(id, CrustUser::Node) => id);
 
     assert!(id_0 != id_1);
 


### PR DESCRIPTION
This will help us verify that someone who bootstrapped as client-kind does not send client_restriction as false later in ClientIdentify