### PR TITLE
MAID-2000: chore/all: cleanup/improve CI scripts and README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,36 +2,33 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-branches:
-  only:
-    - master
-    - stable
 os:
   - linux
   - osx
 language: rust
 rust:
-  - 1.14.0
-  - nightly-2016-12-19
+  - 1.16.0
+  - nightly-2017-03-16
 sudo: false
+branches:
+  only:
+    - master
+    - stable
 cache:
   cargo: true
 before_script:
   - (which cargo-install-update && cargo install-update cargo-update) || cargo install cargo-update
   - (which cargo-prune && cargo install-update cargo-prune) || cargo install cargo-prune
-  - if [ "${TRAVIS_RUST_VERSION}" = 1.14.0 ]; then
-      rustfmt_vers=0.7.0;
-      if ! cargo fmt -- --version | grep -q $rustfmt_vers; then
-        cargo install rustfmt --vers==$rustfmt_vers --force;
-      fi
+  - if [ "${TRAVIS_RUST_VERSION}" = 1.16.0 ]; then
+      (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt;
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      clippy_vers=0.0.104;
+      clippy_vers=0.0.120;
       if ! cargo clippy --version | grep -q $clippy_vers; then
         cargo install clippy --vers=$clippy_vers --force;
       fi
     fi
 script:
-  - if [ "${TRAVIS_RUST_VERSION}" = 1.14.0 ]; then
+  - if [ "${TRAVIS_RUST_VERSION}" = 1.16.0 ]; then
       (
         set -x;
         cargo fmt -- --write-mode=diff &&
@@ -51,4 +48,4 @@ script:
       );
     fi
 before_cache:
- - cargo prune
+  - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "A secured storage DHT"
-documentation = "https://docs.rs/routing/"
-homepage = "http://maidsafe.net"
+documentation = "https://docs.rs/routing"
+homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "routing"
 readme = "README.md"
@@ -31,12 +31,10 @@ libc = "~0.2.20"
 [[example]]
 bench = false
 name = "key_value_store"
-test = false
 
 [[example]]
 bench = false
 name = "ci_test"
-test = false
 
 [features]
 use-mock-crust = []

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Routing - a specialised storage DHT
 
-|Crate|Linux/OS X|ARM (Linux)|Windows|Coverage|Issues|
-|:---:|:--------:|:---------:|:-----:|:------:|:----:|
-|[![](http://meritbadge.herokuapp.com/routing)](https://crates.io/crates/routing)|[![Build Status](https://travis-ci.org/maidsafe/routing.svg?branch=master)](https://travis-ci.org/maidsafe/routing)|[![Build Status](http://ci.maidsafe.net:8080/buildStatus/icon?job=routing_arm_status_badge)](http://ci.maidsafe.net:8080/job/routing_arm_status_badge/)|[![Build status](https://ci.appveyor.com/api/projects/status/2w1joqd2h64o4xrh/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/routing/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/routing/badge.svg)](https://coveralls.io/r/maidsafe/routing)|[![Stories in Ready](https://badge.waffle.io/maidsafe/routing.png?label=ready&title=Ready)](https://waffle.io/maidsafe/routing)|
+|Crate|Documentation|Linux/OS X|Windows|Issues|
+|:---:|:-----------:|:--------:|:-----:|:----:|
+|[![](http://meritbadge.herokuapp.com/routing)](https://crates.io/crates/routing)|[![Documentation](https://docs.rs/routing/badge.svg)](https://docs.rs/routing)|[![Build Status](https://travis-ci.org/maidsafe/routing.svg?branch=master)](https://travis-ci.org/maidsafe/routing)|[![Build status](https://ci.appveyor.com/api/projects/status/2w1joqd2h64o4xrh/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/routing/branch/master)|[![Stories in Ready](https://badge.waffle.io/maidsafe/routing.png?label=ready&title=Ready)](https://waffle.io/maidsafe/routing)|
 
-| [![Documentation](https://docs.rs/routing/badge.svg)](https://docs.rs/routing) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
-|:------:|:-------:|:-------:|:-------:|
+| [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
 
 ## Overview
 
@@ -51,6 +51,5 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
-work by you, as defined in the MaidSafe Contributor Agreement, version 1.1 ([CONTRIBUTOR]
-(CONTRIBUTOR)), shall be dual licensed as above, and you agree to be bound by the terms of the
-MaidSafe Contributor Agreement, version 1.1.
+work by you, as defined in the MaidSafe Contributor Agreement ([CONTRIBUTOR](CONTRIBUTOR)), shall be
+dual licensed as above, and you agree to be bound by the terms of the MaidSafe Contributor Agreement.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,17 +3,23 @@ environment:
     RUST_BACKTRACE: 1
   matrix:
     - RUST_VERSION: stable
+
 branches:
   only:
     - master
     - stable
+
+cache:
+  - '%USERPROFILE%\.cargo'
+  - '%APPVEYOR_BUILD_FOLDER%\target'
+
 clone_depth: 1
 
 install:
   - ps: |
-        $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor/Install%20Rustup.ps1"
-        Invoke-WebRequest $url -OutFile "Install Rustup.ps1"
-        . ".\Install Rustup.ps1"
+        $url = "https://github.com/maidsafe/QA/raw/master/appveyor/install_rustup.ps1"
+        Invoke-WebRequest $url -OutFile "install_rustup.ps1"
+        . ".\install_rustup.ps1"
 
 platform:
   - x86
@@ -23,7 +29,7 @@ configuration:
   - Release
 
 build_script:
-  - cargo rustc --verbose --release -- --test -Zno-trans
+  - cargo rustc --verbose --release --profile test --lib -- -Zno-trans
 
 test_script:
   - cargo test --verbose --release --features use-mock-crust

--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -31,7 +31,7 @@
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations, variant_size_differences)]
 
-#![cfg_attr(feature = "use-mock-crust", allow(unused_extern_crates))]
+#![cfg_attr(feature = "use-mock-crust", allow(unused_extern_crates, unused_imports))]
 
 #[macro_use]
 extern crate log;

--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -148,7 +148,8 @@ mod unnamed {
                     let wait_for = wait_range.ind_sample(&mut rng);
 
                     while !*stop_condition && !wait_timed_out {
-                        let wake_up_result = unwrap!(condvar.wait_timeout(stop_condition,
+                        let wake_up_result =
+                            unwrap!(condvar.wait_timeout(stop_condition,
                                                          Duration::from_secs(wait_for)));
                         stop_condition = wake_up_result.0;
                         wait_timed_out = wake_up_result.1.timed_out();

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -110,7 +110,7 @@ Options:
         Put(String, String),
     }
 
-    fn read_user_commands(command_sender: Sender<UserCommand>) {
+    fn read_user_commands(command_sender: &Sender<UserCommand>) {
         loop {
             let mut command = String::new();
             let stdin = io::stdin();
@@ -153,7 +153,7 @@ Options:
                 command_receiver: command_receiver,
                 exit: false,
                 _joiner: thread::named("Command reader",
-                                       move || read_user_commands(command_sender)),
+                                       move || read_user_commands(&command_sender)),
             }
         }
 

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -34,7 +34,7 @@
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations, variant_size_differences)]
 
-#![cfg_attr(feature = "use-mock-crust", allow(unused_extern_crates))]
+#![cfg_attr(feature = "use-mock-crust", allow(unused_extern_crates, unused_imports))]
 
 #[macro_use]
 extern crate log;

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -129,8 +129,8 @@ Options:
             } else if parts.len() == 2 && parts[0] == "get" {
                 let _ = command_sender.send(UserCommand::Get(parts[1].to_string()));
             } else if parts.len() == 3 && parts[0] == "put" {
-                let _ =
-                command_sender.send(UserCommand::Put(parts[1].to_string(), parts[2].to_string()));
+                let _ = command_sender.send(UserCommand::Put(parts[1].to_string(),
+                                                             parts[2].to_string()));
             } else {
                 println!("Unrecognised command");
             }

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -79,10 +79,9 @@ impl ExampleClient {
     /// This is a blocking call and will wait indefinitely for the response.
     pub fn get(&mut self, request: DataIdentifier) -> Option<Data> {
         let message_id = MessageId::new();
-        unwrap!(self.routing_client
-            .send_get_request(Authority::NaeManager(*request.name()),
-                              request.clone(),
-                              message_id));
+        unwrap!(self.routing_client.send_get_request(Authority::NaeManager(*request.name()),
+                                                     request.clone(),
+                                                     message_id));
 
         // Wait for Get success event from Routing
         loop {
@@ -120,8 +119,9 @@ impl ExampleClient {
     pub fn put(&self, data: Data) -> Result<(), ()> {
         let data_id = data.identifier();
         let message_id = MessageId::new();
-        unwrap!(self.routing_client
-            .send_put_request(Authority::ClientManager(*self.name()), data, message_id));
+        unwrap!(self.routing_client.send_put_request(Authority::ClientManager(*self.name()),
+                                                     data,
+                                                     message_id));
 
         // Wait for Put success event from Routing
         loop {

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -276,6 +276,8 @@ impl ExampleNode {
 
 /// Refresh messages.
 #[derive(RustcEncodable, RustcDecodable)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 enum RefreshContent {
     /// A message to a `ClientManager` to insert a new client.
     Client { client_name: XorName, data: u64 },

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -15,13 +15,13 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::MIN_SECTION_SIZE;
 use lru_time_cache::LruCache;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use routing::{Authority, Data, DataIdentifier, Event, EventStream, MessageId, Node, Prefix,
-              Request, Response, XorName};
+use routing::{Authority, Data, DataIdentifier, Event, EventStream, MessageId, Node, Prefix, Request,
+              Response, XorName};
 use std::collections::HashMap;
 use std::time::Duration;
-use super::MIN_SECTION_SIZE;
 
 /// A simple example node implementation for a network based on the Routing library.
 pub struct ExampleNode {
@@ -175,8 +175,7 @@ impl ExampleNode {
                        self.get_debug_name(),
                        data.name(),
                        data);
-                let _ = self.node
-                    .send_put_success(dst, src, data.identifier(), id);
+                let _ = self.node.send_put_success(dst, src, data.identifier(), id);
                 let _ = self.db.insert(data.identifier(), data);
             }
             Authority::ClientManager(_) => {

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -87,9 +87,7 @@ impl AckManager {
     // returns None.
     pub fn find_timed_out(&mut self, token: u64) -> Option<(UnacknowledgedMessage, Ack)> {
         let timed_out_ack = if let Some((sip_hash, _)) =
-            self.pending
-                .iter()
-                .find(|&(_, unacked_msg)| unacked_msg.timer_token == token) {
+            self.pending.iter().find(|&(_, unacked_msg)| unacked_msg.timer_token == token) {
             *sip_hash
         } else {
             return None;

--- a/src/action.rs
+++ b/src/action.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/action.rs
+++ b/src/action.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+
 use error::InterfaceError;
 use messages::{Request, UserMessage};
 use routing_table::Authority;
@@ -29,6 +30,8 @@ use xor_name::XorName;
 ///       pending events should be handled.
 ///       After completion `Core` will send `Event::Terminated`.
 #[derive(Clone)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum Action {
     NodeSendMessage {
         src: Authority<XorName>,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,11 +102,11 @@ impl Client {
         });
 
         Ok(Client {
-            interface_result_tx: tx,
-            interface_result_rx: rx,
-            action_sender: action_sender,
-            _raii_joiner: raii_joiner,
-        })
+               interface_result_tx: tx,
+               interface_result_rx: rx,
+               action_sender: action_sender,
+               _raii_joiner: raii_joiner,
+           })
     }
 
     fn make_state_machine(keys: Option<FullId>,
@@ -226,12 +226,12 @@ impl Client {
         let (tx, rx) = channel();
 
         Ok(Client {
-            interface_result_tx: tx,
-            interface_result_rx: rx,
-            action_sender: action_sender,
-            machine: RefCell::new(machine),
-            event_buffer: RefCell::new(event_buffer),
-        })
+               interface_result_tx: tx,
+               interface_result_rx: rx,
+               action_sender: action_sender,
+               machine: RefCell::new(machine),
+               event_buffer: RefCell::new(event_buffer),
+           })
     }
 
     /// Get the next event in a non-blocking manner.
@@ -242,7 +242,10 @@ impl Client {
             return Ok(cached_ev);
         }
         self.try_step()?;
-        self.event_buffer.borrow_mut().take_first().ok_or(TryRecvError::Empty)
+        self.event_buffer
+            .borrow_mut()
+            .take_first()
+            .ok_or(TryRecvError::Empty)
     }
 
     /// Process all inbound events and buffer any produced events on the internal buffer.
@@ -261,12 +264,18 @@ impl Client {
 
     /// Resend all unacknowledged messages.
     pub fn resend_unacknowledged(&self) -> bool {
-        self.machine.borrow_mut().current_mut().resend_unacknowledged()
+        self.machine
+            .borrow_mut()
+            .current_mut()
+            .resend_unacknowledged()
     }
 
     /// Are there any unacknowledged messages?
     pub fn has_unacknowledged(&self) -> bool {
-        self.machine.borrow().current().has_unacknowledged()
+        self.machine
+            .borrow()
+            .current()
+            .has_unacknowledged()
     }
 }
 

--- a/src/client_errors.rs
+++ b/src/client_errors.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/append_types.rs
+++ b/src/data/append_types.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/append_types.rs
+++ b/src/data/append_types.rs
@@ -15,11 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{DataIdentifier, PrivAppendedData, verify_detached};
 use error::RoutingError;
 use maidsafe_utilities::serialisation::serialise;
 use rust_sodium::crypto::sign::{self, PublicKey, SecretKey, Signature};
 use std::collections::BTreeSet;
-use super::{DataIdentifier, PrivAppendedData, verify_detached};
 use xor_name::XorName;
 
 /// The type of access filter for appendable data.
@@ -63,10 +63,10 @@ impl AppendedData {
         let data_to_sign = serialise(&(&pointer, &pub_key))?;
         let signature = sign::sign_detached(&data_to_sign, secret_key);
         Ok(AppendedData {
-            pointer: pointer,
-            sign_key: pub_key,
-            signature: signature,
-        })
+               pointer: pointer,
+               sign_key: pub_key,
+               signature: signature,
+           })
     }
 
     /// Returns `true` if the signature matches the data.
@@ -125,12 +125,12 @@ impl AppendWrapper {
         let data_to_sign = serialise(&(&append_to, &data, &sign_pair.0, &version))?;
         let signature = sign::sign_detached(&data_to_sign, sign_pair.1);
         Ok(AppendWrapper::Priv {
-            append_to: append_to,
-            data: data,
-            sign_key: *sign_pair.0,
-            version: version,
-            signature: signature,
-        })
+               append_to: append_to,
+               data: data,
+               sign_key: *sign_pair.0,
+               version: version,
+               signature: signature,
+           })
     }
 
     /// Returns the identifier of the data to append to.
@@ -194,10 +194,10 @@ impl AppendWrapper {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use data::{DataIdentifier, PrivAppendedData};
     use rand;
     use rust_sodium::crypto::{box_, sign};
-    use super::*;
 
     #[test]
     fn pub_signatures() {

--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -15,11 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::DataIdentifier;
 use maidsafe_utilities::serialisation::serialised_size;
 use rust_sodium::crypto::hash::sha256;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::fmt::{self, Debug, Formatter};
-use super::DataIdentifier;
 use xor_name::XorName;
 
 /// Maximum allowed size for a serialised Immutable Data (ID) to grow to
@@ -79,9 +79,9 @@ impl Decodable for ImmutableData {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<ImmutableData, D::Error> {
         let value: Vec<u8> = Decodable::decode(decoder)?;
         Ok(ImmutableData {
-            name: XorName(sha256::hash(&value).0),
-            value: value,
-        })
+               name: XorName(sha256::hash(&value).0),
+               value: value,
+           })
     }
 }
 
@@ -93,8 +93,8 @@ impl Debug for ImmutableData {
 
 #[cfg(test)]
 mod tests {
-    use rustc_serialize::hex::ToHex;
     use super::*;
+    use rustc_serialize::hex::ToHex;
 
     #[test]
     fn deterministic_test() {
@@ -102,7 +102,10 @@ mod tests {
 
         // Normal
         let immutable_data = ImmutableData::new(value);
-        let immutable_data_name = immutable_data.name().0.as_ref().to_hex();
+        let immutable_data_name = immutable_data.name()
+            .0
+            .as_ref()
+            .to_hex();
         let expected_name = "ec0775555a7a6afba5f6e0a1deaa06f8928da80cf6ca94742ecc2a00c31033d3";
 
         assert_eq!(&expected_name, &immutable_data_name);

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -21,14 +21,14 @@ mod priv_appendable_data;
 mod pub_appendable_data;
 mod structured_data;
 
-use error::RoutingError;
-use rust_sodium::crypto::sign::{self, PublicKey, Signature};
 pub use self::append_types::{AppendWrapper, AppendedData, Filter};
 pub use self::immutable_data::{ImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES};
 pub use self::priv_appendable_data::{MAX_PRIV_APPENDABLE_DATA_SIZE_IN_BYTES, PrivAppendableData,
                                      PrivAppendedData};
 pub use self::pub_appendable_data::{MAX_PUB_APPENDABLE_DATA_SIZE_IN_BYTES, PubAppendableData};
 pub use self::structured_data::{MAX_STRUCTURED_DATA_SIZE_IN_BYTES, StructuredData};
+use error::RoutingError;
+use rust_sodium::crypto::sign::{self, PublicKey, Signature};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
 use xor_name::XorName;
@@ -48,8 +48,9 @@ pub fn verify_signatures(owners: &BTreeSet<PublicKey>,
     }
 
     // Refuse if there is any invalid signature
-    if !signatures.iter()
-        .all(|(pub_key, sig)| owners.contains(pub_key) && verify_detached(sig, data, pub_key)) {
+    if !signatures.iter().all(|(pub_key, sig)| {
+                                  owners.contains(pub_key) && verify_detached(sig, data, pub_key)
+                              }) {
         return Err(RoutingError::FailedSignature);
     }
     Ok(())
@@ -144,10 +145,10 @@ impl DataIdentifier {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use rand;
     use rust_sodium::crypto::hash::sha256;
     use std::collections::BTreeSet;
-    use super::*;
     use xor_name::XorName;
 
     #[test]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -48,9 +48,8 @@ pub fn verify_signatures(owners: &BTreeSet<PublicKey>,
     }
 
     // Refuse if there is any invalid signature
-    if !signatures.iter().all(|(pub_key, sig)| {
-                                  owners.contains(pub_key) && verify_detached(sig, data, pub_key)
-                              }) {
+    let verify = |(pub_key, sig)| owners.contains(pub_key) && verify_detached(sig, data, pub_key);
+    if !signatures.iter().all(verify) {
         return Err(RoutingError::FailedSignature);
     }
     Ok(())

--- a/src/data/priv_appendable_data.rs
+++ b/src/data/priv_appendable_data.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/pub_appendable_data.rs
+++ b/src/data/pub_appendable_data.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/pub_appendable_data.rs
+++ b/src/data/pub_appendable_data.rs
@@ -15,12 +15,12 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{AppendWrapper, AppendedData, DataIdentifier, Filter, NO_OWNER_PUB_KEY};
 use error::RoutingError;
 use maidsafe_utilities::serialisation::{serialise, serialised_size};
 use rust_sodium::crypto::sign::{self, PublicKey, SecretKey, Signature};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
-use super::{AppendWrapper, AppendedData, DataIdentifier, Filter, NO_OWNER_PUB_KEY};
 use xor_name::XorName;
 
 /// Maximum allowed size for a public appendable data to grow to
@@ -65,14 +65,14 @@ impl PubAppendableData {
         }
 
         Ok(PubAppendableData {
-            name: name,
-            version: version,
-            filter: filter,
-            deleted_data: deleted_data,
-            owners: owners,
-            signatures: BTreeMap::new(),
-            data: BTreeSet::new(),
-        })
+               name: name,
+               version: version,
+               filter: filter,
+               deleted_data: deleted_data,
+               owners: owners,
+               signatures: BTreeMap::new(),
+               data: BTreeSet::new(),
+           })
     }
 
     /// Updates this data item with the given updated version if the update is valid, otherwise
@@ -106,9 +106,9 @@ impl PubAppendableData {
     /// recently been deleted.
     pub fn append(&mut self, appended_data: AppendedData) -> bool {
         if match self.filter {
-            Filter::WhiteList(ref white_list) => !white_list.contains(&appended_data.sign_key),
-            Filter::BlackList(ref black_list) => black_list.contains(&appended_data.sign_key),
-        } || self.deleted_data.contains(&appended_data) {
+               Filter::WhiteList(ref white_list) => !white_list.contains(&appended_data.sign_key),
+               Filter::BlackList(ref black_list) => black_list.contains(&appended_data.sign_key),
+           } || self.deleted_data.contains(&appended_data) {
             return false;
         }
         self.data.insert(appended_data)
@@ -163,7 +163,10 @@ impl PubAppendableData {
         let sd = SerialisablePubAppendableData {
             name: self.name,
             owners: &self.owners,
-            version: self.version.to_string().as_bytes().to_vec(),
+            version: self.version
+                .to_string()
+                .as_bytes()
+                .to_vec(),
             filter: &self.filter,
             deleted_data: &self.deleted_data,
         };
@@ -241,11 +244,11 @@ struct SerialisablePubAppendableData<'a> {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use data::{self, AppendWrapper, AppendedData, DataIdentifier, Filter};
     use rand;
     use rust_sodium::crypto::sign;
     use std::collections::BTreeSet;
-    use super::*;
     use xor_name::XorName;
 
     #[test]
@@ -267,12 +270,12 @@ mod test {
                 assert!(data::verify_signatures(&owner_keys,
                                                 &data,
                                                 pub_appendable_data.get_signatures())
-                    .is_err());
+                                .is_err());
                 assert!(pub_appendable_data.add_signature(&keys).is_ok());
                 assert!(data::verify_signatures(&owner_keys,
                                                 &data,
                                                 pub_appendable_data.get_signatures())
-                    .is_ok());
+                                .is_ok());
             }
             Err(error) => panic!("Error: {:?}", error),
         }
@@ -299,7 +302,7 @@ mod test {
                 assert!(data::verify_signatures(&owner_keys,
                                                 &data,
                                                 pub_appendable_data.get_signatures())
-                    .is_err());
+                                .is_err());
             }
             Err(error) => panic!("Error: {:?}", error),
         }
@@ -310,11 +313,12 @@ mod test {
         let black_key = sign::gen_keypair();
         let white_key = sign::gen_keypair();
 
-        let mut pub_appendable_data = unwrap!(PubAppendableData::new(rand::random(),
-                                              0,
-                                              BTreeSet::new(),
-                                              BTreeSet::new(),
-                                              Filter::white_list(vec![white_key.0]),));
+        let data = PubAppendableData::new(rand::random(),
+                                          0,
+                                          BTreeSet::new(),
+                                          BTreeSet::new(),
+                                          Filter::white_list(vec![white_key.0]));
+        let mut pub_appendable_data = unwrap!(data);
 
         let pointer = DataIdentifier::Structured(rand::random(), 10000);
         let black_appended_data = unwrap!(AppendedData::new(pointer, black_key.0, &black_key.1));
@@ -329,11 +333,12 @@ mod test {
         let black_key = sign::gen_keypair();
         let white_key = sign::gen_keypair();
 
-        let mut pub_appendable_data = unwrap!(PubAppendableData::new(rand::random(),
-                                              0,
-                                              BTreeSet::new(),
-                                              BTreeSet::new(),
-                                              Filter::black_list(vec![black_key.0])));
+        let data = PubAppendableData::new(rand::random(),
+                                          0,
+                                          BTreeSet::new(),
+                                          BTreeSet::new(),
+                                          Filter::black_list(vec![black_key.0]));
+        let mut pub_appendable_data = unwrap!(data);
 
         let pointer = DataIdentifier::Structured(rand::random(), 10000);
         let black_appended_data = unwrap!(AppendedData::new(pointer, black_key.0, &black_key.1));
@@ -348,11 +353,12 @@ mod test {
         let keys = sign::gen_keypair();
         let name: XorName = rand::random();
 
-        let mut pub_appendable_data = unwrap!(PubAppendableData::new(name,
-                                                                     0,
-                                                                     BTreeSet::new(),
-                                                                     BTreeSet::new(),
-                                                                     Filter::black_list(None)));
+        let data = PubAppendableData::new(name,
+                                          0,
+                                          BTreeSet::new(),
+                                          BTreeSet::new(),
+                                          Filter::black_list(None));
+        let mut pub_appendable_data = unwrap!(data);
         let pointer = DataIdentifier::Structured(rand::random(), 10000);
         let appended_data = unwrap!(AppendedData::new(pointer, keys.0, &keys.1));
 
@@ -375,24 +381,24 @@ mod test {
         new_owner.insert(other_keys.0);
         let name: XorName = rand::random();
 
-        let mut ad = unwrap!(PubAppendableData::new(name,
-                                                    0,
-                                                    owner,
-                                                    BTreeSet::new(),
-                                                    Filter::black_list(None)));
-        let mut ad_new = unwrap!(PubAppendableData::new(name,
-                                                        1,
-                                                        new_owner.clone(),
-                                                        BTreeSet::new(),
-                                                        Filter::black_list(None)));
+        let mut data =
+            PubAppendableData::new(name, 0, owner, BTreeSet::new(), Filter::black_list(None));
+        let mut ad = unwrap!(data);
+        data = PubAppendableData::new(name,
+                                      1,
+                                      new_owner.clone(),
+                                      BTreeSet::new(),
+                                      Filter::black_list(None));
+        let mut ad_new = unwrap!(data);
         assert!(ad_new.add_signature(&keys).is_ok());
         assert!(ad.update_with_other(ad_new).is_ok());
 
-        let mut ad_fail = unwrap!(PubAppendableData::new(name,
-                                                         2,
-                                                         new_owner.clone(),
-                                                         BTreeSet::new(),
-                                                         Filter::black_list(None)));
+        data = PubAppendableData::new(name,
+                                      2,
+                                      new_owner.clone(),
+                                      BTreeSet::new(),
+                                      Filter::black_list(None));
+        let mut ad_fail = unwrap!(data);
         assert!(ad_fail.add_signature(&keys).is_ok());
         assert!(ad.update_with_other(ad_fail).is_err());
     }

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -15,12 +15,12 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{DataIdentifier, NO_OWNER_PUB_KEY};
 use error::RoutingError;
 use maidsafe_utilities::serialisation::{serialise, serialised_size};
 use rust_sodium::crypto::sign::{self, PublicKey, SecretKey, Signature};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
-use super::{DataIdentifier, NO_OWNER_PUB_KEY};
 use utils;
 use xor_name::XorName;
 
@@ -54,13 +54,13 @@ impl StructuredData {
         }
 
         Ok(StructuredData {
-            type_tag: type_tag,
-            name: name,
-            data: data,
-            version: version,
-            owners: owners,
-            signatures: BTreeMap::new(),
-        })
+               type_tag: type_tag,
+               name: name,
+               data: data,
+               version: version,
+               owners: owners,
+               signatures: BTreeMap::new(),
+           })
     }
 
     /// Replaces this data item with the given updated version if the update is valid, otherwise
@@ -132,10 +132,16 @@ impl StructuredData {
         // Seems overkill to use serialisation here, but done to ensure cross platform signature
         // handling is OK
         let sd = SerialisableStructuredData {
-            type_tag: self.type_tag.to_string().as_bytes().to_vec(),
+            type_tag: self.type_tag
+                .to_string()
+                .as_bytes()
+                .to_vec(),
             name: self.name,
             data: &self.data,
-            version: self.version.to_string().as_bytes().to_vec(),
+            version: self.version
+                .to_string()
+                .as_bytes()
+                .to_vec(),
             owners: &self.owners,
         };
 
@@ -218,11 +224,11 @@ struct SerialisableStructuredData<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use data;
     use rand;
     use rust_sodium::crypto::sign;
     use std::collections::BTreeSet;
-    use super::*;
     use xor_name::XorName;
 
     #[test]
@@ -240,12 +246,12 @@ mod tests {
                 assert!(data::verify_signatures(&owner_keys,
                                                 &data,
                                                 structured_data.get_signatures())
-                    .is_err());
+                                .is_err());
                 assert!(structured_data.add_signature(&keys).is_ok());
                 assert!(data::verify_signatures(&owner_keys,
                                                 &data,
                                                 structured_data.get_signatures())
-                    .is_ok());
+                                .is_ok());
             }
             Err(error) => panic!("Error: {:?}", error),
         }
@@ -268,7 +274,7 @@ mod tests {
                 assert!(data::verify_signatures(&owner_keys,
                                                 &data,
                                                 structured_data.get_signatures())
-                    .is_err());
+                                .is_err());
             }
             Err(error) => panic!("Error: {:?}", error),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,13 +15,13 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::routing_table::Error as RoutingTableError;
 use action::Action;
 use crust::{self, PeerId};
 use event::Event;
 use maidsafe_utilities::event_sender::{EventSenderError, MaidSafeEventCategory};
 use maidsafe_utilities::serialisation;
 use std::sync::mpsc::{RecvError, SendError};
-use super::routing_table::Error as RoutingTableError;
 
 #[derive(Debug)]
 /// The type of errors that can occur if routing is unable to handle a send request.

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,8 +23,10 @@ use maidsafe_utilities::event_sender::{EventSenderError, MaidSafeEventCategory};
 use maidsafe_utilities::serialisation;
 use std::sync::mpsc::{RecvError, SendError};
 
-#[derive(Debug)]
 /// The type of errors that can occur if routing is unable to handle a send request.
+#[derive(Debug)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum InterfaceError {
     /// We are not connected to the network.
     NotConnected,
@@ -48,8 +50,10 @@ impl From<RecvError> for InterfaceError {
     }
 }
 
-#[derive(Debug)]
 /// The type of errors that can occur during handling of routing events.
+#[derive(Debug)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum RoutingError {
     /// The node/client has not bootstrapped yet
     NotBootstrapped,

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/event.rs
+++ b/src/event.rs
@@ -29,6 +29,8 @@ use xor_name::XorName;
 /// `Request` and `Response` events from section authorities are only raised once the quorum has
 /// been reached, i.e. enough members of the section have sent the same message.
 #[derive(Clone, Eq, PartialEq)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum Event {
     /// Received a request message.
     Request {

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -1,3 +1,20 @@
+// Copyright 2017 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
 use std::sync::mpsc::{RecvError, TryRecvError};
 
 /// Trait to fake a channel.

--- a/src/id.rs
+++ b/src/id.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 
 #![doc(html_logo_url =
            "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-       html_favicon_url = "http://maidsafe.net/img/favicon.ico",
+       html_favicon_url = "https://maidsafe.net/img/favicon.ico",
        html_root_url = "https://docs.rs/routing")]
 
 // For explanation of lint checks, run `rustc -W help` or see

--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -72,7 +72,10 @@ impl<Message: Hash> MessageFilter<Message> {
     #[cfg(test)]
     pub fn count(&self, message: &Message) -> usize {
         let hash_code = hash(message);
-        self.entries.iter().find(|t| t.hash_code == hash_code).map_or(0, |t| t.count)
+        self.entries
+            .iter()
+            .find(|t| t.hash_code == hash_code)
+            .map_or(0, |t| t.count)
     }
 
     /// Removes any expired messages, then returns whether `message` exists in the filter or not.
@@ -133,10 +136,10 @@ impl TimestampedMessage {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use rand::{self, Rng};
     use std::thread;
     use std::time::Duration;
-    use super::*;
 
     #[test]
     fn timeout() {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::QUORUM;
 use ack_manager::Ack;
 #[cfg(not(feature = "use-mock-crust"))]
 use crust::PeerId;
@@ -37,7 +38,6 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::iter;
 use std::time::Duration;
-use super::QUORUM;
 use tiny_keccak::sha3_256;
 use types::MessageId;
 use utils;
@@ -212,11 +212,11 @@ impl HopMessage {
                -> Result<HopMessage, RoutingError> {
         let bytes_to_sign = serialise(&content)?;
         Ok(HopMessage {
-            content: content,
-            route: route,
-            sent_to: sent_to,
-            signature: sign::sign_detached(&bytes_to_sign, signing_key),
-        })
+               content: content,
+               route: route,
+               sent_to: sent_to,
+               signature: sign::sign_detached(&bytes_to_sign, signing_key),
+           })
     }
 
     /// Validate that the message is signed by `verification_key` contained in message.
@@ -280,10 +280,10 @@ impl SignedMessage {
         src_sections.sort_by_key(|list| list.prefix);
         let sig = sign::sign_detached(&serialise(&content)?, full_id.signing_private_key());
         Ok(SignedMessage {
-            content: content,
-            src_sections: src_sections,
-            signatures: iter::once((*full_id.public_id(), sig)).collect(),
-        })
+               content: content,
+               src_sections: src_sections,
+               signatures: iter::once((*full_id.public_id(), sig)).collect(),
+           })
     }
 
     /// Confirms the signatures.
@@ -306,7 +306,10 @@ impl SignedMessage {
 
     /// Returns the number of nodes in the source authority.
     pub fn src_size(&self) -> usize {
-        self.src_sections.iter().map(|sl| sl.pub_ids.len()).sum()
+        self.src_sections
+            .iter()
+            .map(|sl| sl.pub_ids.len())
+            .sum()
     }
 
     /// Adds the given signature if it is new, without validating it. If the collection of section
@@ -406,7 +409,12 @@ impl SignedMessage {
                 let valid_names: HashSet<_> = self.src_sections
                     .iter()
                     .flat_map(|list| list.pub_ids.iter().map(PublicId::name))
-                    .sorted_by(|lhs, rhs| self.content.src.name().cmp_distance(lhs, rhs))
+                    .sorted_by(|lhs, rhs| {
+                                   self.content
+                                       .src
+                                       .name()
+                                       .cmp_distance(lhs, rhs)
+                               })
                     .into_iter()
                     .take(min_section_size)
                     .collect();
@@ -457,10 +465,10 @@ impl RoutingMessage {
     /// Create ack for the given message
     pub fn ack_from(msg: &RoutingMessage, src: Authority<XorName>) -> Result<Self, RoutingError> {
         Ok(RoutingMessage {
-            src: src,
-            dst: msg.src,
-            content: MessageContent::Ack(Ack::compute(msg)?, msg.priority()),
-        })
+               src: src,
+               dst: msg.src,
+               content: MessageContent::Ack(Ack::compute(msg)?, msg.priority()),
+           })
     }
 
     /// Returns the priority Crust should send this message with.
@@ -879,17 +887,17 @@ impl UserMessage {
         let part_count = (len + MAX_PART_LEN - 1) / MAX_PART_LEN;
 
         Ok((0..part_count)
-            .map(|i| {
-                MessageContent::UserMessagePart {
-                    hash: hash,
-                    part_count: part_count as u32,
-                    part_index: i as u32,
-                    cacheable: self.is_cacheable(),
-                    payload: payload[(i * len / part_count)..((i + 1) * len / part_count)].to_vec(),
-                    priority: priority,
-                }
-            })
-            .collect())
+               .map(|i| {
+            MessageContent::UserMessagePart {
+                hash: hash,
+                part_count: part_count as u32,
+                part_index: i as u32,
+                cacheable: self.is_cacheable(),
+                payload: payload[(i * len / part_count)..((i + 1) * len / part_count)].to_vec(),
+                priority: priority,
+            }
+        })
+               .collect())
     }
 
     /// Puts the given parts of a serialised message together and verifies that it matches the
@@ -1208,15 +1216,18 @@ impl UserMessageCache {
             }
         }
 
-        self.0
-            .remove(&(hash, part_count))
-            .and_then(|part_map| UserMessage::from_parts(hash, part_map.values()).ok())
+        self.0.remove(&(hash, part_count)).and_then(|part_map| {
+                                                        UserMessage::from_parts(hash,
+                                                                                part_map.values())
+                                                                .ok()
+                                                    })
     }
 }
 
 #[cfg(test)]
 mod tests {
 
+    use super::*;
     #[cfg(not(feature = "use-mock-crust"))]
     use crust::PeerId;
     use data::{Data, ImmutableData};
@@ -1230,7 +1241,6 @@ mod tests {
     use rust_sodium::crypto::sign;
     use std::collections::BTreeSet;
     use std::iter;
-    use super::*;
     use tiny_keccak::sha3_256;
     use types::MessageId;
     use xor_name::XorName;
@@ -1388,21 +1398,21 @@ mod tests {
         let payloads: Vec<Vec<u8>> = parts.into_iter()
             .enumerate()
             .map(|(i, msg)| match msg {
-                MessageContent::UserMessagePart { hash,
-                                                  part_count,
-                                                  part_index,
-                                                  payload,
-                                                  priority,
-                                                  cacheable } => {
-                    assert_eq!(msg_hash, hash);
-                    assert_eq!(3, part_count);
-                    assert_eq!(i, part_index as usize);
-                    assert_eq!(42, priority);
-                    assert!(!cacheable);
-                    payload
-                }
-                msg => panic!("Unexpected message {:?}", msg),
-            })
+                     MessageContent::UserMessagePart { hash,
+                                                       part_count,
+                                                       part_index,
+                                                       payload,
+                                                       priority,
+                                                       cacheable } => {
+                assert_eq!(msg_hash, hash);
+                assert_eq!(3, part_count);
+                assert_eq!(i, part_index as usize);
+                assert_eq!(42, priority);
+                assert!(!cacheable);
+                payload
+            }
+                     msg => panic!("Unexpected message {:?}", msg),
+                 })
             .collect();
         let deserialised_user_msg = unwrap!(UserMessage::from_parts(msg_hash, payloads.iter()));
         assert_eq!(user_msg, deserialised_user_msg);

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -59,6 +59,8 @@ pub const CLIENT_GET_PRIORITY: u8 = 3;
 ///
 /// This is the only type allowed to be sent / received on the network.
 #[derive(Debug, RustcEncodable, RustcDecodable)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum Message {
     /// A message sent between two nodes directly
     Direct(DirectMessage),
@@ -545,6 +547,8 @@ impl RoutingMessage {
 /// of Y to its routing table.
 ///
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum MessageContent {
     // ---------- Internal ------------
     /// Ask the network to alter your `PublicId` name.
@@ -948,6 +952,8 @@ impl UserMessage {
 
 /// Request message types
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum Request {
     /// Message from upper layers sending network state on any network churn event.
     Refresh(Vec<u8>, MessageId),

--- a/src/messaging/error.rs
+++ b/src/messaging/error.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/messaging/mpid_header.rs
+++ b/src/messaging/mpid_header.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/messaging/mpid_header.rs
+++ b/src/messaging/mpid_header.rs
@@ -147,7 +147,7 @@ mod tests {
         }
         let mut metadata = messaging::generate_random_bytes(MAX_HEADER_METADATA_SIZE);
         let header = unwrap!(MpidHeader::new(sender.clone(), metadata.clone(), &secret_key));
-        assert!(*header.metadata() == metadata);
+        assert_eq!(*header.metadata(), metadata);
         metadata.push(0);
         assert!(MpidHeader::new(sender.clone(), metadata.clone(), &secret_key).is_err());
         let _ = metadata.pop();
@@ -165,15 +165,15 @@ mod tests {
         // different GUIDs and signatures.
         let header1 = unwrap!(MpidHeader::new(sender.clone(), metadata.clone(), &secret_key));
         let header2 = unwrap!(MpidHeader::new(sender.clone(), metadata.clone(), &secret_key));
-        assert!(header1 != header2);
+        assert_ne!(header1, header2);
         assert_eq!(*header1.sender(), sender);
         assert_eq!(header1.sender(), header2.sender());
         assert_eq!(*header1.metadata(), metadata);
         assert_eq!(header1.metadata(), header2.metadata());
-        assert!(header1.guid() != header2.guid());
-        assert!(header1.signature() != header2.signature());
+        assert_ne!(header1.guid(), header2.guid());
+        assert_ne!(header1.signature(), header2.signature());
         let name1 = unwrap!(header1.name());
         let name2 = unwrap!(header2.name());
-        assert!(name1 != name2);
+        assert_ne!(name1, name2);
     }
 }

--- a/src/messaging/mpid_header.rs
+++ b/src/messaging/mpid_header.rs
@@ -19,12 +19,12 @@
 /// bytes).
 pub const MAX_HEADER_METADATA_SIZE: usize = 128; // bytes
 
+use super::{Error, GUID_SIZE};
 use maidsafe_utilities::serialisation::serialise;
 use rand::{self, Rng};
 use rust_sodium::crypto::hash::sha256;
 use rust_sodium::crypto::sign::{self, PublicKey, SecretKey, Signature};
 use std::fmt::{self, Debug, Formatter};
-use super::{Error, GUID_SIZE};
 use utils;
 use xor_name::XorName;
 
@@ -75,9 +75,9 @@ impl MpidHeader {
 
         let encoded = serialise(&detail)?;
         Ok(MpidHeader {
-            detail: detail,
-            signature: sign::sign_detached(&encoded, secret_key),
-        })
+               detail: detail,
+               signature: sign::sign_detached(&encoded, secret_key),
+           })
     }
 
     /// The name of the original creator of the message.
@@ -129,10 +129,10 @@ impl Debug for MpidHeader {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use messaging;
     use rand;
     use rust_sodium::crypto::sign;
-    use super::*;
     use xor_name::XorName;
 
     #[test]

--- a/src/messaging/mpid_message.rs
+++ b/src/messaging/mpid_message.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/messaging/mpid_message.rs
+++ b/src/messaging/mpid_message.rs
@@ -19,10 +19,10 @@
 /// bytes).
 pub const MAX_BODY_SIZE: usize = 102400 - 512 - super::MAX_HEADER_METADATA_SIZE;
 
+use super::{Error, MpidHeader};
 use maidsafe_utilities::serialisation::serialise;
 use rust_sodium::crypto::sign::{self, PublicKey, SecretKey, Signature};
 use std::fmt::{self, Debug, Formatter};
-use super::{Error, MpidHeader};
 use utils;
 use xor_name::XorName;
 
@@ -74,10 +74,10 @@ impl MpidMessage {
 
         let recipient_and_body = serialise(&detail)?;
         Ok(MpidMessage {
-            header: header,
-            detail: detail,
-            signature: sign::sign_detached(&recipient_and_body, secret_key),
-        })
+               header: header,
+               detail: detail,
+               signature: sign::sign_detached(&recipient_and_body, secret_key),
+           })
     }
 
     /// Getter for `MpidHeader` member, created when calling `new()`.
@@ -127,10 +127,10 @@ impl Debug for MpidMessage {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use messaging;
     use rand;
     use rust_sodium::crypto::sign;
-    use super::*;
     use xor_name::XorName;
 
     #[test]
@@ -162,7 +162,7 @@ mod tests {
                                  recipient.clone(),
                                  body.clone(),
                                  &secret_key)
-            .is_err());
+                        .is_err());
         let _ = body.pop();
 
         // Check verify function with a valid and invalid key

--- a/src/messaging/mpid_message.rs
+++ b/src/messaging/mpid_message.rs
@@ -155,7 +155,7 @@ mod tests {
                                                recipient.clone(),
                                                body.clone(),
                                                &secret_key));
-        assert!(*message.body() == body);
+        assert_eq!(*message.body(), body);
         body.push(0);
         assert!(MpidMessage::new(sender.clone(),
                                  metadata.clone(),

--- a/src/messaging/mpid_message_wrapper.rs
+++ b/src/messaging/mpid_message_wrapper.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/messaging/mpid_message_wrapper.rs
+++ b/src/messaging/mpid_message_wrapper.rs
@@ -21,6 +21,8 @@ use xor_name::XorName;
 /// A serialisable wrapper to allow multiplexing all MPID message types and actions via a single
 /// type.
 #[derive(PartialEq, Eq, Hash, Clone, Debug, RustcDecodable, RustcEncodable)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum MpidMessageWrapper {
     /// Sent by a Client to its MpidManagers to notify them that it has just connected to the
     /// network.

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -16,14 +16,14 @@
 // relating to use of the SAFE Network Software.
 
 
+
+use super::support::{self, Endpoint, Network, ServiceHandle, ServiceImpl};
 use maidsafe_utilities::event_sender;
 use std::{fmt, io, thread};
 use std::cell::{RefCell, RefMut};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::rc::Rc;
-
-use super::support::{self, Endpoint, Network, ServiceHandle, ServiceImpl};
 
 /// TCP listener port
 pub const LISTENER_PORT: u16 = 5485;
@@ -43,7 +43,10 @@ impl Service {
     pub fn with_handle(handle: &ServiceHandle,
                        event_sender: CrustEventSender)
                        -> Result<Self, CrustError> {
-        let network = handle.0.borrow().network.clone();
+        let network = handle.0
+            .borrow()
+            .network
+            .clone();
         let service = Service(handle.0.clone(), network);
         service.lock_and_poll(|imp| imp.start(event_sender));
 

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -14,8 +14,6 @@
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
-
-
 
 use super::support::{self, Endpoint, Network, ServiceHandle, ServiceImpl};
 use maidsafe_utilities::event_sender;

--- a/src/mock_crust/mod.rs
+++ b/src/mock_crust/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -15,6 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::crust::{ConnectionInfoResult, CrustEventSender, CrustUser, Event, PeerId,
+                   PrivConnectionInfo, PubConnectionInfo};
 use maidsafe_utilities::SeededRng;
 use rand::{Rng, XorShiftRng};
 use rust_sodium;
@@ -24,8 +26,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::collections::hash_map::Entry;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::rc::{Rc, Weak};
-use super::crust::{ConnectionInfoResult, CrustEventSender, CrustUser, Event, PeerId,
-                   PrivConnectionInfo, PubConnectionInfo};
 
 /// Mock network. Create one before testing with mocks. Use it to create `ServiceHandle`s.
 #[derive(Clone)]
@@ -50,13 +50,13 @@ impl Network {
         };
         unwrap!(rust_sodium::init_with_rng(&mut rng));
         Network(Rc::new(RefCell::new(NetworkImpl {
-            services: HashMap::new(),
-            min_section_size: min_section_size,
-            next_endpoint: 0,
-            queue: HashMap::new(),
-            blocked_connections: HashSet::new(),
-            rng: SeededRng::new(),
-        })))
+                                         services: HashMap::new(),
+                                         min_section_size: min_section_size,
+                                         next_endpoint: 0,
+                                         queue: HashMap::new(),
+                                         blocked_connections: HashSet::new(),
+                                         rng: SeededRng::new(),
+                                     })))
     }
 
     /// Create new ServiceHandle.
@@ -69,10 +69,10 @@ impl Network {
 
         let handle = ServiceHandle::new(self.clone(), config, endpoint);
         if self.0
-            .borrow_mut()
-            .services
-            .insert(endpoint, Rc::downgrade(&handle.0))
-            .is_some() {
+               .borrow_mut()
+               .services
+               .insert(endpoint, Rc::downgrade(&handle.0))
+               .is_some() {
             debug!("Tried to insert duplicate service handle ");
         }
 
@@ -143,11 +143,17 @@ impl Network {
     /// Construct a new [`XorShiftRng`](https://doc.rust-lang.org/rand/rand/struct.XorShiftRng.html)
     /// using a seed generated from random data provided by `self`.
     pub fn new_rng(&self) -> XorShiftRng {
-        self.0.borrow_mut().rng.new_rng()
+        self.0
+            .borrow_mut()
+            .rng
+            .new_rng()
     }
 
     fn connection_blocked(&self, sender: Endpoint, receiver: Endpoint) -> bool {
-        self.0.borrow().blocked_connections.contains(&(sender, receiver))
+        self.0
+            .borrow()
+            .blocked_connections
+            .contains(&(sender, receiver))
     }
 
     fn send(&self, sender: Endpoint, receiver: Endpoint, packet: Packet) {
@@ -163,29 +169,36 @@ impl Network {
     // drop packets going the other way).
     fn drop_pending(&self, sender: Endpoint, receiver: Endpoint) {
         if let Some(deque) = self.0
-            .borrow_mut()
-            .queue
-            .get_mut(&(sender, receiver)) {
+               .borrow_mut()
+               .queue
+               .get_mut(&(sender, receiver)) {
             deque.clear();
         }
     }
 
     // Drops all pending messages across the entire network.
     fn drop_all_pending(&self) {
-        self.0.borrow_mut().queue.clear();
+        self.0
+            .borrow_mut()
+            .queue
+            .clear();
     }
 
     fn pop_packet(&self) -> Option<(Endpoint, Endpoint, Packet)> {
         let mut network_impl = self.0.borrow_mut();
-        let keys: Vec<_> = network_impl.queue.keys().cloned().collect();
+        let keys: Vec<_> = network_impl.queue
+            .keys()
+            .cloned()
+            .collect();
         let (sender, receiver) = if let Some(key) = network_impl.rng.choose(&keys) {
             *key
         } else {
             return None;
         };
-        let result = network_impl.queue
-            .get_mut(&(sender, receiver))
-            .and_then(|packets| packets.pop_front().map(|packet| (sender, receiver, packet)));
+        let result =
+            network_impl.queue.get_mut(&(sender, receiver)).and_then(|packets| {
+                packets.pop_front().map(|packet| (sender, receiver, packet))
+            });
         if result.is_some() {
             if let Entry::Occupied(entry) = network_impl.queue.entry((sender, receiver)) {
                 if entry.get().is_empty() {
@@ -213,7 +226,11 @@ impl Network {
     }
 
     fn find_service(&self, endpoint: Endpoint) -> Option<Rc<RefCell<ServiceImpl>>> {
-        self.0.borrow().services.get(&endpoint).and_then(|s| s.upgrade())
+        self.0
+            .borrow()
+            .services
+            .get(&endpoint)
+            .and_then(|s| s.upgrade())
     }
 }
 
@@ -294,9 +311,9 @@ impl ServiceImpl {
         // immediately.
         if pending_bootstraps == 0 {
             unwrap!(self.event_sender
-                .as_ref()
-                .unwrap()
-                .send(Event::BootstrapFailed));
+                        .as_ref()
+                        .unwrap()
+                        .send(Event::BootstrapFailed));
         }
 
         self.pending_bootstraps = pending_bootstraps;
@@ -469,9 +486,7 @@ impl ServiceImpl {
     // Remove connected peer with the given peer id and return its endpoint,
     // or None if no such peer exists.
     fn remove_connection_by_peer_id(&mut self, peer_id: &PeerId) -> Option<Endpoint> {
-        if let Some(i) = self.connections
-            .iter()
-            .position(|&(id, _)| id == *peer_id) {
+        if let Some(i) = self.connections.iter().position(|&(id, _)| id == *peer_id) {
             Some(self.connections.swap_remove(i).1)
         } else {
             None
@@ -479,9 +494,7 @@ impl ServiceImpl {
     }
 
     fn remove_connection_by_endpoint(&mut self, endpoint: Endpoint) -> Option<PeerId> {
-        if let Some(i) = self.connections
-            .iter()
-            .position(|&(_, ep)| ep == endpoint) {
+        if let Some(i) = self.connections.iter().position(|&(_, ep)| ep == endpoint) {
             Some(self.connections.swap_remove(i).0)
         } else {
             None
@@ -618,11 +631,11 @@ pub fn make_current<F, R>(handle: &ServiceHandle, f: F) -> R
     where F: FnOnce() -> R
 {
     CURRENT.with(|current| {
-        *current.borrow_mut() = Some(handle.clone());
-        let result = f();
-        *current.borrow_mut() = None;
-        result
-    })
+                     *current.borrow_mut() = Some(handle.clone());
+                     let result = f();
+                     *current.borrow_mut() = None;
+                     result
+                 })
 }
 
 pub fn get_current() -> ServiceHandle {

--- a/src/mock_crust/tests.rs
+++ b/src/mock_crust/tests.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/mock_crust/tests.rs
+++ b/src/mock_crust/tests.rs
@@ -17,11 +17,11 @@
 
 // These tests are almost straight up copied from crust::service::tests
 
+use super::crust::{CrustEventSender, CrustUser, Event, Service};
+use super::support::{Config, Network};
 use maidsafe_utilities::event_sender::{MaidSafeEventCategory, MaidSafeObserver};
 use std::collections::HashSet;
 use std::sync::mpsc::{self, Receiver};
-use super::crust::{CrustEventSender, CrustUser, Event, Service};
-use super::support::{Config, Network};
 
 fn get_event_sender() -> (CrustEventSender, Receiver<MaidSafeEventCategory>, Receiver<Event>) {
     let (category_tx, category_rx) = mpsc::channel();
@@ -84,7 +84,8 @@ fn start_two_services_bootstrap_communicate_exit() {
     unwrap!(service_0.send(id_1, data_sent.clone(), 0));
 
     // 1 should rx data
-    let (data_recvd, peer_id) = expect_event!(event_rx_1,
+    let (data_recvd, peer_id) =
+        expect_event!(event_rx_1,
                       Event::NewMessage(their_id, msg) => (msg, their_id));
 
     assert_eq!(data_recvd, data_sent);
@@ -95,7 +96,8 @@ fn start_two_services_bootstrap_communicate_exit() {
     unwrap!(service_1.send(id_0, data_sent.clone(), 0));
 
     // 0 should rx data
-    let (data_recvd, peer_id) = expect_event!(event_rx_0,
+    let (data_recvd, peer_id) =
+        expect_event!(event_rx_0,
                       Event::NewMessage(their_id, msg) => (msg, their_id));
 
     assert_eq!(data_recvd, data_sent);
@@ -146,7 +148,8 @@ fn start_two_services_rendezvous_connect() {
     unwrap!(service_0.send(id_1, data_sent.clone(), 0));
 
     // 1 should rx data
-    let (data_recvd, peer_id) = expect_event!(event_rx_1,
+    let (data_recvd, peer_id) =
+        expect_event!(event_rx_1,
                       Event::NewMessage(their_id, msg) => (msg, their_id));
 
     assert_eq!(data_recvd, data_sent);
@@ -157,7 +160,8 @@ fn start_two_services_rendezvous_connect() {
     unwrap!(service_1.send(id_0, data_sent.clone(), 0));
 
     // 0 should rx data
-    let (data_recvd, peer_id) = expect_event!(event_rx_0,
+    let (data_recvd, peer_id) =
+        expect_event!(event_rx_0,
                       Event::NewMessage(their_id, msg) => (msg, their_id));
 
     assert_eq!(data_recvd, data_sent);

--- a/src/mock_crust/tests.rs
+++ b/src/mock_crust/tests.rs
@@ -77,7 +77,7 @@ fn start_two_services_bootstrap_communicate_exit() {
     let id_0 = expect_event!(event_rx_1, Event::BootstrapConnect(id, _) => id);
     let id_1 = expect_event!(event_rx_0, Event::BootstrapAccept(id, CrustUser::Node) => id);
 
-    assert!(id_0 != id_1);
+    assert_ne!(id_0, id_1);
 
     // send data from 0 to 1
     let data_sent = vec![0, 1, 255, 254, 222, 1];

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/node.rs
+++ b/src/node.rs
@@ -89,11 +89,11 @@ impl NodeBuilder {
         let (tx, rx) = channel();
 
         Ok(Node {
-            interface_result_tx: tx,
-            interface_result_rx: rx,
-            machine: machine,
-            event_buffer: ev_buffer,
-        })
+               interface_result_tx: tx,
+               interface_result_rx: rx,
+               machine: machine,
+               event_buffer: ev_buffer,
+           })
     }
 
     // TODO - remove this `rustfmt_skip` once rustfmt stops adding trailing space at `else if`.
@@ -228,10 +228,10 @@ impl Node {
                             id: MessageId)
                             -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::GetFailure {
-            id: id,
-            data_id: data_id,
-            external_error_indicator: external_error_indicator,
-        });
+                                                 id: id,
+                                                 data_id: data_id,
+                                                 external_error_indicator: external_error_indicator,
+                                             });
         let priority = if dst.is_client() {
             CLIENT_GET_PRIORITY
         } else {
@@ -260,10 +260,10 @@ impl Node {
                             id: MessageId)
                             -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::PutFailure {
-            id: id,
-            data_id: data_id,
-            external_error_indicator: external_error_indicator,
-        });
+                                                 id: id,
+                                                 data_id: data_id,
+                                                 external_error_indicator: external_error_indicator,
+                                             });
         self.send_action(src, dst, user_msg, DEFAULT_PRIORITY)
     }
 
@@ -287,10 +287,10 @@ impl Node {
                              id: MessageId)
                              -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::PostFailure {
-            id: id,
-            data_id: data_id,
-            external_error_indicator: external_error_indicator,
-        });
+                                                 id: id,
+                                                 data_id: data_id,
+                                                 external_error_indicator: external_error_indicator,
+                                             });
         self.send_action(src, dst, user_msg, DEFAULT_PRIORITY)
     }
 
@@ -314,10 +314,10 @@ impl Node {
                                id: MessageId)
                                -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::DeleteFailure {
-            id: id,
-            data_id: data_id,
-            external_error_indicator: external_error_indicator,
-        });
+                                                 id: id,
+                                                 data_id: data_id,
+                                                 external_error_indicator: external_error_indicator,
+                                             });
         self.send_action(src, dst, user_msg, DEFAULT_PRIORITY)
     }
 
@@ -341,10 +341,10 @@ impl Node {
                                id: MessageId)
                                -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::AppendFailure {
-            id: id,
-            data_id: data_id,
-            external_error_indicator: external_error_indicator,
-        });
+                                                 id: id,
+                                                 data_id: data_id,
+                                                 external_error_indicator: external_error_indicator,
+                                             });
         self.send_action(src, dst, user_msg, DEFAULT_PRIORITY)
     }
 
@@ -357,10 +357,10 @@ impl Node {
                                          id: MessageId)
                                          -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::GetAccountInfoSuccess {
-            id: id,
-            data_stored: data_stored,
-            space_available: space_available,
-        });
+                                                 id: id,
+                                                 data_stored: data_stored,
+                                                 space_available: space_available,
+                                             });
         self.send_action(src, dst, user_msg, CLIENT_GET_PRIORITY)
     }
 
@@ -372,9 +372,9 @@ impl Node {
                                          id: MessageId)
                                          -> Result<(), InterfaceError> {
         let user_msg = UserMessage::Response(Response::GetAccountInfoFailure {
-            id: id,
-            external_error_indicator: external_error_indicator,
-        });
+                                                 id: id,
+                                                 external_error_indicator: external_error_indicator,
+                                             });
         self.send_action(src, dst, user_msg, CLIENT_GET_PRIORITY)
     }
 
@@ -458,7 +458,10 @@ impl Node {
 
     /// Routing table of this node.
     pub fn routing_table(&self) -> Option<RoutingTable<XorName>> {
-        self.machine.current().routing_table().cloned()
+        self.machine
+            .current()
+            .routing_table()
+            .cloned()
     }
 
     /// Check whether this node acts as a tunnel node between `client_1` and `client_2`.

--- a/src/outbox.rs
+++ b/src/outbox.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -93,6 +93,8 @@ pub enum RoutingConnection {
 
 /// Our relationship status with a known peer.
 #[derive(Debug)]
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum PeerState {
     /// Waiting for Crust to prepare our `PrivConnectionInfo`. Contains source and destination for
     /// sending it to the peer, and their connection info with the associated request's message ID,

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -484,10 +484,10 @@ impl PeerManager {
             return Err(RoutingError::UnknownCandidate);
         };
         let challenge_response = &mut (if let Some(ref mut rp) = candidate.challenge_response {
-            rp
-        } else {
-            return Err(RoutingError::FailedResourceProofValidation);
-        });
+                                           rp
+                                       } else {
+                                           return Err(RoutingError::FailedResourceProofValidation);
+                                       });
         challenge_response.proof.extend(proof_part);
         if part_index + 1 != part_count {
             return Ok(None);
@@ -512,14 +512,14 @@ impl PeerManager {
         (&self)
          -> Result<(PublicId, Authority<XorName>, SectionMap), RoutingError> {
         if let Some((name, candidate)) =
-            self.candidates
-                .iter()
-                .find(|&(_, cand)| cand.passed_our_challenge && !cand.is_approved()) {
+            self.candidates.iter().find(|&(_, cand)| {
+                                            cand.passed_our_challenge && !cand.is_approved()
+                                        }) {
             return if let Some(peer) = self.peer_map.get_by_name(name) {
-                Ok((*peer.pub_id(), candidate.client_auth, self.pub_ids_by_section()))
-            } else {
-                Err(RoutingError::UnknownCandidate)
-            };
+                       Ok((*peer.pub_id(), candidate.client_auth, self.pub_ids_by_section()))
+                   } else {
+                       Err(RoutingError::UnknownCandidate)
+                   };
         }
         if let Some((name, _)) = self.candidates.iter().find(|&(_, cand)| !cand.is_approved()) {
             info!("{:?} Candidate {} has not passed our resource proof challenge in time. Not \
@@ -591,20 +591,20 @@ impl PeerManager {
             if candidate.is_approved() {
                 Ok(false)
             } else {
-                let conn = self.peer_map
-                    .get(peer_id)
-                    .map_or(RoutingConnection::Direct, Peer::to_routing_connection);
+                let conn =
+                    self.peer_map.get(peer_id).map_or(RoutingConnection::Direct,
+                                                      Peer::to_routing_connection);
                 let state = PeerState::Candidate(conn);
                 let _ = self.peer_map.insert(Peer::new(*pub_id, Some(*peer_id), state));
                 if conn == RoutingConnection::Tunnel {
                     Err(RoutingError::CandidateIsTunnelling)
                 } else {
                     candidate.challenge_response = Some(ChallengeResponse {
-                        target_size: target_size,
-                        difficulty: difficulty,
-                        seed: seed,
-                        proof: VecDeque::new(),
-                    });
+                                                            target_size: target_size,
+                                                            difficulty: difficulty,
+                                                            seed: seed,
+                                                            proof: VecDeque::new(),
+                                                        });
                     Ok(true)
                 }
             }
@@ -714,9 +714,9 @@ impl PeerManager {
 
         // If we've updated the state from tunnel to direct above, we now return here.
         let should_split = self.routing_table.add(*pub_id.name(), want_to_merge)?;
-        let conn = self.peer_map
-            .remove(peer_id)
-            .map_or(unknown_connection, |peer| peer.to_routing_connection());
+        let conn =
+            self.peer_map.remove(peer_id).map_or(unknown_connection,
+                                                 |peer| peer.to_routing_connection());
         let _ = self.peer_map.insert(Peer::new(*pub_id, Some(*peer_id), PeerState::Routing(conn)));
         Ok(should_split)
     }
@@ -734,8 +734,8 @@ impl PeerManager {
         let removal_keys = self.candidates
             .iter()
             .find(|&(name, candidate)| {
-                !candidate.is_approved() && !self.routing_table.our_prefix().matches(name)
-            })
+                      !candidate.is_approved() && !self.routing_table.our_prefix().matches(name)
+                  })
             .map(|(name, _)| *name);
 
         let ids_to_drop = names_to_drop.iter()
@@ -801,11 +801,11 @@ impl PeerManager {
             .collect();
         names_to_drop.into_iter()
             .filter_map(|name| if let Some(peer) = self.peer_map.remove_by_name(&name) {
-                self.cleanup_proxy_peer_id();
-                peer.peer_id.map(|peer_id| (name, peer_id))
-            } else {
-                None
-            })
+                            self.cleanup_proxy_peer_id();
+                            peer.peer_id.map(|peer_id| (name, peer_id))
+                        } else {
+                            None
+                        })
             .collect()
     }
 
@@ -819,16 +819,17 @@ impl PeerManager {
         if !they_want_to_merge && !self.expected_peers.is_empty() {
             return None;
         }
-        self.routing_table.should_merge(we_want_to_merge, they_want_to_merge).map(|merge_details| {
-            let sections =
-                merge_details.sections
+        self.routing_table
+            .should_merge(we_want_to_merge, they_want_to_merge)
+            .map(|merge_details| {
+                let sections = merge_details.sections
                     .into_iter()
                     .map(|(prefix, members)| {
-                        (prefix, self.get_pub_ids(&members).into_iter().collect())
-                    })
+                             (prefix, self.get_pub_ids(&members).into_iter().collect())
+                         })
                     .collect();
-            (merge_details.sender_prefix, merge_details.merge_prefix, sections)
-        })
+                (merge_details.sender_prefix, merge_details.merge_prefix, sections)
+            })
     }
 
     // Returns the `OwnMergeState` from `RoutingTable` which defines what further action needs to be
@@ -848,8 +849,9 @@ impl PeerManager {
 
         let sections_as_names = sections.into_iter()
             .map(|(prefix, members)| {
-                (prefix, members.into_iter().map(|pub_id| *pub_id.name()).collect::<BTreeSet<_>>())
-            })
+                     (prefix,
+                      members.into_iter().map(|pub_id| *pub_id.name()).collect::<BTreeSet<_>>())
+                 })
             .collect();
 
         let own_merge_details = OwnMergeDetails {
@@ -859,13 +861,13 @@ impl PeerManager {
         };
         let mut expected_peers = mem::replace(&mut self.expected_peers, HashMap::new());
         expected_peers.extend(own_merge_details.sections
-            .values()
-            .flat_map(|section| section.iter())
-            .filter_map(|name| if self.routing_table.has(name) {
-                None
-            } else {
-                Some((*name, Instant::now()))
-            }));
+                                  .values()
+                                  .flat_map(|section| section.iter())
+                                  .filter_map(|name| if self.routing_table.has(name) {
+                                                  None
+                                              } else {
+                                                  Some((*name, Instant::now()))
+                                              }));
         self.expected_peers = expected_peers;
         (self.routing_table.merge_own_section(own_merge_details), needed)
     }
@@ -898,10 +900,10 @@ impl PeerManager {
     /// Returns the public ID of the given peer, if it is in `Routing` state.
     pub fn get_routing_peer(&self, peer_id: &PeerId) -> Option<&PublicId> {
         self.peer_map.get(peer_id).and_then(|peer| if let PeerState::Routing(_) = peer.state {
-            Some(&peer.pub_id)
-        } else {
-            None
-        })
+                                                Some(&peer.pub_id)
+                                            } else {
+                                                None
+                                            })
     }
 
     /// Returns the proxy node, if connected.
@@ -957,9 +959,11 @@ impl PeerManager {
     /// Returns the given client's public key, if present.
     pub fn get_client(&self, peer_id: &PeerId) -> Option<&sign::PublicKey> {
         self.peer_map.get(peer_id).and_then(|peer| match peer.state {
-            PeerState::Client => Some(peer.pub_id.signing_public_key()),
-            _ => None,
-        })
+                                                PeerState::Client => {
+                                                    Some(peer.pub_id.signing_public_key())
+                                                }
+                                                _ => None,
+                                            })
     }
 
     /// Inserts the given joining node into the map. Returns true if we already
@@ -971,9 +975,11 @@ impl PeerManager {
     /// Returns the given joining node's public key, if present.
     pub fn get_joining_node(&self, peer_id: &PeerId) -> Option<&sign::PublicKey> {
         self.peer_map.get(peer_id).and_then(|peer| match peer.state {
-            PeerState::JoiningNode => Some(peer.pub_id.signing_public_key()),
-            _ => None,
-        })
+                                                PeerState::JoiningNode => {
+                                                    Some(peer.pub_id.signing_public_key())
+                                                }
+                                                _ => None,
+                                            })
     }
 
     /// Removes all joining nodes that have timed out, and returns their peer
@@ -982,11 +988,12 @@ impl PeerManager {
         let expired_ids = self.peer_map
             .peers()
             .filter(|peer| match peer.state {
-                PeerState::JoiningNode | PeerState::Proxy => {
-                    peer.timestamp.elapsed() >= Duration::from_secs(JOINING_NODE_TIMEOUT_SECS)
-                }
-                _ => false,
-            })
+                        PeerState::JoiningNode | PeerState::Proxy => {
+                            peer.timestamp.elapsed() >=
+                            Duration::from_secs(JOINING_NODE_TIMEOUT_SECS)
+                        }
+                        _ => false,
+                    })
             .filter_map(|peer| peer.peer_id)
             .collect_vec();
 
@@ -1056,8 +1063,8 @@ impl PeerManager {
                 PeerState::Client | PeerState::JoiningNode | PeerState::Proxy => peer.peer_id,
                 _ => None,
             }
-        } else if let Some(join_peer) = self.peer_map
-            .get_by_name(&XorName(sha256::hash(&pub_id.signing_public_key().0).0)) {
+        } else if let Some(join_peer) =
+            self.peer_map.get_by_name(&XorName(sha256::hash(&pub_id.signing_public_key().0).0)) {
             // Joining node might have relocated by now but we might have it via its client name
             match join_peer.state {
                 PeerState::JoiningNode => join_peer.peer_id,
@@ -1074,9 +1081,9 @@ impl PeerManager {
         self.peer_map
             .peers()
             .filter(|&peer| match peer.state {
-                PeerState::JoiningNode => true,
-                _ => false,
-            })
+                        PeerState::JoiningNode => true,
+                        _ => false,
+                    })
             .count()
     }
 
@@ -1086,9 +1093,9 @@ impl PeerManager {
         self.peer_map
             .peers()
             .filter(|&peer| match peer.state {
-                PeerState::Client => true,
-                _ => false,
-            })
+                        PeerState::Client => true,
+                        _ => false,
+                    })
             .count()
     }
 
@@ -1118,10 +1125,10 @@ impl PeerManager {
     /// Returns the public ID of the given peer, if it is in `CrustConnecting` state.
     pub fn get_connecting_peer(&self, peer_id: &PeerId) -> Option<&PublicId> {
         self.peer_map.get(peer_id).and_then(|peer| if let PeerState::CrustConnecting = peer.state {
-            return Some(&peer.pub_id);
-        } else {
-            None
-        })
+                                                return Some(&peer.pub_id);
+                                            } else {
+                                                None
+                                            })
     }
 
     /// Returns the name of the given peer.
@@ -1133,13 +1140,13 @@ impl PeerManager {
     /// connected states.
     pub fn get_connected_peer(&self, peer_id: &PeerId) -> Option<&Peer> {
         self.peer_map.get(peer_id).and_then(|peer| match peer.state {
-            PeerState::Client |
-            PeerState::JoiningNode |
-            PeerState::Proxy |
-            PeerState::Candidate(_) |
-            PeerState::Routing(_) => Some(peer),
-            _ => None,
-        })
+                                                PeerState::Client |
+                                                PeerState::JoiningNode |
+                                                PeerState::Proxy |
+                                                PeerState::Candidate(_) |
+                                                PeerState::Routing(_) => Some(peer),
+                                                _ => None,
+                                            })
     }
 
     /// Are we expecting a connection from this name?
@@ -1165,8 +1172,8 @@ impl PeerManager {
     pub fn get_pub_ids(&self, names: &BTreeSet<XorName>) -> BTreeSet<PublicId> {
         names.into_iter()
             .filter_map(|name| if name == self.our_public_id.name() {
-                Some(self.our_public_id)
-            } else if let Some(peer) = self.peer_map.get_by_name(name) {
+                            Some(self.our_public_id)
+                        } else if let Some(peer) = self.peer_map.get_by_name(name) {
                 Some(*peer.pub_id())
             } else {
                 error!("{:?} Missing public ID for peer {:?}.", self, name);
@@ -1271,36 +1278,38 @@ impl PeerManager {
                                     token: u32,
                                     our_info: PrivConnectionInfo)
                                     -> Result<ConnectionInfoPreparedResult, Error> {
-        let pub_id = self.connection_token_map.remove(&token).ok_or(Error::PeerNotFound)?;
-        let (us_as_src, them_as_dst, opt_their_info) = match self.peer_map
-            .remove_by_name(pub_id.name()) {
-            Some(Peer { state: PeerState::ConnectionInfoPreparing { us_as_src,
-                                                             them_as_dst,
-                                                             their_info },
-                        .. }) => (us_as_src, them_as_dst, their_info),
-            Some(peer) => {
-                let _ = self.peer_map.insert(peer);
-                return Err(Error::UnexpectedState);
-            }
-            None => return Err(Error::PeerNotFound),
-        };
+        let pub_id = self.connection_token_map
+            .remove(&token)
+            .ok_or(Error::PeerNotFound)?;
+        let (us_as_src, them_as_dst, opt_their_info) =
+            match self.peer_map.remove_by_name(pub_id.name()) {
+                Some(Peer { state: PeerState::ConnectionInfoPreparing { us_as_src,
+                                                                 them_as_dst,
+                                                                 their_info },
+                            .. }) => (us_as_src, them_as_dst, their_info),
+                Some(peer) => {
+                    let _ = self.peer_map.insert(peer);
+                    return Err(Error::UnexpectedState);
+                }
+                None => return Err(Error::PeerNotFound),
+            };
         Ok(ConnectionInfoPreparedResult {
-            pub_id: pub_id,
-            src: us_as_src,
-            dst: them_as_dst,
-            infos: match opt_their_info {
-                Some((their_info, msg_id)) => {
-                    let state = PeerState::CrustConnecting;
-                    self.insert_peer(pub_id, Some(their_info.id()), state);
-                    Some((our_info, their_info, msg_id))
-                }
-                None => {
-                    let state = PeerState::ConnectionInfoReady(our_info);
-                    self.insert_peer(pub_id, None, state);
-                    None
-                }
-            },
-        })
+               pub_id: pub_id,
+               src: us_as_src,
+               dst: them_as_dst,
+               infos: match opt_their_info {
+                   Some((their_info, msg_id)) => {
+            let state = PeerState::CrustConnecting;
+            self.insert_peer(pub_id, Some(their_info.id()), state);
+            Some((our_info, their_info, msg_id))
+        }
+                   None => {
+            let state = PeerState::ConnectionInfoReady(our_info);
+            self.insert_peer(pub_id, None, state);
+            None
+        }
+               },
+           })
     }
 
     /// Inserts the given connection info in the map to wait for the preparation of our own info, or
@@ -1405,7 +1414,9 @@ impl PeerManager {
 
     /// If preparing connection info failed with the given token, prepares and returns a new token.
     pub fn get_new_connection_info_token(&mut self, token: u32) -> Result<u32, Error> {
-        let pub_id = self.connection_token_map.remove(&token).ok_or(Error::PeerNotFound)?;
+        let pub_id = self.connection_token_map
+            .remove(&token)
+            .ok_or(Error::PeerNotFound)?;
         let new_token = rand::random();
         let _ = self.connection_token_map.insert(new_token, pub_id);
         Ok(new_token)
@@ -1416,11 +1427,11 @@ impl PeerManager {
         self.peer_map
             .peers()
             .filter_map(|peer| match peer.state {
-                PeerState::SearchingForTunnel => {
-                    peer.peer_id.and_then(|peer_id| Some((peer_id, *peer.name())))
-                }
-                _ => None,
-            })
+                            PeerState::SearchingForTunnel => {
+                                peer.peer_id.and_then(|peer_id| Some((peer_id, *peer.name())))
+                            }
+                            _ => None,
+                        })
             .collect()
     }
 
@@ -1502,8 +1513,8 @@ impl PeerManager {
     /// Removes expired candidates and returns the list of peers from which we should disconnect.
     pub fn remove_expired_candidates(&mut self) -> Vec<PeerId> {
         let candidates = mem::replace(&mut self.candidates, HashMap::new());
-        let (to_prune, to_keep) = candidates.into_iter()
-            .partition(|&(_, ref candidate)| candidate.is_expired());
+        let (to_prune, to_keep) =
+            candidates.into_iter().partition(|&(_, ref candidate)| candidate.is_expired());
         self.candidates = to_keep;
         to_prune.into_iter().filter_map(|(name, _)| self.get_peer_id(&name).cloned()).collect()
     }
@@ -1536,12 +1547,12 @@ impl PeerManager {
         let remove_names = self.peer_map
             .peers()
             .filter(|peer| match peer.state {
-                PeerState::ConnectionInfoPreparing { .. } |
-                PeerState::ConnectionInfoReady(_) |
-                PeerState::CrustConnecting |
-                PeerState::SearchingForTunnel => true,
-                _ => false,
-            })
+                        PeerState::ConnectionInfoPreparing { .. } |
+                        PeerState::ConnectionInfoReady(_) |
+                        PeerState::CrustConnecting |
+                        PeerState::SearchingForTunnel => true,
+                        _ => false,
+                    })
             .map(|peer| *peer.name())
             .collect_vec();
 
@@ -1561,11 +1572,11 @@ impl PeerManager {
 
 #[cfg(all(test, feature = "use-mock-crust"))]
 mod tests {
+    use super::*;
     use id::FullId;
     use mock_crust::Endpoint;
     use mock_crust::crust::{PeerId, PrivConnectionInfo, PubConnectionInfo};
     use routing_table::Authority;
-    use super::*;
     use types::MessageId;
     use xor_name::{XOR_NAME_LEN, XorName};
 
@@ -1621,10 +1632,10 @@ mod tests {
         let original_msg_id = MessageId::new();
         // We received a connection info from the peer and get a token to prepare ours.
         let token = match peer_mgr.connection_info_received(node_auth(0),
-                                                            node_auth(1),
-                                                            orig_pub_id,
-                                                            their_connection_info.clone(),
-                                                            original_msg_id) {
+                                                node_auth(1),
+                                                orig_pub_id,
+                                                their_connection_info.clone(),
+                                                original_msg_id) {
             Ok(ConnectionInfoReceivedResult::Prepare(token)) => token,
             result => panic!("Unexpected result: {:?}", result),
         };

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/authority.rs
+++ b/src/routing_table/authority.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/authority.rs
+++ b/src/routing_table/authority.rs
@@ -15,10 +15,10 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{Prefix, Xorable};
 use crust::PeerId;
 use rust_sodium::crypto::{hash, sign};
 use std::fmt::{self, Binary, Debug, Display, Formatter};
-use super::{Prefix, Xorable};
 
 /// An entity that can act as a source or destination of a message.
 ///

--- a/src/routing_table/error.rs
+++ b/src/routing_table/error.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -1171,6 +1171,7 @@ mod tests {
     use super::SPLIT_BUFFER;
     use itertools::Itertools;
     use std::collections::BTreeSet;
+    use std::str::FromStr;
 
     #[test]
     fn small() {
@@ -1404,20 +1405,23 @@ mod tests {
             unwrap!(table.add(i * 0x10, false));
         }
         assert_eq!(prefixes_from_strs(vec![""]), table.prefixes());
-        assert_eq!(Vec::<u8>::new(), table.add_prefix(Prefix::from_str("01")));
+        assert_eq!(Vec::<u8>::new(),
+                   table.add_prefix(unwrap!(Prefix::from_str("01"))));
         assert_eq!(prefixes_from_strs(vec!["1", "00", "01"]), table.prefixes());
         assert_eq!(vec![0xc0, 0xd0, 0xe0, 0xf0u8],
-                   table.add_prefix(Prefix::from_str("111")).into_iter().sorted());
+                   table.add_prefix(unwrap!(Prefix::from_str("111"))).into_iter().sorted());
         assert_eq!(prefixes_from_strs(vec!["110", "111", "10", "0"]),
                    table.prefixes());
-        assert_eq!(Vec::<u8>::new(), table.add_prefix(Prefix::from_str("0")));
+        assert_eq!(Vec::<u8>::new(),
+                   table.add_prefix(unwrap!(Prefix::from_str("0"))));
         assert_eq!(prefixes_from_strs(vec!["110", "111", "10", "0"]),
                    table.prefixes());
-        assert_eq!(Vec::<u8>::new(), table.add_prefix(Prefix::from_str("")));
+        assert_eq!(Vec::<u8>::new(),
+                   table.add_prefix(unwrap!(Prefix::from_str(""))));
         assert_eq!(prefixes_from_strs(vec![""]), table.prefixes());
     }
 
     fn prefixes_from_strs(strs: Vec<&str>) -> BTreeSet<Prefix<u8>> {
-        strs.into_iter().map(Prefix::from_str).collect()
+        strs.into_iter().map(|s| unwrap!(Prefix::from_str(s))).collect()
     }
 }

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -113,13 +113,13 @@ mod network_tests;
 mod prefix;
 mod xorable;
 
-use itertools::Itertools;
 pub use self::authority::Authority;
 pub use self::error::Error;
 #[cfg(any(test, feature = "use-mock-crust"))]
 pub use self::network_tests::verify_network_invariant;
 pub use self::prefix::Prefix;
 pub use self::xorable::Xorable;
+use itertools::Itertools;
 use std::{iter, mem};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, btree_map, btree_set};
@@ -341,7 +341,10 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
     pub fn iter(&self) -> Iter<T> {
         let iter: fn(_) -> _ = BTreeSet::iter;
         Iter {
-            inner: self.sections.values().flat_map(iter).chain(self.our_section.iter()),
+            inner: self.sections
+                .values()
+                .flat_map(iter)
+                .chain(self.our_section.iter()),
             our_name: self.our_name,
         }
     }
@@ -356,9 +359,8 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
 
         // Estimated fraction of the network that we have in our RT.
         // Computed as the sum of 1 / 2^(prefix.bit_count) for all known section prefixes.
-        let network_fraction: f64 = known_prefixes.iter()
-            .map(|p| 1.0 / (p.bit_count() as f64).exp2())
-            .sum();
+        let network_fraction: f64 =
+            known_prefixes.iter().map(|p| 1.0 / (p.bit_count() as f64).exp2()).sum();
 
         // Total size estimate = known_nodes / network_fraction
         let network_size = (self.len() + 1) as f64 / network_fraction;
@@ -369,12 +371,19 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
     /// Collects prefixes of all sections known by the routing table other than ours into a
     /// `BTreeSet`.
     pub fn other_prefixes(&self) -> BTreeSet<Prefix<T>> {
-        self.sections.keys().cloned().collect()
+        self.sections
+            .keys()
+            .cloned()
+            .collect()
     }
 
     /// Collects prefixes of all sections known by the routing table into a `BTreeSet`.
     pub fn prefixes(&self) -> BTreeSet<Prefix<T>> {
-        self.sections.keys().cloned().chain(iter::once(self.our_prefix)).collect()
+        self.sections
+            .keys()
+            .cloned()
+            .chain(iter::once(self.our_prefix))
+            .collect()
     }
 
     /// If our section is the closest one to `name`, returns all names in our section *including
@@ -412,8 +421,8 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
             .sorted_by(|&(pfx0, _), &(pfx1, _)| pfx0.cmp_distance(pfx1, name))
             .into_iter()
             .flat_map(|(_, section)| {
-                section.iter().sorted_by(|name0, name1| name.cmp_distance(name0, name1))
-            })
+                          section.iter().sorted_by(|name0, name1| name.cmp_distance(name0, name1))
+                      })
             .take(count)
             .collect_vec()
     }
@@ -434,9 +443,9 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
     /// isn't among `count` names closest to `name`.
     pub fn other_closest_names(&self, name: &T, count: usize) -> Option<Vec<&T>> {
         self.closest_names(name, count).map(|mut result| {
-            result.retain(|name| *name != &self.our_name);
-            result
-        })
+                                                result.retain(|name| *name != &self.our_name);
+                                                result
+                                            })
     }
 
     /// Returns true if `name` is in our section (including if it is our own name).
@@ -539,8 +548,8 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         if let Some(to_split) = self.sections.remove(&prefix) {
             let prefix0 = prefix.pushed(false);
             let prefix1 = prefix.pushed(true);
-            let (section0, section1) = to_split.into_iter()
-                .partition::<BTreeSet<_>, _>(|name| prefix0.matches(name));
+            let (section0, section1) =
+                to_split.into_iter().partition::<BTreeSet<_>, _>(|name| prefix0.matches(name));
 
             for (pfx, section) in vec![(prefix0, section0), (prefix1, section1)] {
                 if self.our_prefix.is_neighbour(&pfx) {
@@ -645,10 +654,10 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         }
         let merge_prefix = self.our_prefix.popped();
         Some(OwnMergeDetails {
-            sender_prefix: self.our_prefix,
-            merge_prefix: merge_prefix,
-            sections: self.all_sections(),
-        })
+                 sender_prefix: self.our_prefix,
+                 merge_prefix: merge_prefix,
+                 sections: self.all_sections(),
+             })
     }
 
     /// When a merge of our own section is triggered (either from our own section or a neighbouring
@@ -800,12 +809,15 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
                             None
                         };
                         return Ok(self.sections
-                            .iter()
-                            .filter_map(is_compatible)
-                            .flat_map(BTreeSet::iter)
-                            .chain(self.our_section.iter().filter(|name| **name != self.our_name))
-                            .cloned()
-                            .collect());
+                                      .iter()
+                                      .filter_map(is_compatible)
+                                      .flat_map(BTreeSet::iter)
+                                      .chain(self.our_section.iter().filter(|name| {
+                                                                                **name !=
+                                                                                self.our_name
+                                                                            }))
+                                      .cloned()
+                                      .collect());
                     } else {
                         return Err(Error::CannotRoute);
                     }
@@ -814,7 +826,7 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
             }
         };
         Ok(iter::once(self.get_routeth_node(&closest_section, dst.name(), Some(exclude), route)?)
-            .collect())
+               .collect())
     }
 
     /// Returns whether we are a part of the given authority.
@@ -859,7 +871,10 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         if self.our_prefix.matches(name) {
             return Some(self.our_prefix);
         }
-        self.sections.keys().find(|&prefix| prefix.matches(name)).cloned()
+        self.sections
+            .keys()
+            .find(|&prefix| prefix.matches(name))
+            .cloned()
     }
 
     /// Returns `name` modified so that it belongs to one of the known prefixes with minimal bit
@@ -876,9 +891,10 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         let next_bit = self.our_name.bit(self.our_prefix.bit_count());
         let other_prefix = self.our_prefix.pushed(!next_bit);
         self.our_prefix = self.our_prefix.pushed(next_bit);
-        let (our_new_section, other_section) = self.our_section
-            .iter()
-            .partition::<BTreeSet<_>, _>(|name| self.our_prefix.matches(name));
+        let (our_new_section, other_section) =
+            self.our_section.iter().partition::<BTreeSet<_>, _>(|name| {
+                                                                    self.our_prefix.matches(name)
+                                                                });
         self.our_section = our_new_section;
         // Drop sections that ceased to be our neighbours.
         let sections_to_remove = self.sections
@@ -992,8 +1008,8 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
                                                            dst_name: &T,
                                                            route: usize)
                                                            -> &'a T {
-        let sorted_names = names.into_iter()
-            .sorted_by(|&lhs, &rhs| dst_name.cmp_distance(lhs, rhs));
+        let sorted_names =
+            names.into_iter().sorted_by(|&lhs, &rhs| dst_name.cmp_distance(lhs, rhs));
         sorted_names[route % sorted_names.len()]
     }
 
@@ -1070,8 +1086,11 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
         let all_are_neighbours = self.sections.keys().all(|&x| self.our_prefix.is_neighbour(&x));
         let all_neighbours_covered = {
             let prefixes = self.prefixes();
-            (0..self.our_prefix.bit_count())
-                .all(|i| self.our_prefix.with_flipped_bit(i).is_covered_by(&prefixes))
+            (0..self.our_prefix.bit_count()).all(|i| {
+                                                     self.our_prefix
+                                                         .with_flipped_bit(i)
+                                                         .is_covered_by(&prefixes)
+                                                 })
         };
         if !all_are_neighbours {
             return warn(format!("Some sections in the RT aren't neighbours of our section: {:?}",
@@ -1148,10 +1167,10 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> Debug for Rout
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-    use std::collections::BTreeSet;
     use super::*;
     use super::SPLIT_BUFFER;
+    use itertools::Itertools;
+    use std::collections::BTreeSet;
 
     #[test]
     fn small() {

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -20,6 +20,9 @@
 #![cfg(any(test, feature = "use-mock-crust"))]
 #![allow(dead_code, missing_docs)]
 
+use super::{Error, RoutingTable};
+use super::authority::Authority;
+use super::prefix::Prefix;
 use maidsafe_utilities::SeededRng;
 use rand::Rng;
 use routing_table::{OwnMergeDetails, OwnMergeState};
@@ -28,9 +31,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Binary, Debug};
 use std::hash::Hash;
 use std::iter::IntoIterator;
-use super::{Error, RoutingTable};
-use super::authority::Authority;
-use super::prefix::Prefix;
 
 /// A simulated network, consisting of a set of "nodes" (routing tables) and a random number
 /// generator.
@@ -150,11 +150,11 @@ impl Network {
                 let nodes = self.nodes_covered_by_prefixes(&[merge_own_details.merge_prefix]);
                 for node in &nodes {
                     let target_node = unwrap!(self.nodes.get_mut(&node));
-                    let node_expected = expected_peers.entry(*node)
-                        .or_insert_with(BTreeSet::new);
+                    let node_expected = expected_peers.entry(*node).or_insert_with(BTreeSet::new);
                     for section in &merge_own_details.sections {
-                        node_expected.extend(
-                            section.1.iter().filter(|name| !target_node.has(name)));
+                        node_expected.extend(section.1.iter().filter(|name| {
+                                                                         !target_node.has(name)
+                                                                     }));
                     }
                     match target_node.merge_own_section(merge_own_details.clone()) {
                         OwnMergeState::Ongoing |
@@ -256,14 +256,17 @@ impl Network {
     fn close_node(&self, address: u64) -> u64 {
         let target = Authority::Section(address);
         unwrap!(self.nodes
-            .iter()
-            .find(|&(_, table)| table.in_authority(&target))
-            .map(|(&peer, _)| peer))
+                    .iter()
+                    .find(|&(_, table)| table.in_authority(&target))
+                    .map(|(&peer, _)| peer))
     }
 
     /// Returns all node names.
     fn keys(&self) -> Vec<u64> {
-        self.nodes.keys().cloned().collect()
+        self.nodes
+            .keys()
+            .cloned()
+            .collect()
     }
 }
 
@@ -385,24 +388,20 @@ fn merging_sections() {
         network.add_node();
         verify_invariant(&network);
     }
-    assert!(network.nodes
-        .iter()
-        .all(|(_, table)| if table.num_of_sections() < 2 {
-            trace!("{:?}", table);
-            false
-        } else {
-            true
-        }));
+    assert!(network.nodes.iter().all(|(_, table)| if table.num_of_sections() < 2 {
+                                         trace!("{:?}", table);
+                                         false
+                                     } else {
+                                         true
+                                     }));
     for _ in 0..95 {
         network.drop_node();
         verify_invariant(&network);
     }
-    assert!(network.nodes
-        .iter()
-        .all(|(_, table)| if table.num_of_sections() > 0 {
-            trace!("{:?}", table);
-            false
-        } else {
-            true
-        }));
+    assert!(network.nodes.iter().all(|(_, table)| if table.num_of_sections() > 0 {
+                                         trace!("{:?}", table);
+                                         false
+                                     } else {
+                                         true
+                                     }));
 }

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -321,16 +321,17 @@ pub fn verify_network_invariant<'a, T, U>(nodes: U)
                 node.sections[&prefix].clone()
             };
             if let Some(&mut (ref mut src, ref mut section)) = sections.get_mut(&prefix) {
-                assert!(*section == section_content,
-                        "Section with prefix {:?} doesn't agree between nodes {:?} and {:?}\n\
-                        {:?}: {:?}, {:?}: {:?}",
-                        prefix,
-                        node.our_name,
-                        src,
-                        node.our_name,
-                        section_content,
-                        src,
-                        section);
+                assert_eq!(*section,
+                           section_content,
+                           "Section with prefix {:?} doesn't agree between nodes {:?} and {:?}\n\
+                            {:?}: {:?}, {:?}: {:?}",
+                           prefix,
+                           node.our_name,
+                           src,
+                           node.our_name,
+                           section_content,
+                           src,
+                           section);
                 continue;
             }
             let _ = sections.insert(prefix, (node.our_name, section_content));

--- a/src/routing_table/prefix.rs
+++ b/src/routing_table/prefix.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/prefix.rs
+++ b/src/routing_table/prefix.rs
@@ -15,11 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::xorable::Xorable;
 use std::cmp::{self, Ordering};
 use std::fmt::{Binary, Debug, Formatter};
 use std::fmt::Result as FmtResult;
 use std::hash::{Hash, Hasher};
-use super::xorable::Xorable;
 
 /// A section prefix, i.e. a sequence of bits specifying the part of the network's name space
 /// consisting of all names that start with this sequence.
@@ -127,7 +127,11 @@ impl<T: Clone + Copy + Default + Binary + Xorable> Prefix<T> {
         where T: 'a,
               U: IntoIterator<Item = &'a Prefix<T>> + Clone
     {
-        let max_prefix_len = prefixes.clone().into_iter().map(|x| x.bit_count()).max().unwrap_or(0);
+        let max_prefix_len = prefixes.clone()
+            .into_iter()
+            .map(|x| x.bit_count())
+            .max()
+            .unwrap_or(0);
         self.is_covered_by_impl(prefixes, max_prefix_len)
     }
 
@@ -135,9 +139,10 @@ impl<T: Clone + Copy + Default + Binary + Xorable> Prefix<T> {
         where T: 'a,
               U: IntoIterator<Item = &'a Prefix<T>> + Clone
     {
-        prefixes.clone()
-            .into_iter()
-            .any(|x| x.is_compatible(self) && x.bit_count() <= self.bit_count()) ||
+        prefixes.clone().into_iter().any(|x| {
+                                             x.is_compatible(self) &&
+                                             x.bit_count() <= self.bit_count()
+                                         }) ||
         (self.bit_count() <= max_prefix_len &&
          self.pushed(false).is_covered_by_impl(prefixes.clone(), max_prefix_len) &&
          self.pushed(true).is_covered_by_impl(prefixes, max_prefix_len))

--- a/src/routing_table/xorable.rs
+++ b/src/routing_table/xorable.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/routing_table/xorable.rs
+++ b/src/routing_table/xorable.rs
@@ -74,7 +74,11 @@ pub fn debug_format(input: String) -> String {
     if input.len() <= 20 {
         return input;
     }
-    input.chars().take(8).chain("...".chars()).chain(input.chars().skip(input.len() - 8)).collect()
+    input.chars()
+        .take(8)
+        .chain("...".chars())
+        .chain(input.chars().skip(input.len() - 8))
+        .collect()
 }
 
 macro_rules! impl_xorable_for_array {
@@ -298,8 +302,8 @@ impl_xorable!(u8);
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering;
     use super::*;
+    use std::cmp::Ordering;
 
     #[test]
     fn common_prefix() {

--- a/src/section_list_cache.rs
+++ b/src/section_list_cache.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/section_list_cache.rs
+++ b/src/section_list_cache.rs
@@ -15,14 +15,14 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::QUORUM;
+use super::XorName;
 use id::PublicId;
 use itertools::Itertools;
 use messages::SectionList;
 use routing_table::Prefix;
 use rust_sodium::crypto::sign::Signature;
 use std::collections::HashMap;
-use super::QUORUM;
-use super::XorName;
 
 pub type Signatures = HashMap<PublicId, Signature>;
 pub type PrefixMap<T> = HashMap<Prefix<XorName>, T>;
@@ -65,8 +65,10 @@ impl SectionListCache {
         // remove all conflicting signatures
         self.remove_signatures_for_prefix_by(prefix, pub_id);
         // remember that this public id signed this section list
-        let _ =
-            self.signed_by.entry(pub_id).or_insert_with(HashMap::new).insert(prefix, list.clone());
+        let _ = self.signed_by
+            .entry(pub_id)
+            .or_insert_with(HashMap::new)
+            .insert(prefix, list.clone());
         // remember that this section list has a new signature
         let _ = self.signatures
             .entry(prefix)
@@ -121,9 +123,10 @@ impl SectionListCache {
     fn update_lists_cache(&mut self, our_section_size: usize) {
         for (prefix, map) in &self.signatures {
             // find the entries with the most signatures
-            let entries = map.iter()
-                .map(|(list, sigs)| (list, sigs.len()))
-                .sorted_by(|lhs, rhs| rhs.1.cmp(&lhs.1));
+            let entries =
+                map.iter().map(|(list, sigs)| (list, sigs.len())).sorted_by(|lhs, rhs| {
+                                                                                rhs.1.cmp(&lhs.1)
+                                                                            });
             if let Some(&(list, sig_count)) = entries.first() {
                 // entry.0 = list, entry.1 = num of signatures
                 if 100 * sig_count >= QUORUM * our_section_size {

--- a/src/sha3.rs
+++ b/src/sha3.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -77,7 +77,10 @@ impl SignatureAccumulator {
                 entry.get_mut().0.add_signatures(msg);
             }
             Entry::Vacant(entry) => {
-                for (pub_id, sig) in self.sigs.remove(&hash).into_iter().flat_map(|(vec, _)| vec) {
+                for (pub_id, sig) in self.sigs
+                        .remove(&hash)
+                        .into_iter()
+                        .flat_map(|(vec, _)| vec) {
                     msg.add_signature(pub_id, sig);
                 }
                 let _ = entry.insert((msg, route, Instant::now()));
@@ -124,6 +127,7 @@ impl SignatureAccumulator {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use id::{FullId, PublicId};
     use itertools::Itertools;
     use messages::{DirectMessage, MessageContent, RoutingMessage, SectionList, SignedMessage};
@@ -131,7 +135,6 @@ mod tests {
     use routing_table::Authority;
     use routing_table::Prefix;
     use std::collections::BTreeSet;
-    use super::*;
 
     struct MessageAndSignatures {
         signed_msg: SignedMessage,
@@ -155,8 +158,9 @@ mod tests {
             let lists = vec![SectionList::new(prefix, all_ids)];
             let signed_msg = unwrap!(SignedMessage::new(routing_msg, msg_sender_id, lists));
             let signature_msgs = other_ids.map(|id| {
-                    unwrap!(signed_msg.routing_message().to_signature(id.signing_private_key()))
-                })
+                                                   unwrap!(signed_msg.routing_message()
+                                              .to_signature(id.signing_private_key()))
+                                               })
                 .collect();
             MessageAndSignatures {
                 signed_msg: signed_msg,
@@ -184,8 +188,10 @@ mod tests {
             }
             let msgs_and_sigs = (0..5)
                 .map(|_| {
-                    MessageAndSignatures::new(&msg_sender_id, other_ids.iter(), pub_ids.clone())
-                })
+                         MessageAndSignatures::new(&msg_sender_id,
+                                                   other_ids.iter(),
+                                                   pub_ids.clone())
+                     })
                 .collect();
             Env {
                 _msg_sender_id: msg_sender_id,
@@ -211,23 +217,25 @@ mod tests {
                 .iter()
                 .zip(env.other_ids.iter())
                 .foreach(|(signature_msg, full_id)| match *signature_msg {
-                    DirectMessage::MessageSignature(ref hash, ref sig) => {
-                        let result =
-                                sig_accumulator.add_signature(env.num_nodes(),
-                                                              *hash,
-                                                              *sig,
-                                                              *full_id.public_id());
-                        assert!(result.is_none());
-                    }
-                    ref unexpected_msg => panic!("Unexpected message: {:?}", unexpected_msg),
-                });
+                             DirectMessage::MessageSignature(ref hash, ref sig) => {
+                    let result = sig_accumulator.add_signature(env.num_nodes(),
+                                                               *hash,
+                                                               *sig,
+                                                               *full_id.public_id());
+                    assert!(result.is_none());
+                }
+                             ref unexpected_msg => {
+                                 panic!("Unexpected message: {:?}", unexpected_msg)
+                             }
+                         });
         });
 
         assert!(sig_accumulator.msgs.is_empty());
         assert_eq!(sig_accumulator.sigs.len(), env.msgs_and_sigs.len());
         sig_accumulator.sigs.values().foreach(|&(ref pub_ids_and_sigs, _)| {
-            assert_eq!(pub_ids_and_sigs.len(), env.other_ids.len())
-        });
+                                                  assert_eq!(pub_ids_and_sigs.len(),
+                                                             env.other_ids.len())
+                                              });
 
         // Add each message with the section list added - each should accumulate.
         let mut expected_sigs_count = env.msgs_and_sigs.len();
@@ -245,9 +253,7 @@ mod tests {
             assert_eq!(signed_msg.routing_message(), returned_msg.routing_message());
             unwrap!(returned_msg.check_integrity(1000));
             assert!(returned_msg.check_fully_signed(env.num_nodes()));
-            env.senders
-                .iter()
-                .foreach(|pub_id| assert!(returned_msg.signed_by(pub_id)));
+            env.senders.iter().foreach(|pub_id| assert!(returned_msg.signed_by(pub_id)));
         });
     }
 
@@ -267,29 +273,36 @@ mod tests {
         assert!(sig_accumulator.sigs.is_empty());
 
         // Add each message's signatures - each should accumulate once quorum has been reached.
-        env.msgs_and_sigs.iter().enumerate().foreach(|(route, msg_and_sigs)| {
-            msg_and_sigs.signature_msgs
-                .iter()
-                .zip(env.other_ids.iter())
-                .foreach(|(signature_msg, full_id)| {
-                    let result = match *signature_msg {
-                        DirectMessage::MessageSignature(hash, sig) => {
-                            sig_accumulator.add_signature(env.num_nodes(), hash, sig,
-                                *full_id.public_id())
-                        }
-                        ref unexpected_msg => panic!("Unexpected message: {:?}", unexpected_msg),
-                    };
+        env.msgs_and_sigs
+            .iter()
+            .enumerate()
+            .foreach(|(route, msg_and_sigs)| {
+                msg_and_sigs.signature_msgs
+                    .iter()
+                    .zip(env.other_ids.iter())
+                    .foreach(|(signature_msg, full_id)| {
+                        let result = match *signature_msg {
+                            DirectMessage::MessageSignature(hash, sig) => {
+                                sig_accumulator.add_signature(env.num_nodes(),
+                                                              hash,
+                                                              sig,
+                                                              *full_id.public_id())
+                            }
+                            ref unexpected_msg => {
+                                panic!("Unexpected message: {:?}", unexpected_msg)
+                            }
+                        };
 
-                    if let Some((mut returned_msg, returned_route)) = result {
-                        expected_msgs_count -= 1;
-                        assert_eq!(sig_accumulator.msgs.len(), expected_msgs_count);
-                        assert_eq!(route as u8, returned_route);
-                        assert_eq!(msg_and_sigs.signed_msg.routing_message(),
-                                   returned_msg.routing_message());
-                        unwrap!(returned_msg.check_integrity(1000));
-                        assert!(returned_msg.check_fully_signed(env.num_nodes()));
-                    }
-                });
-        });
+                        if let Some((mut returned_msg, returned_route)) = result {
+                            expected_msgs_count -= 1;
+                            assert_eq!(sig_accumulator.msgs.len(), expected_msgs_count);
+                            assert_eq!(route as u8, returned_route);
+                            assert_eq!(msg_and_sigs.signed_msg.routing_message(),
+                                       returned_msg.routing_message());
+                            unwrap!(returned_msg.check_integrity(1000));
+                            assert!(returned_msg.check_fully_signed(env.num_nodes()));
+                        }
+                    });
+            });
     }
 }

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -46,6 +46,8 @@ pub struct StateMachine {
     is_running: bool,
 }
 
+// FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
+#[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 pub enum State {
     Bootstrapping(Bootstrapping),
     Client(Client),

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -15,6 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{Client, Node};
+use super::common::Base;
 use action::Action;
 use cache::Cache;
 use crust::{CrustUser, PeerId, Service};
@@ -34,8 +36,6 @@ use std::collections::HashSet;
 use std::fmt::{self, Debug, Formatter};
 use std::net::SocketAddr;
 use std::time::Duration;
-use super::{Client, Node};
-use super::common::Base;
 use timer::Timer;
 use xor_name::XorName;
 
@@ -71,16 +71,16 @@ impl Bootstrapping {
         }
 
         Some(Bootstrapping {
-            bootstrap_blacklist: HashSet::new(),
-            bootstrap_connection: None,
-            cache: cache,
-            client_restriction: client_restriction,
-            crust_service: crust_service,
-            full_id: full_id,
-            min_section_size: min_section_size,
-            stats: Stats::new(),
-            timer: timer,
-        })
+                 bootstrap_blacklist: HashSet::new(),
+                 bootstrap_connection: None,
+                 cache: cache,
+                 client_restriction: client_restriction,
+                 crust_service: crust_service,
+                 full_id: full_id,
+                 min_section_size: min_section_size,
+                 stats: Stats::new(),
+                 timer: timer,
+             })
     }
 
     pub fn handle_action(&mut self, action: Action) -> Transition {
@@ -315,8 +315,8 @@ impl Bootstrapping {
             } else {
                 CrustUser::Node
             };
-            let _ = self.crust_service
-                .start_bootstrap(self.bootstrap_blacklist.clone(), crust_user);
+            let _ = self.crust_service.start_bootstrap(self.bootstrap_blacklist.clone(),
+                                                       crust_user);
         }
     }
 }

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::common::{Base, Bootstrapped, USER_MSG_CACHE_EXPIRY_DURATION_SECS};
 use ack_manager::{Ack, AckManager};
 use action::Action;
 use crust::{PeerId, Service};
@@ -33,7 +34,6 @@ use stats::Stats;
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Formatter};
 use std::time::Duration;
-use super::common::{Base, Bootstrapped, USER_MSG_CACHE_EXPIRY_DURATION_SECS};
 use timer::Timer;
 use xor_name::XorName;
 

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/common/bootstrapped.rs
+++ b/src/states/common/bootstrapped.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/common/bootstrapped.rs
+++ b/src/states/common/bootstrapped.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::Base;
 use ack_manager::{ACK_TIMEOUT_SECS, Ack, AckManager, UnacknowledgedMessage};
 use crust::PeerId;
 use error::RoutingError;
@@ -24,7 +25,6 @@ use routing_message_filter::RoutingMessageFilter;
 use routing_table::Authority;
 use std::collections::BTreeSet;
 use std::time::Duration;
-use super::Base;
 use timer::Timer;
 use xor_name::XorName;
 

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -33,7 +33,7 @@ use maidsafe_utilities::serialisation;
 use messages::{DEFAULT_PRIORITY, DirectMessage, HopMessage, MAX_PART_LEN, Message, MessageContent,
                RoutingMessage, SectionList, SignedMessage, UserMessage, UserMessageCache};
 use outbox::EventBox;
-use peer_manager::{ConnectionInfoPreparedResult, PeerManager, PeerState,
+use peer_manager::{ConnectionInfoPreparedResult, Peer, PeerManager, PeerState,
                    RESOURCE_PROOF_DURATION_SECS, SectionMap};
 use rand::{self, Rng};
 use resource_proof::ResourceProof;
@@ -1832,9 +1832,9 @@ impl Node {
             let message = DirectMessage::TunnelDisconnect(dst_id);
             self.send_direct_message(peer_id, message);
         }
-        if self.peer_mgr.get_connected_peer(&peer_id).map_or(false, |peer| {
-            peer.state().can_tunnel_for()
-        }) && self.tunnels.add(dst_id, peer_id) {
+        let can_tunnel_for = |peer: &Peer| peer.state().can_tunnel_for();
+        if self.peer_mgr.get_connected_peer(&peer_id).map_or(false, can_tunnel_for) &&
+           self.tunnels.add(dst_id, peer_id) {
             debug!("{:?} Adding {:?} as a tunnel node for {:?}.",
                    self,
                    peer_id,

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -15,7 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use ::QUORUM;
+use super::common::{Base, Bootstrapped, USER_MSG_CACHE_EXPIRY_DURATION_SECS};
+use QUORUM;
 use ack_manager::{ACK_TIMEOUT_SECS, Ack, AckManager};
 use action::Action;
 use cache::Cache;
@@ -53,7 +54,6 @@ use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
 use std::time::{Duration, Instant};
-use super::common::{Base, Bootstrapped, USER_MSG_CACHE_EXPIRY_DURATION_SECS};
 use timer::Timer;
 use tunnels::Tunnels;
 use types::MessageId;
@@ -721,12 +721,19 @@ impl Node {
                                              *self.full_id.public_id(),
                                              section.clone(),
                                              sig,
-                                             self.peer_mgr.routing_table().our_section().len());
+                                             self.peer_mgr
+                                                 .routing_table()
+                                                 .our_section()
+                                                 .len());
 
         // this defines whom we are sending signature to: our section if dst is None, or given
         // name if it's Some
         let peers = if let Some(dst) = dst {
-            self.peer_mgr.get_peer_id(&dst).into_iter().cloned().collect_vec()
+            self.peer_mgr
+                .get_peer_id(&dst)
+                .into_iter()
+                .cloned()
+                .collect_vec()
         } else {
             self.peer_mgr
                 .routing_table()
@@ -749,16 +756,19 @@ impl Node {
                                      section_list: SectionList,
                                      sig: sign::Signature)
                                      -> Result<(), RoutingError> {
-        let src_pub_id =
-            self.peer_mgr.get_routing_peer(&peer_id).ok_or(RoutingError::InvalidSource)?;
+        let src_pub_id = self.peer_mgr
+            .get_routing_peer(&peer_id)
+            .ok_or(RoutingError::InvalidSource)?;
         let serialised = serialisation::serialise(&section_list)?;
         if sign::verify_detached(&sig, &serialised, src_pub_id.signing_public_key()) {
-            self.section_list_sigs
-                .add_signature(section_list.prefix,
-                               *src_pub_id,
-                               section_list,
-                               sig,
-                               self.peer_mgr.routing_table().our_section().len());
+            self.section_list_sigs.add_signature(section_list.prefix,
+                                                 *src_pub_id,
+                                                 section_list,
+                                                 sig,
+                                                 self.peer_mgr
+                                                     .routing_table()
+                                                     .our_section()
+                                                     .len());
             Ok(())
         } else {
             Err(RoutingError::FailedSignature)
@@ -1012,13 +1022,15 @@ impl Node {
         // Or a node may receive CandidateApproval before connection established.
         // If we are not connected to the candidate, we do not want to add them
         // to our RT.
-        let opt_peer_id = match self.peer_mgr
-            .handle_candidate_approval(*candidate_id.name(), client_auth) {
+        let opt_peer_id = match self.peer_mgr.handle_candidate_approval(*candidate_id.name(),
+                                                      client_auth) {
             Ok(peer_id) => peer_id,
             Err(_) => {
                 let src = Authority::ManagedNode(*self.name());
-                if let Err(error) =
-                    self.send_connection_info_request(candidate_id, src, client_auth, outbox) {
+                if let Err(error) = self.send_connection_info_request(candidate_id,
+                                                                      src,
+                                                                      client_auth,
+                                                                      outbox) {
                     debug!("{:?} - Failed to send connection info to {:?}: {:?}",
                            self,
                            candidate_id,
@@ -1093,8 +1105,10 @@ impl Node {
                            pub_id);
                     let src = Authority::ManagedNode(*self.name());
                     let node_auth = Authority::ManagedNode(*pub_id.name());
-                    if let Err(error) =
-                        self.send_connection_info_request(*pub_id, src, node_auth, outbox) {
+                    if let Err(error) = self.send_connection_info_request(*pub_id,
+                                                                          src,
+                                                                          node_auth,
+                                                                          outbox) {
                         debug!("{:?} - Failed to send connection info to {:?}: {:?}",
                                self,
                                pub_id,
@@ -1117,8 +1131,8 @@ impl Node {
         backlog.into_iter().rev().foreach(|msg| self.msg_queue.push_front(msg));
         self.resource_proof_response_parts.clear();
         self.reset_rt_timer();
-        self.candidate_status_token = Some(self.timer
-            .schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
+        self.candidate_status_token =
+            Some(self.timer.schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
         Ok(())
     }
 
@@ -1211,8 +1225,11 @@ impl Node {
             return;
         };
 
-        match self.peer_mgr
-            .verify_candidate(&name, part_index, part_count, proof, leading_zero_bytes) {
+        match self.peer_mgr.verify_candidate(&name,
+                                             part_index,
+                                             part_count,
+                                             proof,
+                                             leading_zero_bytes) {
             Err(error) => {
                 debug!("{:?} Failed to verify candidate {}: {:?}",
                        self,
@@ -1411,7 +1428,11 @@ impl Node {
             (0, 1)
         } else {
             (RESOURCE_PROOF_DIFFICULTY,
-             RESOURCE_PROOF_TARGET_SIZE / (self.peer_mgr.routing_table().our_section().len() + 1))
+             RESOURCE_PROOF_TARGET_SIZE /
+             (self.peer_mgr
+                  .routing_table()
+                  .our_section()
+                  .len() + 1))
         };
         let seed: Vec<u8> = if cfg!(feature = "use-mock-crust") {
             vec![5u8; 4]
@@ -1486,7 +1507,10 @@ impl Node {
             }
         }
 
-        if self.peer_mgr.routing_table().our_section().contains(public_id.name()) {
+        if self.peer_mgr
+               .routing_table()
+               .our_section()
+               .contains(public_id.name()) {
             self.reset_rt_timer();
         }
 
@@ -1507,8 +1531,8 @@ impl Node {
             }
 
             if let Some(prefix) = self.peer_mgr
-                .routing_table()
-                .find_section_prefix(public_id.name()) {
+                   .routing_table()
+                   .find_section_prefix(public_id.name()) {
                 self.send_section_list_signature(prefix, None);
                 if prefix == *self.our_prefix() {
                     // if the node joined our section, send signatures for all section lists to it
@@ -1692,13 +1716,17 @@ impl Node {
             _ => unreachable!(),
         };
         self.peer_mgr.allow_connect(name)?;
-        let their_connection_info = self.decrypt_connection_info(&encrypted_connection_info,
-                                     &box_::Nonce(nonce_bytes),
-                                     &public_id)?;
+        let their_connection_info =
+            self.decrypt_connection_info(&encrypted_connection_info,
+                                         &box_::Nonce(nonce_bytes),
+                                         &public_id)?;
         let peer_id = their_connection_info.id();
         use peer_manager::ConnectionInfoReceivedResult::*;
-        match self.peer_mgr
-            .connection_info_received(src, dst, public_id, their_connection_info, message_id) {
+        match self.peer_mgr.connection_info_received(src,
+                                                     dst,
+                                                     public_id,
+                                                     their_connection_info,
+                                                     message_id) {
             Ok(Ready(our_info, their_info)) => {
                 debug!("{:?} Already sent a connection info request to {:?} ({:?}); resending \
                         our same details as a response.",
@@ -1737,17 +1765,17 @@ impl Node {
                                        dst: Authority<XorName>)
                                        -> Result<(), RoutingError> {
         self.peer_mgr.allow_connect(&src)?;
-        let their_connection_info = self.decrypt_connection_info(&encrypted_connection_info,
-                                     &box_::Nonce(nonce_bytes),
-                                     &public_id)?;
+        let their_connection_info =
+            self.decrypt_connection_info(&encrypted_connection_info,
+                                         &box_::Nonce(nonce_bytes),
+                                         &public_id)?;
         let peer_id = their_connection_info.id();
         use peer_manager::ConnectionInfoReceivedResult::*;
-        match self.peer_mgr
-            .connection_info_received(Authority::ManagedNode(src),
-                                      dst,
-                                      public_id,
-                                      their_connection_info,
-                                      message_id) {
+        match self.peer_mgr.connection_info_received(Authority::ManagedNode(src),
+                                                     dst,
+                                                     public_id,
+                                                     their_connection_info,
+                                                     message_id) {
             Ok(Ready(our_info, their_info)) => {
                 trace!("{:?} Received connection info response. Trying to connect to {:?} ({:?}).",
                        self,
@@ -1804,10 +1832,9 @@ impl Node {
             let message = DirectMessage::TunnelDisconnect(dst_id);
             self.send_direct_message(peer_id, message);
         }
-        if self.peer_mgr
-            .get_connected_peer(&peer_id)
-            .map_or(false, |peer| peer.state().can_tunnel_for()) &&
-           self.tunnels.add(dst_id, peer_id) {
+        if self.peer_mgr.get_connected_peer(&peer_id).map_or(false, |peer| {
+            peer.state().can_tunnel_for()
+        }) && self.tunnels.add(dst_id, peer_id) {
             debug!("{:?} Adding {:?} as a tunnel node for {:?}.",
                    self,
                    peer_id,
@@ -1945,8 +1972,8 @@ impl Node {
         let duration = Duration::from_secs(APPROVAL_TIMEOUT_SECS);
         self.approval_expiry_time = Instant::now() + duration;
         self.get_approval_timer_token = Some(self.timer.schedule(duration));
-        self.approval_progress_timer_token = Some(self.timer
-            .schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
+        self.approval_progress_timer_token =
+            Some(self.timer.schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
 
         self.full_id.public_id_mut().set_name(*relocated_id.name());
         self.peer_mgr.reset_routing_table(*self.full_id.public_id());
@@ -2002,7 +2029,10 @@ impl Node {
         });
         candidate_id.set_name(relocated_name);
 
-        if self.peer_mgr.routing_table().should_join_our_section(candidate_id.name()).is_err() {
+        if self.peer_mgr
+               .routing_table()
+               .should_join_our_section(candidate_id.name())
+               .is_err() {
             let request_content = MessageContent::ExpectCandidate {
                 expect_id: candidate_id,
                 client_auth: client_auth,
@@ -2045,8 +2075,8 @@ impl Node {
             return Ok(());
         }
 
-        self.candidate_timer_token = Some(self.timer
-            .schedule(Duration::from_secs(RESOURCE_PROOF_DURATION_SECS)));
+        self.candidate_timer_token =
+            Some(self.timer.schedule(Duration::from_secs(RESOURCE_PROOF_DURATION_SECS)));
 
         let own_section = self.peer_mgr.accept_as_candidate(*candidate_id.name(), client_auth);
         let response_content = MessageContent::GetNodeNameResponse {
@@ -2121,10 +2151,11 @@ impl Node {
         let own_name = *self.name();
         for pub_id in members {
             self.peer_mgr.expect_peer(&pub_id);
-            if let Err(error) = self.send_connection_info_request(pub_id,
-                                              Authority::ManagedNode(own_name),
-                                              Authority::ManagedNode(*pub_id.name()),
-                                              outbox) {
+            if let Err(error) =
+                self.send_connection_info_request(pub_id,
+                                                  Authority::ManagedNode(own_name),
+                                                  Authority::ManagedNode(*pub_id.name()),
+                                                  outbox) {
                 debug!("{:?} - Failed to send connection info to {:?}: {:?}",
                        self,
                        pub_id,
@@ -2201,7 +2232,10 @@ impl Node {
               self.peer_mgr.routing_table().prefixes());
         let src = Authority::ManagedNode(*self.name());
         for member in members {
-            if self.peer_mgr.routing_table().need_to_add(member.name()).is_ok() {
+            if self.peer_mgr
+                   .routing_table()
+                   .need_to_add(member.name())
+                   .is_ok() {
                 let dst = Authority::ManagedNode(*member.name());
                 if let Err(error) = self.send_connection_info_request(member, src, dst, outbox) {
                     debug!("{:?} - Failed to send connection info to {:?}: {:?}",
@@ -2315,8 +2349,8 @@ impl Node {
                                  outbox: &mut EventBox)
                                  -> Result<(), RoutingError> {
         let merge_prefix = sender_prefix.popped();
-        let (merge_state, needed_peers) = self.peer_mgr
-            .merge_own_section(sender_prefix, merge_prefix, sections);
+        let (merge_state, needed_peers) =
+            self.peer_mgr.merge_own_section(sender_prefix, merge_prefix, sections);
 
         match merge_state {
             OwnMergeState::Ongoing |
@@ -2339,10 +2373,11 @@ impl Node {
                     debug!("{:?} Sending connection info to {:?} due to merging own section.",
                            self,
                            needed);
-                    if let Err(error) = self.send_connection_info_request(*needed,
-                                                      Authority::ManagedNode(own_name),
-                                                      Authority::ManagedNode(*needed.name()),
-                                                      outbox) {
+                    if let Err(error) =
+                        self.send_connection_info_request(*needed,
+                                                          Authority::ManagedNode(own_name),
+                                                          Authority::ManagedNode(*needed.name()),
+                                                          outbox) {
                         debug!("{:?} - Failed to send connection info to {:?}: {:?}",
                                self,
                                needed,
@@ -2380,10 +2415,11 @@ impl Node {
                    self,
                    needed);
             let needed_name = *needed.name();
-            if let Err(error) = self.send_connection_info_request(needed,
-                                              Authority::ManagedNode(own_name),
-                                              Authority::ManagedNode(needed_name),
-                                              outbox) {
+            if let Err(error) =
+                self.send_connection_info_request(needed,
+                                                  Authority::ManagedNode(own_name),
+                                                  Authority::ManagedNode(needed_name),
+                                                  outbox) {
                 debug!("{:?} - Failed to send connection info: {:?}", self, error);
             }
         }
@@ -2434,12 +2470,12 @@ impl Node {
             self.candidate_timer_token = None;
             self.send_candidate_approval();
         } else if self.candidate_status_token == Some(token) {
-            self.candidate_status_token = Some(self.timer
-                .schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
+            self.candidate_status_token =
+                Some(self.timer.schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
             self.peer_mgr.show_candidate_status();
         } else if self.approval_progress_timer_token == Some(token) {
-            self.approval_progress_timer_token = Some(self.timer
-                .schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
+            self.approval_progress_timer_token =
+                Some(self.timer.schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
             let now = Instant::now();
             let remaining_duration = if now < self.approval_expiry_time {
                 let duration = self.approval_expiry_time - now;
@@ -2555,12 +2591,12 @@ impl Node {
             let sections = self.peer_mgr.pub_ids_by_section();
             let prefixes = self.peer_mgr.routing_table().prefixes();
             let digest = sha256::hash(&match serialisation::serialise(&(sections, prefixes)) {
-                Ok(serialised) => serialised,
-                Err(e) => {
-                    warn!("{:?} Serialisation failed: {:?}", self, e);
-                    return;
-                }
-            });
+                                           Ok(serialised) => serialised,
+                                           Err(e) => {
+                warn!("{:?} Serialisation failed: {:?}", self, e);
+                return;
+            }
+                                       });
             trace!("{:?} Sending RT request {:?} with digest {:?}",
                    self,
                    msg_id,
@@ -2891,7 +2927,7 @@ impl Node {
                                     -> Result<(), RoutingError> {
         let their_name = *their_public_id.name();
         if let Some(peer_id) = self.peer_mgr
-            .get_proxy_or_client_or_joining_node_peer_id(&their_public_id) {
+               .get_proxy_or_client_or_joining_node_peer_id(&their_public_id) {
 
             self.send_node_identify(peer_id);
             self.add_to_routing_table(&their_public_id, &peer_id, outbox);
@@ -2972,10 +3008,11 @@ impl Node {
                    self,
                    peer.pub_id());
             let own_name = *self.name();
-            if let Err(error) = self.send_connection_info_request(*peer.pub_id(),
-                                              Authority::ManagedNode(own_name),
-                                              Authority::ManagedNode(*peer.name()),
-                                              outbox) {
+            if let Err(error) =
+                self.send_connection_info_request(*peer.pub_id(),
+                                                  Authority::ManagedNode(own_name),
+                                                  Authority::ManagedNode(*peer.name()),
+                                                  outbox) {
                 debug!("{:?} - Failed to send connection info to {:?}: {:?}",
                        self,
                        peer.pub_id(),
@@ -3001,13 +3038,18 @@ impl Node {
 
         self.merge_if_necessary();
 
-        self.peer_mgr.routing_table().find_section_prefix(&details.name).map_or((), |prefix| {
-            self.send_section_list_signature(prefix, None);
-        });
+        self.peer_mgr
+            .routing_table()
+            .find_section_prefix(&details.name)
+            .map_or((),
+                    |prefix| { self.send_section_list_signature(prefix, None); });
         if details.was_in_our_section {
             self.reset_rt_timer();
-            self.section_list_sigs
-                .remove_signatures_by(*pub_id, self.peer_mgr.routing_table().our_section().len());
+            self.section_list_sigs.remove_signatures_by(*pub_id,
+                                                        self.peer_mgr
+                                                            .routing_table()
+                                                            .our_section()
+                                                            .len());
         }
 
         if self.peer_mgr.routing_table().is_empty() {
@@ -3083,8 +3125,10 @@ impl Node {
             .remove_tunnel(peer_id)
             .into_iter()
             .filter_map(|dst_id| {
-                self.peer_mgr.get_routing_peer(&dst_id).map(|dst_pub_id| (dst_id, *dst_pub_id))
-            })
+                            self.peer_mgr.get_routing_peer(&dst_id).map(|dst_pub_id| {
+                                                                            (dst_id, *dst_pub_id)
+                                                                        })
+                        })
             .collect_vec();
         for (dst_id, pub_id) in peers {
             self.dropped_peer(&dst_id, outbox, false);
@@ -3170,9 +3214,9 @@ impl Node {
 
     fn cache_section_update_request(&mut self, other_section_prefix: Prefix<XorName>) {
         if (self.peer_mgr
-            .routing_table()
-            .should_merge(self.we_want_to_merge(), self.they_want_to_merge())
-            .is_some() || self.we_want_to_merge() || self.they_want_to_merge()) &&
+                .routing_table()
+                .should_merge(self.we_want_to_merge(), self.they_want_to_merge())
+                .is_some() || self.we_want_to_merge() || self.they_want_to_merge()) &&
            other_section_prefix != self.our_prefix().sibling() {
             // We don't care about duplicate cached prefixes - ignore result.
             let _ = self.cached_section_update_requests.insert(other_section_prefix);
@@ -3322,19 +3366,19 @@ impl Bootstrapped for Node {
         use routing_table::Authority::*;
         let sending_names = match routing_msg.src {
             ClientManager(_) | NaeManager(_) | NodeManager(_) | ManagedNode(_) => {
-                let section = self.peer_mgr
-                    .routing_table()
-                    .get_section(self.name())
-                    .ok_or(RoutingError::RoutingTable(RoutingTableError::NoSuchPeer))?;
+                let section =
+                    self.peer_mgr
+                        .routing_table()
+                        .get_section(self.name())
+                        .ok_or(RoutingError::RoutingTable(RoutingTableError::NoSuchPeer))?;
                 let pub_ids = self.peer_mgr.get_pub_ids(section);
                 vec![SectionList::new(*self.our_prefix(), pub_ids)]
             }
             Section(_) => {
                 vec![SectionList::new(*self.our_prefix(),
-                                      self.peer_mgr
-                                          .get_pub_ids(self.peer_mgr
-                                              .routing_table()
-                                              .our_section()))]
+                                      self.peer_mgr.get_pub_ids(self.peer_mgr
+                                                                    .routing_table()
+                                                                    .our_section()))]
             }
             PrefixSection(ref prefix) => {
                 self.peer_mgr
@@ -3342,10 +3386,10 @@ impl Bootstrapped for Node {
                     .all_sections()
                     .into_iter()
                     .filter_map(|(p, members)| if prefix.is_compatible(&p) {
-                        Some(SectionList::new(p, self.peer_mgr.get_pub_ids(&members)))
-                    } else {
-                        None
-                    })
+                                    Some(SectionList::new(p, self.peer_mgr.get_pub_ids(&members)))
+                                } else {
+                                    None
+                                })
                     .collect()
             }
             Client { .. } => vec![],

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -63,7 +63,10 @@ mod implementation {
             self.next_token = token.wrapping_add(1);
             let &(ref mutex, ref cond_var) = &*self.detail_and_cond_var;
             let mut detail = mutex.lock().expect("Failed to lock.");
-            detail.deadlines.entry(Instant::now() + duration).or_insert_with(Vec::new).push(token);
+            detail.deadlines
+                .entry(Instant::now() + duration)
+                .or_insert_with(Vec::new)
+                .push(token);
             cond_var.notify_one();
             token
         }
@@ -94,8 +97,11 @@ mod implementation {
                     detail = cond_var.wait(detail).expect("Failed to lock.");
                 } else {
                     // Safe to call `expect()` as `deadlines` has at least one entry.
-                    let nearest =
-                        detail.deadlines.keys().next().cloned().expect("Bug in `BTreeMap`.");
+                    let nearest = detail.deadlines
+                        .keys()
+                        .next()
+                        .cloned()
+                        .expect("Bug in `BTreeMap`.");
                     let duration = nearest - now;
                     detail = cond_var.wait_timeout(detail, duration).expect("Failed to lock.").0;
                 }
@@ -114,12 +120,12 @@ mod implementation {
 
     #[cfg(test)]
     mod tests {
+        use super::*;
         use action::Action;
         use maidsafe_utilities::event_sender::MaidSafeEventCategory;
         use std::sync::mpsc;
         use std::thread;
         use std::time::{Duration, Instant};
-        use super::*;
         use types::RoutingActionSender;
 
         #[test]

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -94,9 +94,9 @@ impl Tunnels {
             .collect_vec();
         pairs.into_iter()
             .map(|pair| {
-                self.clients.remove(&pair);
-                if pair.0 == *peer_id { pair.1 } else { pair.0 }
-            })
+                     self.clients.remove(&pair);
+                     if pair.0 == *peer_id { pair.1 } else { pair.0 }
+                 })
             .collect()
     }
 
@@ -192,9 +192,9 @@ impl Default for Tunnels {
 
 #[cfg(all(test, feature = "use-mock-crust"))]
 mod tests {
+    use super::*;
     use itertools::Itertools;
     use mock_crust::crust::PeerId;
-    use super::*;
 
     fn id(i: usize) -> PeerId {
         PeerId(i)
@@ -219,9 +219,7 @@ mod tests {
         tunnels.add(id(1), id(0));
         tunnels.add(id(2), id(0));
         tunnels.add(id(3), id(4));
-        let removed_peers = tunnels.remove_tunnel(&id(0))
-            .into_iter()
-            .sorted();
+        let removed_peers = tunnels.remove_tunnel(&id(0)).into_iter().sorted();
         assert_eq!(&[id(1), id(2)], &*removed_peers);
         assert_eq!(None, tunnels.tunnel_for(&id(1)));
         assert_eq!(None, tunnels.tunnel_for(&id(2)));

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -85,7 +85,7 @@ mod tests {
         close_nodes_one_entry.push(rand::random());
         let actual_relocated_name_one_entry =
             super::calculate_relocated_name(close_nodes_one_entry.clone(), &original_name);
-        assert!(original_name != actual_relocated_name_one_entry);
+        assert_ne!(original_name, actual_relocated_name_one_entry);
 
         let mut combined_one_node_vec: Vec<XorName> = Vec::new();
         combined_one_node_vec.push(original_name);
@@ -111,7 +111,7 @@ mod tests {
         }
         let actual_relocated_name = super::calculate_relocated_name(close_nodes.clone(),
                                                                     &original_name);
-        assert!(original_name != actual_relocated_name);
+        assert_ne!(original_name, actual_relocated_name);
         close_nodes.sort_by(|a, b| original_name.cmp_distance(a, b));
         let first_closest = close_nodes[0];
         let second_closest = close_nodes[1];
@@ -141,6 +141,6 @@ mod tests {
             invalid_combined.push(*i);
         }
         let invalid_relocated_name = XorName(sha256::hash(&invalid_combined).0);
-        assert!(invalid_relocated_name != actual_relocated_name);
+        assert_ne!(invalid_relocated_name, actual_relocated_name);
     }
 }

--- a/src/xor_name.rs
+++ b/src/xor_name.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/xor_name.rs
+++ b/src/xor_name.rs
@@ -65,7 +65,10 @@ impl XorName {
 
     /// Returns the number of bits in which `self` differs from `other`.
     pub fn count_differing_bits(&self, other: &XorName) -> u32 {
-        self.0.iter().zip(other.0.iter()).fold(0, |acc, (a, b)| acc + (a ^ b).count_ones())
+        self.0
+            .iter()
+            .zip(other.0.iter())
+            .fold(0, |acc, (a, b)| acc + (a ^ b).count_ones())
     }
 
     /// Hex-decode a `XorName` from a `&str`.
@@ -246,11 +249,11 @@ impl Decodable for XorName {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use maidsafe_utilities::serialisation::{deserialise, serialise};
     use rand;
     use routing_table::Xorable;
     use std::cmp::Ordering;
-    use super::*;
 
     #[test]
     fn serialisation_xor_name() {

--- a/src/xor_name.rs
+++ b/src/xor_name.rs
@@ -268,9 +268,9 @@ mod tests {
     fn xor_name_ord() {
         let type1: XorName = XorName([1u8; XOR_NAME_LEN]);
         let type2: XorName = XorName([2u8; XOR_NAME_LEN]);
-        assert!(Ord::cmp(&type1, &type1) == Ordering::Equal);
-        assert!(Ord::cmp(&type1, &type2) == Ordering::Less);
-        assert!(Ord::cmp(&type2, &type1) == Ordering::Greater);
+        assert_eq!(Ord::cmp(&type1, &type1), Ordering::Equal);
+        assert_eq!(Ord::cmp(&type1, &type2), Ordering::Less);
+        assert_eq!(Ord::cmp(&type2, &type1), Ordering::Greater);
         assert!(type1 < type2);
         assert!(type1 <= type2);
         assert!(type1 <= type1);
@@ -289,9 +289,8 @@ mod tests {
         let type1_clone = type1;
         let type2: XorName = rand::random();
         assert_eq!(type1, type1_clone);
-        assert!(type1 == type1_clone);
         assert!(!(type1 != type1_clone));
-        assert!(type1 != type2);
+        assert_ne!(type1, type2);
     }
 
     #[test]

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -217,9 +217,10 @@ fn wait_for_nodes_to_connect(nodes: &mut [TestNode],
                 connection_counts[index] += 1;
 
                 let k = nodes.len();
-                let all_events_received = (0..k)
-                    .map(|i| connection_counts[i])
-                    .all(|n| n >= k - 1 || n >= min_section_size);
+                let all_events_received =
+                    (0..k).map(|i| connection_counts[i]).all(|n| {
+                                                                 n >= k - 1 || n >= min_section_size
+                                                             });
                 if all_events_received {
                     break;
                 }
@@ -268,7 +269,7 @@ fn gen_structured_data<R: Rng>(full_id: &FullId, rng: &mut R) -> Data {
                                      0,
                                      rng.gen_iter().take(10).collect(),
                                      owner)
-        .expect("Cannot create structured data for test");
+            .expect("Cannot create structured data for test");
     let _ = sd.add_signature(&(owner_pubkey, full_id.signing_private_key().clone()));
     Data::Structured(sd)
 }
@@ -403,15 +404,18 @@ fn core() {
                                                dst: Authority::ClientManager(name) }) => {
                         let src = Authority::ClientManager(name);
                         let dst = Authority::NaeManager(*data.name());
-                        unwrap!(nodes[index]
-                            .node
-                            .send_put_request(src, dst, data.clone(), id.clone()));
+                        unwrap!(nodes[index].node.send_put_request(src,
+                                                                   dst,
+                                                                   data.clone(),
+                                                                   id.clone()));
                     }
                     TestEvent(index, Event::Request { request, src, dst }) => {
                         if let Request::Put(data, id) = request {
-                            unwrap!(nodes[index]
-                                .node
-                                .send_put_failure(dst, src, data.identifier(), vec![], id));
+                            unwrap!(nodes[index].node.send_put_failure(dst,
+                                                                       src,
+                                                                       data.identifier(),
+                                                                       vec![],
+                                                                       id));
                         }
                     }
                     TestEvent(index,
@@ -502,10 +506,10 @@ fn core() {
             match test_event {
                 TestEvent(index, Event::Connected) if index == client.index => {
                     assert!(client.client
-                        .send_put_request(Authority::ClientManager(*client.name()),
-                                          data.clone(),
-                                          MessageId::new())
-                        .is_ok());
+                                .send_put_request(Authority::ClientManager(*client.name()),
+                                                  data.clone(),
+                                                  MessageId::new())
+                                .is_ok());
                 }
                 TestEvent(index,
                           Event::Request { request: Request::Put(data, id),
@@ -513,16 +517,16 @@ fn core() {
                                            dst: Authority::ClientManager(name) }) => {
                     let src = Authority::ClientManager(name);
                     let dst = Authority::NaeManager(*data.name());
-                    unwrap!(nodes[index]
-                        .node
-                        .send_put_request(src, dst, data.clone(), id.clone()));
+                    unwrap!(nodes[index].node.send_put_request(src, dst, data.clone(), id.clone()));
                 }
                 TestEvent(index, Event::Request { request, src, dst }) => {
                     if let Request::Put(data, id) = request {
                         if 2 * (index + 1) < min_section_size {
-                            unwrap!(nodes[index]
-                                .node
-                                .send_put_failure(dst, src, data.identifier(), vec![], id));
+                            unwrap!(nodes[index].node.send_put_failure(dst,
+                                                                       src,
+                                                                       data.identifier(),
+                                                                       vec![],
+                                                                       id));
                         }
                     }
                 }
@@ -561,9 +565,7 @@ fn core() {
                         // A node received request from the client. Reply with a success.
                         let data_id = data.identifier();
                         if let Request::Put(_, id) = request {
-                            unwrap!(nodes[index]
-                                .node
-                                .send_put_success(dst, src, data_id, id));
+                            unwrap!(nodes[index].node.send_put_success(dst, src, data_id, id));
                         }
                     }
                     TestEvent(index,

--- a/tests/mock_crust/accumulate.rs
+++ b/tests/mock_crust/accumulate.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/accumulate.rs
+++ b/tests/mock_crust/accumulate.rs
@@ -15,11 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{TestNode, create_connected_nodes, gen_immutable_data, poll_all,
+            sort_nodes_by_distance_to};
 use routing::{Authority, Event, EventStream, MessageId, QUORUM, Response, XorName};
 use routing::mock_crust::Network;
 use std::sync::mpsc;
-use super::{TestNode, create_connected_nodes, gen_immutable_data, poll_all,
-            sort_nodes_by_distance_to};
 
 #[test]
 fn messages_accumulate_with_quorum() {
@@ -33,9 +33,7 @@ fn messages_accumulate_with_quorum() {
     sort_nodes_by_distance_to(&mut nodes, &src.name());
 
     let send = |node: &mut TestNode, dst: &Authority<XorName>, message_id: MessageId| {
-        assert!(node.inner
-            .send_get_success(src, *dst, data.clone(), message_id)
-            .is_ok());
+        assert!(node.inner.send_get_success(src, *dst, data.clone(), message_id).is_ok());
     };
 
     let dst = Authority::ManagedNode(nodes[0].name()); // The closest node.

--- a/tests/mock_crust/cache.rs
+++ b/tests/mock_crust/cache.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/cache.rs
+++ b/tests/mock_crust/cache.rs
@@ -15,12 +15,12 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{TestNode, create_connected_clients, create_connected_nodes_until_split,
+            gen_immutable_data, poll_all};
 use rand::Rng;
 use routing::{Authority, Data, Event, EventStream, MessageId, Prefix, Request, Response};
 use routing::mock_crust::Network;
 use std::sync::mpsc;
-use super::{TestNode, create_connected_clients, create_connected_nodes_until_split,
-            gen_immutable_data, poll_all};
 
 // Generate random immutable data, but make sure the first node in the given
 // node slice (the proxy node) is not in the data's section.
@@ -72,8 +72,10 @@ fn response_caching() {
                                     src: req_src,
                                     dst: req_dst }) => {
                     if req_data_id == data_id && req_message_id == message_id {
-                        unwrap!(node.inner
-                            .send_get_success(req_dst, req_src, data.clone(), req_message_id));
+                        unwrap!(node.inner.send_get_success(req_dst,
+                                                            req_src,
+                                                            data.clone(),
+                                                            req_message_id));
                         break;
                     }
                 }

--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/drop.rs
+++ b/tests/mock_crust/drop.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/drop.rs
+++ b/tests/mock_crust/drop.rs
@@ -34,7 +34,7 @@ fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {
             match node.try_next_ev() {
                 Ok(Event::NodeLost(lost_name, _)) if lost_name == name => break,
                 Ok(_) => (),
-                Err(_) => panic!("Event::NodeLost({:?}) not received", name),
+                _ => panic!("Event::NodeLost({:?}) not received", name),
             }
         }
     }

--- a/tests/mock_crust/drop.rs
+++ b/tests/mock_crust/drop.rs
@@ -15,9 +15,9 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{TestNode, create_connected_nodes, poll_all, verify_invariant_for_all_nodes};
 use routing::{Event, EventStream};
 use routing::mock_crust::Network;
-use super::{TestNode, create_connected_nodes, poll_all, verify_invariant_for_all_nodes};
 
 // Drop node at index and verify its own section receives NodeLost.
 fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {

--- a/tests/mock_crust/merge.rs
+++ b/tests/mock_crust/merge.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/merge.rs
+++ b/tests/mock_crust/merge.rs
@@ -15,11 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{create_connected_nodes_until_split, poll_and_resend, verify_invariant_for_all_nodes};
 use rand::Rng;
 use routing::{Event, EventStream, Prefix, XOR_NAME_LEN, XorName};
 use routing::mock_crust::Network;
 use std::collections::{BTreeMap, BTreeSet};
-use super::{create_connected_nodes_until_split, poll_and_resend, verify_invariant_for_all_nodes};
 
 // See docs for `create_connected_nodes_with_cache_until_split` for details on `prefix_lengths`.
 fn merge(prefix_lengths: Vec<usize>) {
@@ -118,8 +118,8 @@ fn concurrent_merge() {
     // `min_section_size`.
     for (prefix, len) in &mut section_map {
         while *len >= min_section_size {
-            let index = unwrap!(nodes.iter()
-                .position(|node| node.routing_table().our_prefix() == prefix));
+            let index =
+                unwrap!(nodes.iter().position(|node| node.routing_table().our_prefix() == prefix));
             let removed = nodes.remove(index);
             drop(removed);
             *len -= 1;

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -24,15 +24,15 @@ mod requests;
 mod tunnel;
 mod utils;
 
-use routing::{Event, EventStream, Prefix, XOR_NAME_LEN, XorName};
-use routing::mock_crust::{Config, Endpoint, Network};
-use routing::mock_crust::crust::PeerId;
 pub use self::utils::{Nodes, TestClient, TestNode, add_connected_nodes_until_split,
                       create_connected_clients, create_connected_nodes,
                       create_connected_nodes_until_split, gen_bytes, gen_immutable_data,
                       gen_range_except, poll_all, poll_and_resend,
                       remove_nodes_which_failed_to_connect, sort_nodes_by_distance_to,
                       verify_invariant_for_all_nodes};
+use routing::{Event, EventStream, Prefix, XOR_NAME_LEN, XorName};
+use routing::mock_crust::{Config, Endpoint, Network};
+use routing::mock_crust::crust::PeerId;
 
 // -----  Miscellaneous tests below  -----
 
@@ -168,8 +168,8 @@ fn simultaneous_joining_nodes() {
 fn check_close_names_for_min_section_size_nodes() {
     let min_section_size = 8;
     let nodes = create_connected_nodes(&Network::new(min_section_size, None), min_section_size);
-    let close_sections_complete = nodes.iter()
-        .all(|n| nodes.iter().all(|m| m.close_names().contains(&n.name())));
+    let close_sections_complete =
+        nodes.iter().all(|n| nodes.iter().all(|m| m.close_names().contains(&n.name())));
     assert!(close_sections_complete);
 }
 
@@ -181,7 +181,10 @@ fn whitelist() {
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
 
     for node in &mut *nodes {
-        node.handle.0.borrow_mut().whitelist_peer(PeerId(min_section_size));
+        node.handle
+            .0
+            .borrow_mut()
+            .whitelist_peer(PeerId(min_section_size));
     }
     // The next node has peer ID `min_section_size`: It should be able to join.
     nodes.push(TestNode::builder(&network).config(config.clone()).create());

--- a/tests/mock_crust/requests.rs
+++ b/tests/mock_crust/requests.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/requests.rs
+++ b/tests/mock_crust/requests.rs
@@ -119,7 +119,7 @@ fn successful_get_request() {
         }
     }
 
-    assert!(response_received_count == 1);
+    assert_eq!(response_received_count, 1);
 }
 
 #[test]
@@ -185,7 +185,7 @@ fn failed_get_request() {
         }
     }
 
-    assert!(response_received_count == 1);
+    assert_eq!(response_received_count, 1);
 }
 
 #[test]

--- a/tests/mock_crust/tunnel.rs
+++ b/tests/mock_crust/tunnel.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/tunnel.rs
+++ b/tests/mock_crust/tunnel.rs
@@ -15,12 +15,12 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::{TestNode, add_connected_nodes_until_split, create_connected_nodes, poll_all,
+            poll_and_resend, verify_invariant_for_all_nodes};
 use itertools::Itertools;
 use routing::{Event, EventStream, XOR_NAME_LEN, XorName, Xorable};
 use routing::mock_crust::{Config, Endpoint, Network};
 use routing::mock_crust::crust::{self, PeerId};
-use super::{TestNode, add_connected_nodes_until_split, create_connected_nodes, poll_all,
-            poll_and_resend, verify_invariant_for_all_nodes};
 
 #[test]
 fn failing_connections_ring() {
@@ -69,10 +69,10 @@ fn remove_nodes_from_section_till_merge(prefix_name: &XorName,
         .enumerate()
         .rev()
         .filter_map(|(index, node)| if node.routing_table().our_prefix().matches(prefix_name) {
-            Some(index)
-        } else {
-            None
-        })
+                        Some(index)
+                    } else {
+                        None
+                    })
         .collect();
     section_indexes.iter()
         .take(section_indexes.len() - min_section_size + 1)
@@ -111,10 +111,10 @@ fn locate_tunnel_node(nodes: &[TestNode], client_1: PeerId, client_2: PeerId) ->
     let tunnel_node_indexes: Vec<usize> = nodes.iter()
         .enumerate()
         .filter_map(|(index, node)| if node.inner.has_tunnel_clients(client_1, client_2) {
-            Some(index)
-        } else {
-            None
-        })
+                        Some(index)
+                    } else {
+                        None
+                    })
         .collect();
     // There shall be only one tunnel_node for a pair of tunnel_clients across the network
     // Or None if they are directly connected or one of them are no longer in the network
@@ -153,9 +153,9 @@ fn tunnel_clients() {
     verify_invariant_for_all_nodes(&nodes);
     assert!(locate_tunnel_node(&nodes, direct_pair_peer_ids.0, direct_pair_peer_ids.1).is_none());
     assert!(locate_tunnel_node(&nodes, tunnel_pair_1_peer_ids.0, tunnel_pair_1_peer_ids.1)
-        .is_some());
+                .is_some());
     assert!(locate_tunnel_node(&nodes, tunnel_pair_2_peer_ids.0, tunnel_pair_2_peer_ids.1)
-        .is_some());
+                .is_some());
 
     add_connected_nodes_until_split(&network, &mut nodes, vec![2, 2, 2, 2], false);
     verify_invariant_for_all_nodes(&nodes);
@@ -171,9 +171,9 @@ fn tunnel_clients() {
     verify_invariant_for_all_nodes(&nodes);
     assert!(locate_tunnel_node(&nodes, direct_pair_peer_ids.0, direct_pair_peer_ids.1).is_some());
     assert!(locate_tunnel_node(&nodes, tunnel_pair_1_peer_ids.0, tunnel_pair_1_peer_ids.1)
-        .is_some());
+                .is_some());
     assert!(locate_tunnel_node(&nodes, tunnel_pair_2_peer_ids.0, tunnel_pair_2_peer_ids.1)
-        .is_none());
+                .is_none());
 }
 
 #[test]
@@ -326,17 +326,17 @@ fn avoid_tunnelling_when_proxying() {
     let config = Config::with_contacts(&[nodes[1].handle.endpoint()]);
     let endpoint = Endpoint(nodes.len());
     nodes.push(TestNode::builder(&network)
-        .config(config.clone())
-        .endpoint(endpoint)
-        .cache(false)
-        .create());
+                   .config(config.clone())
+                   .endpoint(endpoint)
+                   .cache(false)
+                   .create());
     poll_and_resend(&mut nodes, &mut []);
     let endpoint = Endpoint(nodes.len());
     nodes.push(TestNode::builder(&network)
-        .config(config.clone())
-        .endpoint(endpoint)
-        .cache(false)
-        .create());
+                   .config(config.clone())
+                   .endpoint(endpoint)
+                   .cache(false)
+                   .create());
     network.block_connection(Endpoint(nodes.len() - 1), Endpoint(0));
     network.block_connection(Endpoint(0), Endpoint(nodes.len() - 1));
     poll_and_resend(&mut nodes, &mut []);

--- a/tests/mock_crust/tunnel.rs
+++ b/tests/mock_crust/tunnel.rs
@@ -217,11 +217,11 @@ fn verify_tunnel_switch(nodes: &mut Vec<TestNode>, node: usize, client_1: usize,
     while let Ok(event) = nodes[client_2].inner.try_next_ev() {
         match event {
             Event::NodeLost(name, _) => {
-                assert!(name == nodes[client_1].name());
+                assert_eq!(name, nodes[client_1].name());
                 event_count += 1;
             }
             Event::NodeAdded(name, _) => {
-                assert!(name == nodes[client_1].name());
+                assert_eq!(name, nodes[client_1].name());
                 assert_eq!(event_count, 1);
             }
             _ => {
@@ -245,7 +245,8 @@ fn tunnel_node_disrupted() {
     network.lost_connection(Endpoint(2), Endpoint(tunnel_node_index));
     poll_and_resend(&mut nodes, &mut []);
     verify_tunnel_switch(&mut nodes, tunnel_node_index, 2, 3);
-    assert!(tunnel_node_index != unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))));
+    assert_ne!(tunnel_node_index,
+               unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))));
     verify_invariant_for_all_nodes(&nodes);
 }
 
@@ -263,7 +264,8 @@ fn tunnel_node_blocked() {
     network.lost_connection(Endpoint(2), Endpoint(tunnel_node_index));
     poll_and_resend(&mut nodes, &mut []);
     verify_tunnel_switch(&mut nodes, tunnel_node_index, 2, 3);
-    assert!(tunnel_node_index != unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))));
+    assert_ne!(tunnel_node_index,
+               unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))));
     verify_invariant_for_all_nodes(&nodes);
 }
 
@@ -285,7 +287,8 @@ fn tunnel_node_dropped() {
     expect_any_event!(nodes[1], Event::NodeAdded(..));
     expect_any_event!(nodes[2], Event::NodeAdded(..));
     verify_invariant_for_all_nodes(&nodes);
-    assert!(tunnel_node_index != unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))));
+    assert_ne!(tunnel_node_index,
+               unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))));
 }
 
 #[test]
@@ -309,7 +312,8 @@ fn tunnel_node_split_out() {
     add_connected_nodes_until_split(&network, &mut nodes, vec![2, 2, 2, 2], false);
 
     verify_invariant_for_all_nodes(&nodes);
-    assert!(tunnel_node_index != unwrap!(locate_tunnel_node(&nodes, peer_id_1, peer_id_2)));
+    assert_ne!(tunnel_node_index,
+               unwrap!(locate_tunnel_node(&nodes, peer_id_1, peer_id_2)));
 }
 
 #[test]
@@ -321,7 +325,7 @@ fn avoid_tunnelling_when_proxying() {
     let mut nodes = create_connected_nodes(&network, min_section_size);
     verify_invariant_for_all_nodes(&nodes);
     // Nodes[0] acts as proxy to others, shall not be chosen as tunnel node.
-    assert!(unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))) != 0);
+    assert_ne!(unwrap!(locate_tunnel_node(&nodes, PeerId(2), PeerId(3))), 0);
 
     let config = Config::with_contacts(&[nodes[1].handle.endpoint()]);
     let endpoint = Endpoint(nodes.len());

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -130,9 +130,9 @@ impl TestNode {
         let handle = network.new_service_handle(config, endpoint);
         let node = mock_crust::make_current(&handle, || {
             unwrap!(Node::builder()
-                .cache(cache)
-                .first(first_node)
-                .create(network.min_section_size()))
+                        .cache(cache)
+                        .first(first_node)
+                        .create(network.min_section_size()))
         });
 
         TestNode {
@@ -336,10 +336,10 @@ pub fn create_connected_nodes_with_cache(network: &Network, size: usize, use_cac
 
     // Create the seed node.
     nodes.push(TestNode::builder(network)
-        .first()
-        .endpoint(Endpoint(0))
-        .cache(use_cache)
-        .create());
+                   .first()
+                   .endpoint(Endpoint(0))
+                   .cache(use_cache)
+                   .create());
     nodes[0].poll();
 
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
@@ -347,10 +347,10 @@ pub fn create_connected_nodes_with_cache(network: &Network, size: usize, use_cac
     // Create other nodes using the seed node endpoint as bootstrap contact.
     for i in 1..size {
         nodes.push(TestNode::builder(network)
-            .config(config.clone())
-            .endpoint(Endpoint(i))
-            .cache(use_cache)
-            .create());
+                       .config(config.clone())
+                       .endpoint(Endpoint(i))
+                       .cache(use_cache)
+                       .create());
         poll_and_resend(&mut nodes, &mut []);
         verify_invariant_for_all_nodes(&nodes);
     }
@@ -386,8 +386,11 @@ pub fn create_connected_nodes_until_split(network: &Network,
                                           use_cache: bool)
                                           -> Nodes {
     // Start first node.
-    let mut nodes =
-        vec![TestNode::builder(network).first().endpoint(Endpoint(0)).cache(use_cache).create()];
+    let mut nodes = vec![TestNode::builder(network)
+                             .first()
+                             .endpoint(Endpoint(0))
+                             .cache(use_cache)
+                             .create()];
     nodes[0].poll();
     add_connected_nodes_until_split(network, &mut nodes, prefix_lengths, use_cache);
     Nodes(nodes)
@@ -547,7 +550,10 @@ fn resend_unacknowledged(nodes: &mut [TestNode], clients: &mut [TestClient]) -> 
     let node_resend = |node: &mut TestNode| node.inner.resend_unacknowledged();
     let client_resend = |client: &mut TestClient| client.inner.resend_unacknowledged();
     let or = |x, y| x || y;
-    nodes.iter_mut().map(node_resend).chain(clients.iter_mut().map(client_resend)).fold(false, or)
+    nodes.iter_mut()
+        .map(node_resend)
+        .chain(clients.iter_mut().map(client_resend))
+        .fold(false, or)
 }
 
 fn sanity_check(prefix_lengths: &[usize]) {
@@ -596,10 +602,10 @@ fn add_node_to_section<T: Rng>(network: &Network,
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
     let endpoint = Endpoint(nodes.len());
     nodes.push(TestNode::builder(network)
-        .config(config.clone())
-        .endpoint(endpoint)
-        .cache(use_cache)
-        .create());
+                   .config(config.clone())
+                   .endpoint(endpoint)
+                   .cache(use_cache)
+                   .create());
     poll_and_resend(nodes, &mut []);
     expect_any_event!(unwrap!(nodes.last_mut()), Event::Connected);
     assert_eq!(relocation_name, nodes[nodes.len() - 1].name());

--- a/tests/mock_crust_tests.rs
+++ b/tests/mock_crust_tests.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
As per the details mentioned in MAID-2000:

* fixed some outdated URLs
* removed mention of a version of the Contributor Agreement
* improved AppVeyor and Travis scripts
* applied rustfmt
* fixed clippy warnings

This also has the following changes:

* updated Travis script to use current versions of Rust, Clippy and rustfmt
* updated AppVeyor script to use the relocated QA Powershell script