### PR TITLE
fix/tunnels: fix bug when handling tunnel messages

### DIFF
--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -82,6 +82,14 @@ impl<Message: Hash> MessageFilter<Message> {
         self.entries.iter().any(|entry| entry.hash_code == hash_code)
     }
 
+    /// Remove the entry for `message`, regardless of how many times it was previously inserted.
+    pub fn remove(&mut self, message: &Message) {
+        let hash_code = hash(message);
+        if let Some(index) = self.entries.iter().position(|t| t.hash_code == hash_code) {
+            let _old_val = self.entries.remove(index);
+        }
+    }
+
     /// Clears the filter, removing all the entries.
     #[cfg(feature = "use-mock-crust")]
     pub fn clear(&mut self) {

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -505,24 +505,36 @@ impl Node {
                 self.handle_direct_message(direct_msg, peer_id, outbox)
             }
             Ok(Message::TunnelDirect { content, src, dst }) => {
-                if dst == self.crust_service.id() &&
-                   self.tunnels.tunnel_for(&src) == Some(&peer_id) {
-                    self.handle_direct_message(content, src, outbox)
+                if dst == self.crust_service.id() {
+                    if self.tunnels.tunnel_for(&src) == Some(&peer_id) {
+                        self.handle_direct_message(content, src, outbox)
+                    } else {
+                        debug!("{:?} Message recd via unregistered tunnel node {:?} from src {:?}",
+                               self,
+                               peer_id,
+                               src);
+                        Err(RoutingError::InvalidDestination)
+                    }
                 } else if self.tunnels.has_clients(src, dst) {
                     self.send_or_drop(&dst, bytes, content.priority());
                     Ok(())
                 } else if !self.peer_mgr.can_tunnel_for(&src, &dst) {
-                    debug!("{:?} mistakenly accepted to act as tunnel_node for {:?} - {:?}",
+                    debug!("{:?} Can no longer accept as a tunnel node for {:?} - {:?}",
                            self,
                            src,
                            dst);
                     self.send_direct_message(src, DirectMessage::TunnelClosed(dst));
                     Err(RoutingError::InvalidDestination)
-                } else if self.tunnels.accept_clients(src, dst) {
-                    debug!("{:?} agreed to act as tunnel_node for {:?} - {:?}",
+                } else if match content {
+                    DirectMessage::CandidateIdentify { .. } |
+                    DirectMessage::NodeIdentify { .. } => true,
+                    _ => false,
+                } && self.tunnels.accept_clients(src, dst) {
+                    debug!("{:?} Agreed to act as tunnel node for {:?} - {:?}",
                            self,
                            src,
                            dst);
+
                     self.send_direct_message(dst, DirectMessage::TunnelSuccess(src));
                     self.send_or_drop(&dst, bytes, content.priority());
                     Ok(())
@@ -3073,6 +3085,10 @@ impl Node {
 
     fn dropped_tunnel_client(&mut self, peer_id: &PeerId) {
         for other_id in self.tunnels.drop_client(peer_id) {
+            trace!("{:?} Closing tunnel client connection between {:?} and {:?}",
+                   self,
+                   peer_id,
+                   other_id);
             let message = DirectMessage::TunnelClosed(*peer_id);
             self.send_direct_message(other_id, message);
         }

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -75,8 +75,8 @@ impl Tunnels {
     /// `consider_clients` must be called with the client pair before this.
     pub fn accept_clients(&mut self, src_id: PeerId, dst_id: PeerId) -> bool {
         let pair = (src_id, dst_id);
-        // TODO(afck): Remove the pair from the new clients once message_filter supports that.
         if self.new_clients.contains(&pair) {
+            self.new_clients.remove(&pair);
             self.clients.insert(pair);
             true
         } else {


### PR DESCRIPTION
This fixes a couple of issues in node when handling 'TunnelDirect' messages - one where a tunnel
client would ignore a message intended for it, and another where _any_ 'DirectMessage' being handled
by a tunnel node from a pending tunnel client would cause the node to accept both clients.

Also fixed a todo in tunnels.rs to clean up 'new_clients' when moving a pair to 'clients'.