### PR TITLE
refactor/timer: make timer clonable

### DIFF
--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -216,7 +216,8 @@ mod unnamed {
         let mut term = term::stdout().expect("Could not open stdout.");
         term.fg(color).expect("Failed to set color");
         print!("{}", text);
-        term.reset().expect("Failed to restore stdout attributes.");
+        term.reset()
+            .expect("Failed to restore stdout attributes.");
         io::stdout().flush().expect("Could not flush stdout");
     }
 

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -119,7 +119,8 @@ Options:
             let _ = io::stdout().flush();
             let _ = stdin.read_line(&mut command);
 
-            let parts = command.trim_right_matches(|c| c == '\r' || c == '\n')
+            let parts = command
+                .trim_right_matches(|c| c == '\r' || c == '\n')
                 .split(' ')
                 .collect::<Vec<_>>();
 
@@ -190,7 +191,8 @@ Options:
         /// Get data from the network.
         pub fn get(&mut self, what: String) {
             let name = KeyValueStore::calculate_key_name(&what);
-            let data = self.example_client.get(DataIdentifier::Structured(name, 10000));
+            let data = self.example_client
+                .get(DataIdentifier::Structured(name, 10000));
             match data {
                 Some(data) => {
                     let sd = if let Data::Structured(sd) = data {

--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -79,9 +79,10 @@ impl ExampleClient {
     /// This is a blocking call and will wait indefinitely for the response.
     pub fn get(&mut self, request: DataIdentifier) -> Option<Data> {
         let message_id = MessageId::new();
-        unwrap!(self.routing_client.send_get_request(Authority::NaeManager(*request.name()),
-                                                     request.clone(),
-                                                     message_id));
+        unwrap!(self.routing_client
+                    .send_get_request(Authority::NaeManager(*request.name()),
+                                      request.clone(),
+                                      message_id));
 
         // Wait for Get success event from Routing
         loop {
@@ -97,8 +98,8 @@ impl ExampleClient {
                     return Some(data);
                 }
                 Some(Event::Response {
-                    response: Response::GetFailure { external_error_indicator, .. },
-                .. }) => {
+                         response: Response::GetFailure { external_error_indicator, .. }, ..
+                     }) => {
                     error!("Failed to Get {:?}: {:?}",
                            request.name(),
                            unwrap!(String::from_utf8(external_error_indicator)));
@@ -119,14 +120,17 @@ impl ExampleClient {
     pub fn put(&self, data: Data) -> Result<(), ()> {
         let data_id = data.identifier();
         let message_id = MessageId::new();
-        unwrap!(self.routing_client.send_put_request(Authority::ClientManager(*self.name()),
-                                                     data,
-                                                     message_id));
+        unwrap!(self.routing_client
+                    .send_put_request(Authority::ClientManager(*self.name()),
+                                      data,
+                                      message_id));
 
         // Wait for Put success event from Routing
         loop {
             match recv_with_timeout(&self.receiver, Duration::from_secs(RESPONSE_TIMEOUT_SECS)) {
-                Some(Event::Response { response: Response::PutSuccess(rec_data_id, id), .. }) => {
+                Some(Event::Response {
+                         response: Response::PutSuccess(rec_data_id, id), ..
+                     }) => {
                     if message_id != id {
                         error!("Stored {:?}, but with wrong message_id {:?} instead of {:?}.",
                                data_id.name(),

--- a/examples/utils/example_node.rs
+++ b/examples/utils/example_node.rs
@@ -18,8 +18,8 @@
 use super::MIN_SECTION_SIZE;
 use lru_time_cache::LruCache;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use routing::{Authority, Data, DataIdentifier, Event, EventStream, MessageId, Node, Prefix, Request,
-              Response, XorName};
+use routing::{Authority, Data, DataIdentifier, Event, EventStream, MessageId, Node, Prefix,
+              Request, Response, XorName};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -175,7 +175,8 @@ impl ExampleNode {
                        self.get_debug_name(),
                        data.name(),
                        data);
-                let _ = self.node.send_put_success(dst, src, data.identifier(), id);
+                let _ = self.node
+                    .send_put_success(dst, src, data.identifier(), id);
                 let _ = self.db.insert(data.identifier(), data);
             }
             Authority::ClientManager(_) => {

--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -87,7 +87,9 @@ impl AckManager {
     // returns None.
     pub fn find_timed_out(&mut self, token: u64) -> Option<(UnacknowledgedMessage, Ack)> {
         let timed_out_ack = if let Some((sip_hash, _)) =
-            self.pending.iter().find(|&(_, unacked_msg)| unacked_msg.timer_token == token) {
+            self.pending
+                .iter()
+                .find(|&(_, unacked_msg)| unacked_msg.timer_token == token) {
             *sip_hash
         } else {
             return None;

--- a/src/action.rs
+++ b/src/action.rs
@@ -59,7 +59,11 @@ impl Debug for Action {
                        "Action::NodeSendMessage {{ {:?}, result_tx }}",
                        content)
             }
-            Action::ClientSendRequest { ref content, ref dst, .. } => {
+            Action::ClientSendRequest {
+                ref content,
+                ref dst,
+                ..
+            } => {
                 write!(formatter,
                        "Action::ClientSendRequest {{ {:?}, dst: {:?}, result_tx }}",
                        content,

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,7 +187,8 @@ impl Client {
     /// Returns the name of this node.
     pub fn name(&self) -> Result<XorName, InterfaceError> {
         let (result_tx, result_rx) = channel();
-        self.action_sender.send(Action::Name { result_tx: result_tx })?;
+        self.action_sender
+            .send(Action::Name { result_tx: result_tx })?;
 
         self.receive_action_result(&result_rx)
     }
@@ -264,7 +265,9 @@ impl Client {
 
     /// Step the underlying state machine if there are any events for it to process.
     fn try_step(&self) -> Result<(), TryRecvError> {
-        self.machine.borrow_mut().try_step(&mut *self.event_buffer.borrow_mut())
+        self.machine
+            .borrow_mut()
+            .try_step(&mut *self.event_buffer.borrow_mut())
     }
 
     /// Resend all unacknowledged messages.
@@ -277,10 +280,7 @@ impl Client {
 
     /// Are there any unacknowledged messages?
     pub fn has_unacknowledged(&self) -> bool {
-        self.machine
-            .borrow()
-            .current()
-            .has_unacknowledged()
+        self.machine.borrow().current().has_unacknowledged()
     }
 }
 

--- a/src/data/append_types.rs
+++ b/src/data/append_types.rs
@@ -145,11 +145,13 @@ impl AppendWrapper {
     pub fn verify_signature(&self) -> bool {
         match *self {
             AppendWrapper::Pub { ref data, .. } => data.verify_signature(),
-            AppendWrapper::Priv { ref append_to,
-                                  ref data,
-                                  ref sign_key,
-                                  ref version,
-                                  ref signature } => {
+            AppendWrapper::Priv {
+                ref append_to,
+                ref data,
+                ref sign_key,
+                ref version,
+                ref signature,
+            } => {
                 let data_to_sign = match serialise(&(append_to, data, sign_key, version)) {
                     Err(_) => return false,
                     Ok(data) => data,

--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -102,10 +102,7 @@ mod tests {
 
         // Normal
         let immutable_data = ImmutableData::new(value);
-        let immutable_data_name = immutable_data.name()
-            .0
-            .as_ref()
-            .to_hex();
+        let immutable_data_name = immutable_data.name().0.as_ref().to_hex();
         let expected_name = "ec0775555a7a6afba5f6e0a1deaa06f8928da80cf6ca94742ecc2a00c31033d3";
 
         assert_eq!(&expected_name, &immutable_data_name);

--- a/src/data/priv_appendable_data.rs
+++ b/src/data/priv_appendable_data.rs
@@ -206,10 +206,7 @@ impl PrivAppendableData {
         // handling is OK
         let sd = SerialisablePrivAppendableData {
             name: self.name,
-            version: self.version
-                .to_string()
-                .as_bytes()
-                .to_vec(),
+            version: self.version.to_string().as_bytes().to_vec(),
             filter: &self.filter,
             encrypt_key: &self.encrypt_key,
             owners: &self.owners,

--- a/src/data/pub_appendable_data.rs
+++ b/src/data/pub_appendable_data.rs
@@ -163,10 +163,7 @@ impl PubAppendableData {
         let sd = SerialisablePubAppendableData {
             name: self.name,
             owners: &self.owners,
-            version: self.version
-                .to_string()
-                .as_bytes()
-                .to_vec(),
+            version: self.version.to_string().as_bytes().to_vec(),
             filter: &self.filter,
             deleted_data: &self.deleted_data,
         };

--- a/src/data/structured_data.rs
+++ b/src/data/structured_data.rs
@@ -132,16 +132,10 @@ impl StructuredData {
         // Seems overkill to use serialisation here, but done to ensure cross platform signature
         // handling is OK
         let sd = SerialisableStructuredData {
-            type_tag: self.type_tag
-                .to_string()
-                .as_bytes()
-                .to_vec(),
+            type_tag: self.type_tag.to_string().as_bytes().to_vec(),
             name: self.name,
             data: &self.data,
-            version: self.version
-                .to_string()
-                .as_bytes()
-                .to_vec(),
+            version: self.version.to_string().as_bytes().to_vec(),
             owners: &self.owners,
         };
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -73,14 +73,22 @@ pub enum Event {
 impl Debug for Event {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
-            Event::Request { ref request, ref src, ref dst } => {
+            Event::Request {
+                ref request,
+                ref src,
+                ref dst,
+            } => {
                 write!(formatter,
                        "Event::Request {{ request: {:?}, src: {:?}, dst: {:?} }}",
                        request,
                        src,
                        dst)
             }
-            Event::Response { ref response, ref src, ref dst } => {
+            Event::Response {
+                ref response,
+                ref src,
+                ref dst,
+            } => {
                 write!(formatter,
                        "Event::Response {{ response: {:?}, src: {:?}, dst: {:?} }}",
                        response,

--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -56,14 +56,17 @@ impl<Message: Hash> MessageFilter<Message> {
     pub fn insert(&mut self, message: &Message) -> usize {
         self.remove_expired();
         let hash_code = hash(message);
-        if let Some(index) = self.entries.iter().position(|t| t.hash_code == hash_code) {
+        if let Some(index) = self.entries
+               .iter()
+               .position(|t| t.hash_code == hash_code) {
             let mut timestamped_message = self.entries.remove(index);
             timestamped_message.update_expiry_point(self.time_to_live);
             let count = timestamped_message.increment_count();
             self.entries.push(timestamped_message);
             count
         } else {
-            self.entries.push(TimestampedMessage::new(hash_code, self.time_to_live));
+            self.entries
+                .push(TimestampedMessage::new(hash_code, self.time_to_live));
             1
         }
     }
@@ -82,13 +85,17 @@ impl<Message: Hash> MessageFilter<Message> {
     pub fn contains(&mut self, message: &Message) -> bool {
         self.remove_expired();
         let hash_code = hash(message);
-        self.entries.iter().any(|entry| entry.hash_code == hash_code)
+        self.entries
+            .iter()
+            .any(|entry| entry.hash_code == hash_code)
     }
 
     /// Remove the entry for `message`, regardless of how many times it was previously inserted.
     pub fn remove(&mut self, message: &Message) {
         let hash_code = hash(message);
-        if let Some(index) = self.entries.iter().position(|t| t.hash_code == hash_code) {
+        if let Some(index) = self.entries
+               .iter()
+               .position(|t| t.hash_code == hash_code) {
             let _old_val = self.entries.remove(index);
         }
     }
@@ -104,7 +111,9 @@ impl<Message: Hash> MessageFilter<Message> {
         // The entries are sorted from oldest to newest, so just split off the vector at the
         // first unexpired entry and the returned vector is the remaining unexpired values.  If
         // we don't find any unexpired value, just clear the vector.
-        if let Some(at) = self.entries.iter().position(|entry| entry.expiry_point > now) {
+        if let Some(at) = self.entries
+               .iter()
+               .position(|entry| entry.expiry_point > now) {
             self.entries = self.entries.split_off(at)
         } else {
             self.entries.clear();

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -41,10 +41,7 @@ impl Service {
     pub fn with_handle(handle: &ServiceHandle,
                        event_sender: CrustEventSender)
                        -> Result<Self, CrustError> {
-        let network = handle.0
-            .borrow()
-            .network
-            .clone();
+        let network = handle.0.borrow().network.clone();
         let service = Service(handle.0.clone(), network);
         service.lock_and_poll(|imp| imp.start(event_sender));
 

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -120,16 +120,25 @@ impl Network {
         let service_1 = unwrap!(self.find_service(node_1),
                                 "Cannot fetch service of {:?}.",
                                 node_1);
-        if service_1.borrow_mut().remove_connection_by_endpoint(node_2).is_none() {
+        if service_1
+               .borrow_mut()
+               .remove_connection_by_endpoint(node_2)
+               .is_none() {
             return;
         }
         let service_2 = unwrap!(self.find_service(node_2),
                                 "Cannot fetch service of {:?}.",
                                 node_2);
-        let _ = service_2.borrow_mut().remove_connection_by_endpoint(node_1);
+        let _ = service_2
+            .borrow_mut()
+            .remove_connection_by_endpoint(node_1);
 
-        service_1.borrow_mut().send_event(Event::LostPeer(PeerId(node_2.0)));
-        service_2.borrow_mut().send_event(Event::LostPeer(PeerId(node_1.0)));
+        service_1
+            .borrow_mut()
+            .send_event(Event::LostPeer(PeerId(node_2.0)));
+        service_2
+            .borrow_mut()
+            .send_event(Event::LostPeer(PeerId(node_1.0)));
     }
 
     /// Simulates a crust event being sent to the node.
@@ -143,10 +152,7 @@ impl Network {
     /// Construct a new [`XorShiftRng`](https://doc.rust-lang.org/rand/rand/struct.XorShiftRng.html)
     /// using a seed generated from random data provided by `self`.
     pub fn new_rng(&self) -> XorShiftRng {
-        self.0
-            .borrow_mut()
-            .rng
-            .new_rng()
+        self.0.borrow_mut().rng.new_rng()
     }
 
     fn connection_blocked(&self, sender: Endpoint, receiver: Endpoint) -> bool {
@@ -168,37 +174,32 @@ impl Network {
     // Drops any pending messages on a specific route (does not automatically
     // drop packets going the other way).
     fn drop_pending(&self, sender: Endpoint, receiver: Endpoint) {
-        if let Some(deque) = self.0
-               .borrow_mut()
-               .queue
-               .get_mut(&(sender, receiver)) {
+        if let Some(deque) = self.0.borrow_mut().queue.get_mut(&(sender, receiver)) {
             deque.clear();
         }
     }
 
     // Drops all pending messages across the entire network.
     fn drop_all_pending(&self) {
-        self.0
-            .borrow_mut()
-            .queue
-            .clear();
+        self.0.borrow_mut().queue.clear();
     }
 
     fn pop_packet(&self) -> Option<(Endpoint, Endpoint, Packet)> {
         let mut network_impl = self.0.borrow_mut();
-        let keys: Vec<_> = network_impl.queue
-            .keys()
-            .cloned()
-            .collect();
+        let keys: Vec<_> = network_impl.queue.keys().cloned().collect();
         let (sender, receiver) = if let Some(key) = network_impl.rng.choose(&keys) {
             *key
         } else {
             return None;
         };
-        let result =
-            network_impl.queue.get_mut(&(sender, receiver)).and_then(|packets| {
-                packets.pop_front().map(|packet| (sender, receiver, packet))
-            });
+        let result = network_impl
+            .queue
+            .get_mut(&(sender, receiver))
+            .and_then(|packets| {
+                          packets
+                              .pop_front()
+                              .map(|packet| (sender, receiver, packet))
+                      });
         if result.is_some() {
             if let Entry::Occupied(entry) = network_impl.queue.entry((sender, receiver)) {
                 if entry.get().is_empty() {
@@ -251,7 +252,9 @@ impl ServiceHandle {
 
     /// Returns `true` if this service is connected to the given one.
     pub fn is_connected(&self, handle: &ServiceHandle) -> bool {
-        self.0.borrow().is_peer_connected(&handle.0.borrow().peer_id)
+        self.0
+            .borrow()
+            .is_peer_connected(&handle.0.borrow().peer_id)
     }
 }
 
@@ -469,7 +472,9 @@ impl ServiceImpl {
     }
 
     fn add_connection(&mut self, peer_id: PeerId, peer_endpoint: Endpoint) -> bool {
-        if self.connections.iter().any(|&(id, ep)| id == peer_id && ep == peer_endpoint) {
+        if self.connections
+               .iter()
+               .any(|&(id, ep)| id == peer_id && ep == peer_endpoint) {
             // Connection already exists
             return false;
         }
@@ -486,7 +491,9 @@ impl ServiceImpl {
     // Remove connected peer with the given peer id and return its endpoint,
     // or None if no such peer exists.
     fn remove_connection_by_peer_id(&mut self, peer_id: &PeerId) -> Option<Endpoint> {
-        if let Some(i) = self.connections.iter().position(|&(id, _)| id == *peer_id) {
+        if let Some(i) = self.connections
+               .iter()
+               .position(|&(id, _)| id == *peer_id) {
             Some(self.connections.swap_remove(i).1)
         } else {
             None
@@ -494,7 +501,9 @@ impl ServiceImpl {
     }
 
     fn remove_connection_by_endpoint(&mut self, endpoint: Endpoint) -> Option<PeerId> {
-        if let Some(i) = self.connections.iter().position(|&(_, ep)| ep == endpoint) {
+        if let Some(i) = self.connections
+               .iter()
+               .position(|&(_, ep)| ep == endpoint) {
             Some(self.connections.swap_remove(i).0)
         } else {
             None
@@ -516,7 +525,9 @@ impl ServiceImpl {
     }
 
     fn is_connected(&self, endpoint: &Endpoint, peer_id: &PeerId) -> bool {
-        self.connections.iter().any(|&conn| conn == (*peer_id, *endpoint))
+        self.connections
+            .iter()
+            .any(|&conn| conn == (*peer_id, *endpoint))
     }
 
     pub fn disconnect(&mut self, peer_id: &PeerId) -> bool {

--- a/src/node.rs
+++ b/src/node.rs
@@ -56,17 +56,26 @@ pub struct NodeBuilder {
 impl NodeBuilder {
     /// Configures the node to use the given request cache.
     pub fn cache(self, cache: Box<Cache>) -> NodeBuilder {
-        NodeBuilder { cache: cache, ..self }
+        NodeBuilder {
+            cache: cache,
+            ..self
+        }
     }
 
     /// Configures the node to start a new network instead of joining an existing one.
     pub fn first(self, first: bool) -> NodeBuilder {
-        NodeBuilder { first: first, ..self }
+        NodeBuilder {
+            first: first,
+            ..self
+        }
     }
 
     /// Causes node creation to fail if another node on the local network is detected.
     pub fn deny_other_local_nodes(self) -> NodeBuilder {
-        NodeBuilder { deny_other_local_nodes: true, ..self }
+        NodeBuilder {
+            deny_other_local_nodes: true,
+            ..self
+        }
     }
 
     /// Creates new `Node`.
@@ -417,8 +426,11 @@ impl Node {
             result_tx: self.interface_result_tx.clone(),
         };
 
-        let transition = self.machine.current_mut().handle_action(action, &mut self.event_buffer);
-        self.machine.apply_transition(transition, &mut self.event_buffer);
+        let transition = self.machine
+            .current_mut()
+            .handle_action(action, &mut self.event_buffer);
+        self.machine
+            .apply_transition(transition, &mut self.event_buffer);
 
         self.receive_action_result(&self.interface_result_rx)?
     }
@@ -458,15 +470,14 @@ impl Node {
 
     /// Routing table of this node.
     pub fn routing_table(&self) -> Option<RoutingTable<XorName>> {
-        self.machine
-            .current()
-            .routing_table()
-            .cloned()
+        self.machine.current().routing_table().cloned()
     }
 
     /// Check whether this node acts as a tunnel node between `client_1` and `client_2`.
     pub fn has_tunnel_clients(&self, client_1: PeerId, client_2: PeerId) -> bool {
-        self.machine.current().has_tunnel_clients(client_1, client_2)
+        self.machine
+            .current()
+            .has_tunnel_clients(client_1, client_2)
     }
 
     /// Resend all unacknowledged messages.
@@ -493,7 +504,9 @@ impl Node {
 
     /// Sets a name to be used when the next node relocation request is received by this node.
     pub fn set_next_node_name(&mut self, relocation_name: XorName) {
-        self.machine.current_mut().set_next_node_name(Some(relocation_name))
+        self.machine
+            .current_mut()
+            .set_next_node_name(Some(relocation_name))
     }
 
     /// Clears the name to be used when the next node relocation request is received by this node so
@@ -513,7 +526,9 @@ impl Debug for Node {
 impl Drop for Node {
     fn drop(&mut self) {
         self.poll();
-        let _ = self.machine.current_mut().handle_action(Action::Terminate, &mut self.event_buffer);
+        let _ = self.machine
+            .current_mut()
+            .handle_action(Action::Terminate, &mut self.event_buffer);
         let _ = self.event_buffer.take_all();
     }
 }

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -77,7 +77,9 @@ impl RoutingMessageFilter {
     pub fn filter_outgoing(&mut self, msg: &RoutingMessage, peer_id: &PeerId, route: u8) -> bool {
         if let Ok(msg_bytes) = serialise(msg) {
             let hash = sha3_256(&msg_bytes);
-            self.outgoing.insert((hash, *peer_id, route), ()).is_some()
+            self.outgoing
+                .insert((hash, *peer_id, route), ())
+                .is_some()
         } else {
             trace!("Tried to filter oversized routing message: {:?}", msg);
             false

--- a/src/routing_table/authority.rs
+++ b/src/routing_table/authority.rs
@@ -121,7 +121,11 @@ impl<N: Xorable + Clone + Copy + Binary + Default + Display> Debug for Authority
                 write!(formatter, "PrefixSection(prefix: {:?})", prefix)
             }
             Authority::ManagedNode(ref name) => write!(formatter, "ManagedNode(name: {})", name),
-            Authority::Client { ref client_key, ref proxy_node_name, ref peer_id } => {
+            Authority::Client {
+                ref client_key,
+                ref proxy_node_name,
+                ref peer_id,
+            } => {
                 write!(formatter,
                        "Client {{ client_name: {}, proxy_node_name: {}, peer_id: {:?} }}",
                        N::from_hash(hash::sha256::hash(&client_key[..]).0),

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -62,7 +62,8 @@ impl Network {
         let name = self.random_free_name(); // The new node's name.
         if self.nodes.is_empty() {
             // If this is the first node, just add it and return.
-            let result = self.nodes.insert(name, RoutingTable::new(name, self.min_section_size));
+            let result = self.nodes
+                .insert(name, RoutingTable::new(name, self.min_section_size));
             assert!(result.is_none());
             return;
         }
@@ -159,7 +160,10 @@ impl Network {
                     match target_node.merge_own_section(merge_own_details.clone()) {
                         OwnMergeState::Ongoing |
                         OwnMergeState::AlreadyMerged => (),
-                        OwnMergeState::Completed { targets, merge_details } => {
+                        OwnMergeState::Completed {
+                            targets,
+                            merge_details,
+                        } => {
                             Network::store_merge_info(&mut merge_other_info,
                                                       *target_node.our_prefix(),
                                                       (targets, merge_details));
@@ -263,10 +267,7 @@ impl Network {
 
     /// Returns all node names.
     fn keys(&self) -> Vec<u64> {
-        self.nodes
-            .keys()
-            .cloned()
-            .collect()
+        self.nodes.keys().cloned().collect()
     }
 }
 

--- a/src/routing_table/prefix.rs
+++ b/src/routing_table/prefix.rs
@@ -129,7 +129,8 @@ impl<T: Clone + Copy + Default + Binary + Xorable> Prefix<T> {
         where T: 'a,
               U: IntoIterator<Item = &'a Prefix<T>> + Clone
     {
-        let max_prefix_len = prefixes.clone()
+        let max_prefix_len = prefixes
+            .clone()
             .into_iter()
             .map(|x| x.bit_count())
             .max()
@@ -141,13 +142,15 @@ impl<T: Clone + Copy + Default + Binary + Xorable> Prefix<T> {
         where T: 'a,
               U: IntoIterator<Item = &'a Prefix<T>> + Clone
     {
-        prefixes.clone().into_iter().any(|x| {
-                                             x.is_compatible(self) &&
-                                             x.bit_count() <= self.bit_count()
-                                         }) ||
+        prefixes
+            .clone()
+            .into_iter()
+            .any(|x| x.is_compatible(self) && x.bit_count() <= self.bit_count()) ||
         (self.bit_count() <= max_prefix_len &&
-         self.pushed(false).is_covered_by_impl(prefixes.clone(), max_prefix_len) &&
-         self.pushed(true).is_covered_by_impl(prefixes, max_prefix_len))
+         self.pushed(false)
+             .is_covered_by_impl(prefixes.clone(), max_prefix_len) &&
+         self.pushed(true)
+             .is_covered_by_impl(prefixes, max_prefix_len))
     }
 
     /// Returns the neighbouring prefix differing in the `i`-th bit

--- a/src/routing_table/xorable.rs
+++ b/src/routing_table/xorable.rs
@@ -74,7 +74,8 @@ pub fn debug_format(input: String) -> String {
     if input.len() <= 20 {
         return input;
     }
-    input.chars()
+    input
+        .chars()
         .take(8)
         .chain("...".chars())
         .chain(input.chars().skip(input.len() - 8))

--- a/src/section_list_cache.rs
+++ b/src/section_list_cache.rs
@@ -46,9 +46,12 @@ impl SectionListCache {
     pub fn remove_signatures_by(&mut self, author: PublicId, our_section_size: usize) {
         if let Some(lists) = self.signed_by.remove(&author) {
             for (prefix, list) in lists {
-                let _ = self.signatures.get_mut(&prefix).map_or(None, |map| {
-                    map.get_mut(&list).map_or(None, |sigmap| sigmap.remove(&author))
-                });
+                let _ = self.signatures
+                    .get_mut(&prefix)
+                    .map_or(None, |map| {
+                        map.get_mut(&list)
+                            .map_or(None, |sigmap| sigmap.remove(&author))
+                    });
             }
             self.prune();
             self.update_lists_cache(our_section_size);
@@ -123,16 +126,16 @@ impl SectionListCache {
     fn update_lists_cache(&mut self, our_section_size: usize) {
         for (prefix, map) in &self.signatures {
             // find the entries with the most signatures
-            let entries =
-                map.iter().map(|(list, sigs)| (list, sigs.len())).sorted_by(|lhs, rhs| {
-                                                                                rhs.1.cmp(&lhs.1)
-                                                                            });
+            let entries = map.iter()
+                .map(|(list, sigs)| (list, sigs.len()))
+                .sorted_by(|lhs, rhs| rhs.1.cmp(&lhs.1));
             if let Some(&(list, sig_count)) = entries.first() {
                 // entry.0 = list, entry.1 = num of signatures
                 if 100 * sig_count >= QUORUM * our_section_size {
                     // we have a list with a quorum of signatures
                     let signatures = unwrap!(map.get(list));
-                    let _ = self.lists_cache.insert(*prefix, (list.clone(), signatures.clone()));
+                    let _ = self.lists_cache
+                        .insert(*prefix, (list.clone(), signatures.clone()));
                 }
             }
         }
@@ -149,11 +152,16 @@ impl SectionListCache {
             .collect_vec();
         for (prefix, list) in to_remove {
             // remove the signatures from self.signatures
-            let _ = self.signatures.get_mut(&prefix).map_or(None, |map| {
-                map.get_mut(&list).map_or(None, |sigmap| sigmap.remove(&author))
-            });
+            let _ = self.signatures
+                .get_mut(&prefix)
+                .map_or(None, |map| {
+                    map.get_mut(&list)
+                        .map_or(None, |sigmap| sigmap.remove(&author))
+                });
             // remove those entries from self.signed_by
-            let _ = self.signed_by.get_mut(&author).map_or(None, |map| map.remove(&prefix));
+            let _ = self.signed_by
+                .get_mut(&author)
+                .map_or(None, |map| map.remove(&prefix));
         }
 
         self.prune();

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -99,7 +99,8 @@ impl State {
     }
 
     fn close_group(&self, name: XorName, count: usize) -> Option<Vec<XorName>> {
-        self.base_state().and_then(|state| state.close_group(name, count))
+        self.base_state()
+            .and_then(|state| state.close_group(name, count))
     }
 
     fn base_state(&self) -> Option<&Base> {
@@ -263,7 +264,10 @@ impl StateMachine {
     pub fn apply_transition(&mut self, transition: Transition, outbox: &mut EventBox) {
         match transition {
             Transition::Stay => (),
-            Transition::IntoBootstrapped { proxy_peer_id, proxy_public_id } => {
+            Transition::IntoBootstrapped {
+                proxy_peer_id,
+                proxy_public_id,
+            } => {
                 // Temporarily switch to `Terminated` to allow moving out of the current
                 // state without moving `self`.
                 let prev_state = mem::replace(&mut self.state, State::Terminated);

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -130,7 +130,8 @@ impl Bootstrapping {
                 }
                 trace!("{:?} Listener started on port {}.", self, port);
                 self.crust_service.set_service_discovery_listen(true);
-                let _ = self.crust_service.start_bootstrap(HashSet::new(), CrustUser::Node);
+                let _ = self.crust_service
+                    .start_bootstrap(HashSet::new(), CrustUser::Node);
                 Transition::Stay
             }
             CrustEvent::ListenerFailed => {
@@ -274,7 +275,8 @@ impl Bootstrapping {
     fn send_client_identify(&mut self, peer_id: PeerId) {
         debug!("{:?} - Sending ClientIdentify to {:?}.", self, peer_id);
 
-        let token = self.timer.schedule(Duration::from_secs(BOOTSTRAP_TIMEOUT_SECS));
+        let token = self.timer
+            .schedule(Duration::from_secs(BOOTSTRAP_TIMEOUT_SECS));
         self.bootstrap_connection = Some((peer_id, token));
 
         let serialised_public_id = match serialisation::serialise(self.full_id.public_id()) {
@@ -315,8 +317,8 @@ impl Bootstrapping {
             } else {
                 CrustUser::Node
             };
-            let _ = self.crust_service.start_bootstrap(self.bootstrap_blacklist.clone(),
-                                                       crust_user);
+            let _ = self.crust_service
+                .start_bootstrap(self.bootstrap_blacklist.clone(), crust_user);
         }
     }
 }

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -86,7 +86,12 @@ impl Client {
 
     pub fn handle_action(&mut self, action: Action) -> Transition {
         match action {
-            Action::ClientSendRequest { content, dst, priority, result_tx } => {
+            Action::ClientSendRequest {
+                content,
+                dst,
+                priority,
+                result_tx,
+            } => {
                 let src = Authority::Client {
                     client_key: *self.full_id.public_id().signing_public_key(),
                     proxy_node_name: *self.proxy_public_id.name(),
@@ -186,7 +191,8 @@ impl Client {
         }
 
         // Prevents us repeatedly handling identical messages sent by a malicious peer.
-        match self.routing_msg_filter.filter_incoming(routing_msg, hop_msg.route) {
+        match self.routing_msg_filter
+                  .filter_incoming(routing_msg, hop_msg.route) {
             FilteringResult::KnownMessage |
             FilteringResult::KnownMessageAndRoute => return Err(RoutingError::FilterCheckFailed),
             FilteringResult::NewMessage => (),
@@ -205,7 +211,13 @@ impl Client {
                                 -> Transition {
         match routing_msg.content {
             MessageContent::Ack(ack, _) => self.handle_ack_response(ack),
-            MessageContent::UserMessagePart { hash, part_count, part_index, payload, .. } => {
+            MessageContent::UserMessagePart {
+                hash,
+                part_count,
+                part_index,
+                payload,
+                ..
+            } => {
                 trace!("{:?} Got UserMessagePart {:02x}{:02x}{:02x}.., {}/{} from {:?} to {:?}.",
                        self,
                        hash[0],
@@ -215,7 +227,8 @@ impl Client {
                        part_index,
                        routing_msg.src,
                        routing_msg.dst);
-                if let Some(msg) = self.user_msg_cache.add(hash, part_count, part_index, payload) {
+                if let Some(msg) = self.user_msg_cache
+                       .add(hash, part_count, part_index, payload) {
                     self.stats().count_user_message(&msg);
                     outbox.send_event(msg.into_event(routing_msg.src, routing_msg.dst));
                 }

--- a/src/states/common/bootstrapped.rs
+++ b/src/states/common/bootstrapped.rs
@@ -66,7 +66,8 @@ pub trait Bootstrapped: Base {
             return false;
         }
 
-        let token = self.timer().schedule(Duration::from_secs(ACK_TIMEOUT_SECS));
+        let token = self.timer()
+            .schedule(Duration::from_secs(ACK_TIMEOUT_SECS));
         let unacked_msg = UnacknowledgedMessage {
             routing_msg: routing_msg.clone(),
             route: route,
@@ -90,7 +91,8 @@ pub trait Bootstrapped: Base {
                                    peer_id: &PeerId,
                                    route: u8)
                                    -> bool {
-        if self.routing_msg_filter().filter_outgoing(msg, peer_id, route) {
+        if self.routing_msg_filter()
+               .filter_outgoing(msg, peer_id, route) {
             return true;
         }
 

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -204,7 +204,7 @@ impl Node {
            full_id: FullId,
            min_section_size: usize,
            stats: Stats,
-           mut timer: Timer)
+           timer: Timer)
            -> Self {
         let public_id = *full_id.public_id();
         let tick_period = Duration::from_secs(TICK_TIMEOUT_SECS);

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -309,7 +309,13 @@ impl Node {
             Action::ClientSendRequest { result_tx, .. } => {
                 let _ = result_tx.send(Err(InterfaceError::InvalidState));
             }
-            Action::NodeSendMessage { src, dst, content, priority, result_tx } => {
+            Action::NodeSendMessage {
+                src,
+                dst,
+                content,
+                priority,
+                result_tx,
+            } => {
                 let result = match self.send_user_message(src, dst, content, priority) {
                     Err(RoutingError::Interface(err)) => Err(err),
                     Err(_) | Ok(()) => Ok(()),
@@ -360,7 +366,10 @@ impl Node {
                     Err(err) => debug!("{:?} - {:?}", self, err),
                 }
             }
-            CrustEvent::ConnectionInfoPrepared(ConnectionInfoResult { result_token, result }) => {
+            CrustEvent::ConnectionInfoPrepared(ConnectionInfoResult {
+                                                   result_token,
+                                                   result,
+                                               }) => {
                 self.handle_connection_info_prepared(result_token, result)
             }
             CrustEvent::ListenerStarted(port) => {
@@ -581,7 +590,11 @@ impl Node {
             SectionListSignature(section_list, sig) => {
                 self.handle_section_list_signature(peer_id, section_list, sig)?
             }
-            ClientIdentify { ref serialised_public_id, ref signature, client_restriction } => {
+            ClientIdentify {
+                ref serialised_public_id,
+                ref signature,
+                client_restriction,
+            } => {
                 let drop = match self.bootstrappers.remove(&peer_id) {
                     Some(kind) => {
                         if kind == CrustUser::Client && client_restriction ||
@@ -617,7 +630,10 @@ impl Node {
                     self.disconnect_peer(&peer_id, Some(outbox));
                 }
             }
-            NodeIdentify { ref serialised_public_id, ref signature } => {
+            NodeIdentify {
+                ref serialised_public_id,
+                ref signature,
+            } => {
                 if let Ok(public_id) = verify_signed_public_id(serialised_public_id, signature) {
                     debug!("{:?} Handling NodeIdentify from {:?}.",
                            self,
@@ -630,7 +646,10 @@ impl Node {
                     self.disconnect_peer(&peer_id, Some(outbox));
                 }
             }
-            CandidateIdentify { ref serialised_public_id, ref signature } => {
+            CandidateIdentify {
+                ref serialised_public_id,
+                ref signature,
+            } => {
                 if let Ok(public_id) = verify_signed_public_id(serialised_public_id, signature) {
                     self.handle_candidate_identify(public_id, peer_id, outbox);
                 } else {
@@ -645,13 +664,20 @@ impl Node {
             TunnelSuccess(dst_id) => self.handle_tunnel_success(peer_id, dst_id),
             TunnelClosed(dst_id) => self.handle_tunnel_closed(peer_id, dst_id, outbox),
             TunnelDisconnect(dst_id) => self.handle_tunnel_disconnect(peer_id, dst_id),
-            ResourceProof { seed, target_size, difficulty } => {
-                self.handle_resource_proof_request(peer_id, seed, target_size, difficulty)?
-            }
+            ResourceProof {
+                seed,
+                target_size,
+                difficulty,
+            } => self.handle_resource_proof_request(peer_id, seed, target_size, difficulty)?,
             ResourceProofResponseReceipt => {
                 self.handle_resource_proof_response_receipt(peer_id);
             }
-            ResourceProofResponse { part_index, part_count, proof, leading_zero_bytes } => {
+            ResourceProofResponse {
+                part_index,
+                part_count,
+                proof,
+                leading_zero_bytes,
+            } => {
                 self.handle_resource_proof_response(peer_id,
                                                     part_index,
                                                     part_count,
@@ -676,7 +702,8 @@ impl Node {
         if let Some(&pub_id) = self.peer_mgr.get_routing_peer(&peer_id) {
             let min_section_size = self.min_section_size();
             if let Some((signed_msg, route)) =
-                self.sig_accumulator.add_signature(min_section_size, digest, sig, pub_id) {
+                self.sig_accumulator
+                    .add_signature(min_section_size, digest, sig, pub_id) {
                 let hop = *self.name(); // we accumulated the message, so now we act as the last hop
                 return self.handle_signed_message(signed_msg, route, hop, &BTreeSet::new());
             }
@@ -729,14 +756,12 @@ impl Node {
         };
         let sig = sign::sign_detached(&serialised, self.full_id.signing_private_key());
 
-        self.section_list_sigs.add_signature(prefix,
-                                             *self.full_id.public_id(),
-                                             section.clone(),
-                                             sig,
-                                             self.peer_mgr
-                                                 .routing_table()
-                                                 .our_section()
-                                                 .len());
+        self.section_list_sigs
+            .add_signature(prefix,
+                           *self.full_id.public_id(),
+                           section.clone(),
+                           sig,
+                           self.peer_mgr.routing_table().our_section().len());
 
         // this defines whom we are sending signature to: our section if dst is None, or given
         // name if it's Some
@@ -773,14 +798,12 @@ impl Node {
             .ok_or(RoutingError::InvalidSource)?;
         let serialised = serialisation::serialise(&section_list)?;
         if sign::verify_detached(&sig, &serialised, src_pub_id.signing_public_key()) {
-            self.section_list_sigs.add_signature(section_list.prefix,
-                                                 *src_pub_id,
-                                                 section_list,
-                                                 sig,
-                                                 self.peer_mgr
-                                                     .routing_table()
-                                                     .our_section()
-                                                     .len());
+            self.section_list_sigs
+                .add_signature(section_list.prefix,
+                               *src_pub_id,
+                               section_list,
+                               sig,
+                               self.peer_mgr.routing_table().our_section().len());
             Ok(())
         } else {
             Err(RoutingError::FailedSignature)
@@ -814,7 +837,12 @@ impl Node {
             *self.name()
         };
 
-        let HopMessage { content, route, sent_to, .. } = hop_msg;
+        let HopMessage {
+            content,
+            route,
+            sent_to,
+            ..
+        } = hop_msg;
         self.handle_signed_message(content, route, hop_name, &sent_to)
     }
 
@@ -852,7 +880,8 @@ impl Node {
             return Err(RoutingError::NotEnoughSignatures);
         }
 
-        match self.routing_msg_filter.filter_incoming(signed_msg.routing_message(), route) {
+        match self.routing_msg_filter
+                  .filter_incoming(signed_msg.routing_message(), route) {
             FilteringResult::KnownMessageAndRoute => {
                 return Ok(());
             }
@@ -862,7 +891,8 @@ impl Node {
                     self.ack_and_broadcast(&signed_msg, route, hop_name, sent_to);
                     if frslt == FilteringResult::NewMessage {
                         // if addressed to us, then we just queue it and return
-                        self.msg_queue.push_back(signed_msg.into_routing_message());
+                        self.msg_queue
+                            .push_back(signed_msg.into_routing_message());
                     }
                     return Ok(());
                 }
@@ -926,8 +956,15 @@ impl Node {
         }
 
         match (routing_msg.content, routing_msg.src, routing_msg.dst) {
-            (GetNodeName { current_id, message_id },
-             Client { client_key, proxy_node_name, peer_id },
+            (GetNodeName {
+                 current_id,
+                 message_id,
+             },
+             Client {
+                 client_key,
+                 proxy_node_name,
+                 peer_id,
+             },
              Section(dst_name)) => {
                 self.handle_get_node_name_request(current_id,
                                                   client_key,
@@ -936,19 +973,45 @@ impl Node {
                                                   peer_id,
                                                   message_id)
             }
-            (GetNodeNameResponse { relocated_id, section, .. }, Section(_), dst) => {
-                Ok(self.handle_get_node_name_response(relocated_id, section, dst, outbox))
-            }
-            (ExpectCandidate { expect_id, client_auth, message_id }, Section(_), Section(_)) => {
+            (GetNodeNameResponse {
+                 relocated_id,
+                 section,
+                 ..
+             },
+             Section(_),
+             dst) => Ok(self.handle_get_node_name_response(relocated_id, section, dst, outbox)),
+            (ExpectCandidate {
+                 expect_id,
+                 client_auth,
+                 message_id,
+             },
+             Section(_),
+             Section(_)) => {
                 self.handle_expect_candidate(expect_id, client_auth, message_id, outbox)
             }
-            (AcceptAsCandidate { expect_id, client_auth, message_id }, Section(_), Section(_)) => {
+            (AcceptAsCandidate {
+                 expect_id,
+                 client_auth,
+                 message_id,
+             },
+             Section(_),
+             Section(_)) => {
                 self.handle_accept_as_candidate(expect_id, client_auth, message_id, outbox)
             }
-            (ConnectionInfoRequest { encrypted_conn_info, nonce, pub_id, msg_id },
+            (ConnectionInfoRequest {
+                 encrypted_conn_info,
+                 nonce,
+                 pub_id,
+                 msg_id,
+             },
              src @ Client { .. },
              dst @ ManagedNode(_)) |
-            (ConnectionInfoRequest { encrypted_conn_info, nonce, pub_id, msg_id },
+            (ConnectionInfoRequest {
+                 encrypted_conn_info,
+                 nonce,
+                 pub_id,
+                 msg_id,
+             },
              src @ ManagedNode(_),
              dst @ ManagedNode(_)) => {
                 self.handle_connection_info_request(encrypted_conn_info,
@@ -959,10 +1022,20 @@ impl Node {
                                                     dst,
                                                     outbox)
             }
-            (ConnectionInfoResponse { encrypted_conn_info, nonce, pub_id, msg_id },
+            (ConnectionInfoResponse {
+                 encrypted_conn_info,
+                 nonce,
+                 pub_id,
+                 msg_id,
+             },
              ManagedNode(src_name),
              dst @ Client { .. }) |
-            (ConnectionInfoResponse { encrypted_conn_info, nonce, pub_id, msg_id },
+            (ConnectionInfoResponse {
+                 encrypted_conn_info,
+                 nonce,
+                 pub_id,
+                 msg_id,
+             },
              ManagedNode(src_name),
              dst @ ManagedNode(_)) => {
                 self.handle_connection_info_response(encrypted_conn_info,
@@ -972,9 +1045,13 @@ impl Node {
                                                      src_name,
                                                      dst)
             }
-            (CandidateApproval { candidate_id, client_auth, .. }, Section(_), Section(_)) => {
-                self.handle_candidate_approval(candidate_id, client_auth, outbox)
-            }
+            (CandidateApproval {
+                 candidate_id,
+                 client_auth,
+                 ..
+             },
+             Section(_),
+             Section(_)) => self.handle_candidate_approval(candidate_id, client_auth, outbox),
             (NodeApproval { sections }, Section(_), Client { .. }) => {
                 self.handle_node_approval(&sections, outbox)
             }
@@ -982,15 +1059,23 @@ impl Node {
                 self.handle_section_update_request(our_prefix);
                 Ok(())
             }
-            (SectionUpdate { prefix, members, merge }, Section(_), PrefixSection(_)) => {
-                self.handle_section_update(prefix, members, merge, outbox)
-            }
+            (SectionUpdate {
+                 prefix,
+                 members,
+                 merge,
+             },
+             Section(_),
+             PrefixSection(_)) => self.handle_section_update(prefix, members, merge, outbox),
             (RoutingTableRequest(msg_id, digest), src @ ManagedNode(_), dst @ Section(_)) => {
                 self.handle_rt_req(msg_id, digest, src, dst)
             }
-            (RoutingTableResponse { prefix, members, message_id }, Section(_), ManagedNode(_)) => {
-                self.handle_rt_rsp(prefix, members, message_id, outbox)
-            }
+            (RoutingTableResponse {
+                 prefix,
+                 members,
+                 message_id,
+             },
+             Section(_),
+             ManagedNode(_)) => self.handle_rt_rsp(prefix, members, message_id, outbox),
             (SectionSplit(prefix, joining_node), PrefixSection(_), PrefixSection(_)) => {
                 self.handle_section_split(prefix, joining_node, outbox)
             }
@@ -1003,8 +1088,17 @@ impl Node {
                 self.handle_other_section_merge(merge_prefix, section, outbox)
             }
             (Ack(ack, _), _, _) => self.handle_ack_response(ack),
-            (UserMessagePart { hash, part_count, part_index, payload, .. }, src, dst) => {
-                if let Some(msg) = self.user_msg_cache.add(hash, part_count, part_index, payload) {
+            (UserMessagePart {
+                 hash,
+                 part_count,
+                 part_index,
+                 payload,
+                 ..
+             },
+             src,
+             dst) => {
+                if let Some(msg) = self.user_msg_cache
+                       .add(hash, part_count, part_index, payload) {
                     self.stats().count_user_message(&msg);
                     outbox.send_event(msg.into_event(src, dst));
                 }
@@ -1034,8 +1128,8 @@ impl Node {
         // Or a node may receive CandidateApproval before connection established.
         // If we are not connected to the candidate, we do not want to add them
         // to our RT.
-        let opt_peer_id = match self.peer_mgr.handle_candidate_approval(*candidate_id.name(),
-                                                      client_auth) {
+        let opt_peer_id = match self.peer_mgr
+                  .handle_candidate_approval(*candidate_id.name(), client_auth) {
             Ok(peer_id) => peer_id,
             Err(_) => {
                 let src = Authority::ManagedNode(*self.name());
@@ -1090,7 +1184,8 @@ impl Node {
 
         self.get_approval_timer_token = None;
         self.approval_progress_timer_token = None;
-        if let Err(error) = self.peer_mgr.add_prefixes(sections.keys().cloned().collect()) {
+        if let Err(error) = self.peer_mgr
+               .add_prefixes(sections.keys().cloned().collect()) {
             info!("{:?} Received invalid prefixes in NodeApproval: {:?}. Restarting.",
                   self,
                   error);
@@ -1140,11 +1235,15 @@ impl Node {
         self.stats.enable_logging();
 
         let backlog = mem::replace(&mut self.routing_msg_backlog, vec![]);
-        backlog.into_iter().rev().foreach(|msg| self.msg_queue.push_front(msg));
+        backlog
+            .into_iter()
+            .rev()
+            .foreach(|msg| self.msg_queue.push_front(msg));
         self.resource_proof_response_parts.clear();
         self.reset_rt_timer();
         self.candidate_status_token =
-            Some(self.timer.schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
+            Some(self.timer
+                     .schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
         Ok(())
     }
 
@@ -1165,23 +1264,25 @@ impl Node {
         let mut proof = rp_object.create_proof_data(&seed);
         let leading_zero_bytes = rp_object.create_proof(&mut proof);
         let elapsed = start.elapsed();
-        let parts = proof.into_iter()
+        let parts = proof
+            .into_iter()
             .chunks(MAX_PART_LEN)
             .into_iter()
             .map(|chunk| chunk.collect_vec())
             .collect_vec();
         let part_count = parts.len();
-        let mut messages = parts.into_iter()
+        let mut messages = parts
+            .into_iter()
             .enumerate()
             .rev()
             .map(|(part_index, part)| {
-                DirectMessage::ResourceProofResponse {
-                    part_index: part_index,
-                    part_count: part_count,
-                    proof: part,
-                    leading_zero_bytes: leading_zero_bytes,
-                }
-            })
+                     DirectMessage::ResourceProofResponse {
+                         part_index: part_index,
+                         part_count: part_count,
+                         proof: part,
+                         leading_zero_bytes: leading_zero_bytes,
+                     }
+                 })
             .collect_vec();
         let first_message = match messages.pop() {
             Some(message) => message,
@@ -1194,7 +1295,8 @@ impl Node {
                 }
             }
         };
-        let _ = self.resource_proof_response_parts.insert(peer_id, messages);
+        let _ = self.resource_proof_response_parts
+            .insert(peer_id, messages);
         self.send_direct_message(peer_id, first_message);
         trace!("{:?} created proof data in {}. Min section size: {}, Target size: {}, \
                 Difficulty: {}, Seed: {:?}",
@@ -1208,8 +1310,9 @@ impl Node {
     }
 
     fn handle_resource_proof_response_receipt(&mut self, peer_id: PeerId) {
-        let popped_message =
-            self.resource_proof_response_parts.get_mut(&peer_id).and_then(Vec::pop);
+        let popped_message = self.resource_proof_response_parts
+            .get_mut(&peer_id)
+            .and_then(Vec::pop);
         if let Some(message) = popped_message {
             self.send_direct_message(peer_id, message);
         }
@@ -1237,11 +1340,8 @@ impl Node {
             return;
         };
 
-        match self.peer_mgr.verify_candidate(&name,
-                                             part_index,
-                                             part_count,
-                                             proof,
-                                             leading_zero_bytes) {
+        match self.peer_mgr
+                  .verify_candidate(&name, part_index, part_count, proof, leading_zero_bytes) {
             Err(error) => {
                 debug!("{:?} Failed to verify candidate {}: {:?}",
                        self,
@@ -1295,17 +1395,20 @@ impl Node {
                           routing_msg: &RoutingMessage,
                           route: u8)
                           -> Result<bool, RoutingError> {
-        if let MessageContent::UserMessagePart { hash,
-                                                 part_count,
-                                                 part_index,
-                                                 cacheable,
-                                                 ref payload,
-                                                 .. } = routing_msg.content {
+        if let MessageContent::UserMessagePart {
+                   hash,
+                   part_count,
+                   part_index,
+                   cacheable,
+                   ref payload,
+                   ..
+               } = routing_msg.content {
             if !cacheable {
                 return Ok(false);
             }
 
-            match self.cacheable_user_msg_cache.add(hash, part_count, part_index, payload.clone()) {
+            match self.cacheable_user_msg_cache
+                      .add(hash, part_count, part_index, payload.clone()) {
                 Some(UserMessage::Request(request)) => {
                     if let Some(response) = self.response_cache.get(&request) {
                         debug!("{:?} Found cached response to {:?}", self, request);
@@ -1440,22 +1543,19 @@ impl Node {
             (0, 1)
         } else {
             (RESOURCE_PROOF_DIFFICULTY,
-             RESOURCE_PROOF_TARGET_SIZE /
-             (self.peer_mgr
-                  .routing_table()
-                  .our_section()
-                  .len() + 1))
+             RESOURCE_PROOF_TARGET_SIZE / (self.peer_mgr.routing_table().our_section().len() + 1))
         };
         let seed: Vec<u8> = if cfg!(feature = "use-mock-crust") {
             vec![5u8; 4]
         } else {
             rand::thread_rng().gen_iter().take(10).collect()
         };
-        match self.peer_mgr.handle_candidate_identify(&public_id,
-                                                      &peer_id,
-                                                      target_size,
-                                                      difficulty,
-                                                      seed.clone()) {
+        match self.peer_mgr
+                  .handle_candidate_identify(&public_id,
+                                             &peer_id,
+                                             target_size,
+                                             difficulty,
+                                             seed.clone()) {
             Ok(true) => {
                 let direct_message = DirectMessage::ResourceProof {
                     seed: seed,
@@ -1493,7 +1593,8 @@ impl Node {
                             outbox: &mut EventBox) {
         let want_to_merge = self.we_want_to_merge() || self.they_want_to_merge();
         let mut need_split = false;
-        match self.peer_mgr.add_to_routing_table(public_id, peer_id, want_to_merge) {
+        match self.peer_mgr
+                  .add_to_routing_table(public_id, peer_id, want_to_merge) {
             Err(RoutingTableError::AlreadyExists) => return,  // already in RT
             Err(error) => {
                 debug!("{:?} Peer {:?} was not added to the routing table: {}",
@@ -1556,7 +1657,8 @@ impl Node {
         }
 
         for (dst_id, peer_name) in self.peer_mgr.peers_needing_tunnel() {
-            if self.peer_mgr.is_potential_tunnel_node(public_id.name(), &peer_name) {
+            if self.peer_mgr
+                   .is_potential_tunnel_node(public_id.name(), &peer_name) {
                 trace!("{:?} Asking {:?} to serve as a tunnel for {:?}",
                        self,
                        peer_id,
@@ -1584,7 +1686,8 @@ impl Node {
             return;
         }
 
-        let members = self.peer_mgr.get_pub_ids(self.peer_mgr.routing_table().our_section());
+        let members = self.peer_mgr
+            .get_pub_ids(self.peer_mgr.routing_table().our_section());
 
         let content = MessageContent::SectionUpdate {
             prefix: *self.our_prefix(),
@@ -1683,7 +1786,8 @@ impl Node {
         };
 
         let our_pub_info = our_connection_info.to_pub_connection_info();
-        match self.peer_mgr.connection_info_prepared(result_token, our_connection_info) {
+        match self.peer_mgr
+                  .connection_info_prepared(result_token, our_connection_info) {
             Err(error) => {
                 // This usually means we have already connected.
                 debug!("{:?} Prepared connection info, but no entry found in token map: {:?}",
@@ -1691,7 +1795,12 @@ impl Node {
                        error);
                 return;
             }
-            Ok(ConnectionInfoPreparedResult { pub_id, src, dst, infos }) => {
+            Ok(ConnectionInfoPreparedResult {
+                   pub_id,
+                   src,
+                   dst,
+                   infos,
+               }) => {
                 match infos {
                     None => {
                         debug!("{:?} Prepared connection info for {:?}.",
@@ -1734,11 +1843,12 @@ impl Node {
                                          &public_id)?;
         let peer_id = their_connection_info.id();
         use peer_manager::ConnectionInfoReceivedResult::*;
-        match self.peer_mgr.connection_info_received(src,
-                                                     dst,
-                                                     public_id,
-                                                     their_connection_info,
-                                                     message_id) {
+        match self.peer_mgr
+                  .connection_info_received(src,
+                                            dst,
+                                            public_id,
+                                            their_connection_info,
+                                            message_id) {
             Ok(Ready(our_info, their_info)) => {
                 debug!("{:?} Already sent a connection info request to {:?} ({:?}); resending \
                         our same details as a response.",
@@ -1783,11 +1893,12 @@ impl Node {
                                          &public_id)?;
         let peer_id = their_connection_info.id();
         use peer_manager::ConnectionInfoReceivedResult::*;
-        match self.peer_mgr.connection_info_received(Authority::ManagedNode(src),
-                                                     dst,
-                                                     public_id,
-                                                     their_connection_info,
-                                                     message_id) {
+        match self.peer_mgr
+                  .connection_info_received(Authority::ManagedNode(src),
+                                            dst,
+                                            public_id,
+                                            their_connection_info,
+                                            message_id) {
             Ok(Ready(our_info, their_info)) => {
                 trace!("{:?} Received connection info response. Trying to connect to {:?} ({:?}).",
                        self,
@@ -1845,8 +1956,9 @@ impl Node {
             self.send_direct_message(peer_id, message);
         }
         let can_tunnel_for = |peer: &Peer| peer.state().can_tunnel_for();
-        if self.peer_mgr.get_connected_peer(&peer_id).map_or(false, can_tunnel_for) &&
-           self.tunnels.add(dst_id, peer_id) {
+        if self.peer_mgr
+               .get_connected_peer(&peer_id)
+               .map_or(false, can_tunnel_for) && self.tunnels.add(dst_id, peer_id) {
             debug!("{:?} Adding {:?} as a tunnel node for {:?}.",
                    self,
                    peer_id,
@@ -1948,9 +2060,11 @@ impl Node {
             Some(close_section) => close_section.into_iter().collect(),
             None => return Err(RoutingError::InvalidDestination),
         };
-        let relocated_name = self.next_node_name.unwrap_or_else(|| {
-            utils::calculate_relocated_name(close_section, their_public_id.name())
-        });
+        let relocated_name = self.next_node_name
+            .unwrap_or_else(|| {
+                                utils::calculate_relocated_name(close_section,
+                                                                their_public_id.name())
+                            });
         their_public_id.set_name(relocated_name);
 
         // From X -> Y; Send to close section of the relocated name
@@ -1985,10 +2099,14 @@ impl Node {
         self.approval_expiry_time = Instant::now() + duration;
         self.get_approval_timer_token = Some(self.timer.schedule(duration));
         self.approval_progress_timer_token =
-            Some(self.timer.schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
+            Some(self.timer
+                     .schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
 
-        self.full_id.public_id_mut().set_name(*relocated_id.name());
-        self.peer_mgr.reset_routing_table(*self.full_id.public_id());
+        self.full_id
+            .public_id_mut()
+            .set_name(*relocated_id.name());
+        self.peer_mgr
+            .reset_routing_table(*self.full_id.public_id());
         self.challenger_count = section.len();
         if let Some((_, proxy_public_id)) = self.peer_mgr.proxy() {
             if section.contains(proxy_public_id) {
@@ -2036,9 +2154,13 @@ impl Node {
         }
 
         let original_name = *candidate_id.name();
-        let relocated_name = self.next_node_name.take().unwrap_or_else(|| {
-            self.peer_mgr.routing_table().assign_to_min_len_prefix(&original_name)
-        });
+        let relocated_name = self.next_node_name
+            .take()
+            .unwrap_or_else(|| {
+                                self.peer_mgr
+                                    .routing_table()
+                                    .assign_to_min_len_prefix(&original_name)
+                            });
         candidate_id.set_name(relocated_name);
 
         if self.peer_mgr
@@ -2055,7 +2177,8 @@ impl Node {
             return self.send_routing_message(src, dst, request_content);
         }
 
-        self.peer_mgr.expect_candidate(*candidate_id.name(), client_auth)?;
+        self.peer_mgr
+            .expect_candidate(*candidate_id.name(), client_auth)?;
         let response_content = MessageContent::AcceptAsCandidate {
             expect_id: candidate_id,
             client_auth: client_auth,
@@ -2088,9 +2211,11 @@ impl Node {
         }
 
         self.candidate_timer_token =
-            Some(self.timer.schedule(Duration::from_secs(RESOURCE_PROOF_DURATION_SECS)));
+            Some(self.timer
+                     .schedule(Duration::from_secs(RESOURCE_PROOF_DURATION_SECS)));
 
-        let own_section = self.peer_mgr.accept_as_candidate(*candidate_id.name(), client_auth);
+        let own_section = self.peer_mgr
+            .accept_as_candidate(*candidate_id.name(), client_auth);
         let response_content = MessageContent::GetNodeNameResponse {
             relocated_id: candidate_id,
             section: own_section,
@@ -2128,7 +2253,9 @@ impl Node {
         //       at the point where it gets added to the section.
         let pfx_name = prefix.lower_bound();
         // if !prefix.is_compatible(self.our_prefix()) {
-        while let Some(rt_pfx) = self.peer_mgr.routing_table().find_section_prefix(&pfx_name) {
+        while let Some(rt_pfx) = self.peer_mgr
+                  .routing_table()
+                  .find_section_prefix(&pfx_name) {
             if merge && rt_pfx.bit_count() > prefix.bit_count() {
                 for (name, peer_id) in self.peer_mgr.add_prefix(prefix) {
                     self.disconnect_peer(&peer_id, Some(outbox));
@@ -2146,17 +2273,19 @@ impl Node {
         }
         // }
         // Filter list of members to just those we don't know about:
-        let members =
-            if let Some(section) = self.peer_mgr.routing_table().section_with_prefix(&prefix) {
-                let f = |id: &PublicId| !section.contains(id.name());
-                members.into_iter().filter(f).collect_vec()
-            } else {
-                debug!("{:?} Section update received from unknown neighbour {:?}",
+        let members = if let Some(section) = self.peer_mgr
+               .routing_table()
+               .section_with_prefix(&prefix) {
+            let f = |id: &PublicId| !section.contains(id.name());
+            members.into_iter().filter(f).collect_vec()
+        } else {
+            debug!("{:?} Section update received from unknown neighbour {:?}",
                        self,
                        prefix);
-                return Ok(());
-            };
-        let members = members.into_iter()
+            return Ok(());
+        };
+        let members = members
+            .into_iter()
             .filter(|id: &PublicId| !self.peer_mgr.is_expected(id.name()))
             .collect_vec();
 
@@ -2352,7 +2481,8 @@ impl Node {
     }
 
     fn they_want_to_merge(&self) -> bool {
-        self.merge_cache.contains_key(&self.our_prefix().sibling())
+        self.merge_cache
+            .contains_key(&self.our_prefix().sibling())
     }
 
     fn process_own_section_merge(&mut self,
@@ -2362,12 +2492,16 @@ impl Node {
                                  -> Result<(), RoutingError> {
         let merge_prefix = sender_prefix.popped();
         let (merge_state, needed_peers) =
-            self.peer_mgr.merge_own_section(sender_prefix, merge_prefix, sections);
+            self.peer_mgr
+                .merge_own_section(sender_prefix, merge_prefix, sections);
 
         match merge_state {
             OwnMergeState::Ongoing |
             OwnMergeState::AlreadyMerged => (),
-            OwnMergeState::Completed { targets, merge_details } => {
+            OwnMergeState::Completed {
+                targets,
+                merge_details,
+            } => {
                 // TODO - the event should maybe only fire once all new connections have been made?
                 outbox.send_event(Event::SectionMerge(merge_details.prefix));
                 info!("{:?} Own section merge completed. Prefixes: {:?}",
@@ -2483,11 +2617,13 @@ impl Node {
             self.send_candidate_approval();
         } else if self.candidate_status_token == Some(token) {
             self.candidate_status_token =
-                Some(self.timer.schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
+                Some(self.timer
+                         .schedule(Duration::from_secs(CANDIDATE_STATUS_INTERVAL_SECS)));
             self.peer_mgr.show_candidate_status();
         } else if self.approval_progress_timer_token == Some(token) {
             self.approval_progress_timer_token =
-                Some(self.timer.schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
+                Some(self.timer
+                         .schedule(Duration::from_secs(APPROVAL_PROGRESS_INTERVAL_SECS)));
             let now = Instant::now();
             let remaining_duration = if now < self.approval_expiry_time {
                 let duration = self.approval_expiry_time - now;
@@ -2858,8 +2994,9 @@ impl Node {
                 .into_iter()
                 .filter(|target| !sent_to.contains(target))
                 .collect();
-            let new_sent_to = if self.in_authority(&routing_msg.dst) {
-                sent_to.iter()
+            let new_sent_to =
+                if self.in_authority(&routing_msg.dst) {
+                    sent_to.iter()
                     .chain(targets.iter()
                         .filter(|target| match self.peer_mgr.get_state_by_name(target) {
                             Some(&PeerState::Routing(RoutingConnection::Tunnel)) => false,
@@ -2868,9 +3005,9 @@ impl Node {
                     .chain(iter::once(self.name()))
                     .cloned()
                     .collect()
-            } else {
-                BTreeSet::new()
-            };
+                } else {
+                    BTreeSet::new()
+                };
             Ok((new_sent_to, self.peer_mgr.get_peer_ids(&targets)))
         } else if let Authority::Client { ref proxy_node_name, .. } = routing_msg.src {
             // We don't have any contacts in our routing table yet. Keep using
@@ -2952,7 +3089,8 @@ impl Node {
 
         self.peer_mgr.allow_connect(&their_name)?;
 
-        if let Some(token) = self.peer_mgr.get_connection_token(src, dst, their_public_id) {
+        if let Some(token) = self.peer_mgr
+               .get_connection_token(src, dst, their_public_id) {
             self.crust_service.prepare_connection_info(token);
             return Ok(());
         }
@@ -3061,11 +3199,8 @@ impl Node {
                     |prefix| { self.send_section_list_signature(prefix, None); });
         if details.was_in_our_section {
             self.reset_rt_timer();
-            self.section_list_sigs.remove_signatures_by(*pub_id,
-                                                        self.peer_mgr
-                                                            .routing_table()
-                                                            .our_section()
-                                                            .len());
+            self.section_list_sigs
+                .remove_signatures_by(*pub_id, self.peer_mgr.routing_table().our_section().len());
         }
 
         if self.peer_mgr.routing_table().is_empty() {
@@ -3095,7 +3230,8 @@ impl Node {
 
     fn merge_if_necessary(&mut self) {
         if let Some((sender_prefix, merge_prefix, sections)) =
-            self.peer_mgr.should_merge(self.we_want_to_merge(), self.they_want_to_merge()) {
+            self.peer_mgr
+                .should_merge(self.we_want_to_merge(), self.they_want_to_merge()) {
             let content = MessageContent::OwnSectionMerge(sections);
             let src = Authority::PrefixSection(sender_prefix);
             let dst = Authority::PrefixSection(merge_prefix);
@@ -3145,9 +3281,9 @@ impl Node {
             .remove_tunnel(peer_id)
             .into_iter()
             .filter_map(|dst_id| {
-                            self.peer_mgr.get_routing_peer(&dst_id).map(|dst_pub_id| {
-                                                                            (dst_id, *dst_pub_id)
-                                                                        })
+                            self.peer_mgr
+                                .get_routing_peer(&dst_id)
+                                .map(|dst_pub_id| (dst_id, *dst_pub_id))
                         })
             .collect_vec();
         for (dst_id, pub_id) in peers {
@@ -3196,7 +3332,11 @@ impl Node {
         for messages in self.resource_proof_response_parts.values() {
             if let Some(next_message) = messages.last() {
                 match *next_message {
-                    DirectMessage::ResourceProofResponse { part_index, part_count, .. } => {
+                    DirectMessage::ResourceProofResponse {
+                        part_index,
+                        part_count,
+                        ..
+                    } => {
                         parts_per_proof = part_count;
                         incomplete.push(part_index);
                     }
@@ -3239,7 +3379,8 @@ impl Node {
                 .is_some() || self.we_want_to_merge() || self.they_want_to_merge()) &&
            other_section_prefix != self.our_prefix().sibling() {
             // We don't care about duplicate cached prefixes - ignore result.
-            let _ = self.cached_section_update_requests.insert(other_section_prefix);
+            let _ = self.cached_section_update_requests
+                .insert(other_section_prefix);
         }
     }
 
@@ -3339,7 +3480,10 @@ impl Node {
                                    prefix: Prefix<XorName>)
                                    -> Result<BTreeMap<PublicId, sign::Signature>, RoutingError> {
         if let Some(&(_, ref signatures)) = self.section_list_sigs.get_signatures(prefix) {
-            Ok(signatures.iter().map(|(&pub_id, &sig)| (pub_id, sig)).collect())
+            Ok(signatures
+                   .iter()
+                   .map(|(&pub_id, &sig)| (pub_id, sig))
+                   .collect())
         } else {
             Err(RoutingError::NotEnoughSignatures)
         }
@@ -3422,7 +3566,8 @@ impl Bootstrapped for Node {
             Some(our_name) if our_name == *self.name() => {
                 let min_section_size = self.min_section_size();
                 if let Some((msg, route)) =
-                    self.sig_accumulator.add_message(signed_msg, min_section_size, route) {
+                    self.sig_accumulator
+                        .add_message(signed_msg, min_section_size, route) {
                     if self.in_authority(&msg.routing_message().dst) {
                         self.handle_signed_message(msg, route, our_name, &BTreeSet::new())?;
                     } else {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+
 pub use self::implementation::Timer;
 
 #[cfg(not(feature = "use-mock-crust"))]
@@ -22,99 +23,103 @@ mod implementation {
     use action::Action;
     use itertools::Itertools;
     use maidsafe_utilities::thread::{self, Joiner};
+    use std::cell::RefCell;
     use std::collections::BTreeMap;
-    use std::sync::{Arc, Condvar, Mutex};
+    use std::rc::Rc;
+    use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, SyncSender};
     use std::time::{Duration, Instant};
     use types::RoutingActionSender;
 
     struct Detail {
-        deadlines: BTreeMap<Instant, Vec<u64>>,
-        cancelled: bool,
+        expiry: Instant,
+        token: u64,
     }
 
     /// Simple timer.
+    #[derive(Clone)]
     pub struct Timer {
+        inner: Rc<RefCell<Inner>>,
+    }
+
+    struct Inner {
         next_token: u64,
-        detail_and_cond_var: Arc<(Mutex<Detail>, Condvar)>,
+        tx: SyncSender<Detail>,
         _worker: Joiner,
     }
 
     impl Timer {
         /// Creates a new timer, passing a channel sender used to send `Timeout` events.
         pub fn new(sender: RoutingActionSender) -> Self {
-            let detail = Detail {
-                deadlines: BTreeMap::new(),
-                cancelled: false,
-            };
-            let detail_and_cond_var = Arc::new((Mutex::new(detail), Condvar::new()));
-            let detail_and_cond_var_clone = detail_and_cond_var.clone();
-            let worker = thread::named("Timer", move || Self::run(sender, detail_and_cond_var));
+            let (tx, rx) = mpsc::sync_channel(1);
+
+            let worker = thread::named("Timer", move || Self::run(sender, rx));
+
             Timer {
-                next_token: 0,
-                detail_and_cond_var: detail_and_cond_var_clone,
-                _worker: worker,
+                inner: Rc::new(RefCell::new(Inner {
+                                                next_token: 0,
+                                                tx: tx,
+                                                _worker: worker,
+                                            })),
             }
         }
 
+        // TODO Do proper error handling here by returning a result - currently complying it with
+        // existing code and logging and error
         /// Schedules a timeout event after `duration`. Returns a token that can be used to identify
         /// the timeout event.
-        pub fn schedule(&mut self, duration: Duration) -> u64 {
-            let token = self.next_token;
-            self.next_token = token.wrapping_add(1);
-            let &(ref mutex, ref cond_var) = &*self.detail_and_cond_var;
-            let mut detail = mutex.lock().expect("Failed to lock.");
-            detail.deadlines
-                .entry(Instant::now() + duration)
-                .or_insert_with(Vec::new)
-                .push(token);
-            cond_var.notify_one();
-            token
+        pub fn schedule(&self, duration: Duration) -> u64 {
+            let mut inner = self.inner.borrow_mut();
+
+            let token = inner.next_token;
+            inner.next_token = token.wrapping_add(1);
+
+            let detail = Detail {
+                expiry: Instant::now() + duration,
+                token: token,
+            };
+            inner.tx.send(detail).map(|()| token).unwrap_or_else(|e| {
+                error!("Timer could not be scheduled: {:?}", e);
+                0
+            })
         }
 
-        fn run(sender: RoutingActionSender, detail_and_cond_var: Arc<(Mutex<Detail>, Condvar)>) {
-            let &(ref mutex, ref cond_var) = &*detail_and_cond_var;
-            let mut detail = mutex.lock().expect("Failed to lock.");
-            while !detail.cancelled {
-                // Handle expired deadlines.
+        fn run(sender: RoutingActionSender, rx: Receiver<Detail>) {
+            let mut deadlines: BTreeMap<Instant, Vec<u64>> = Default::default();
+
+            loop {
+                let r = if let Some(t) = deadlines.keys().next() {
+                    let now = Instant::now();
+                    let duration = *t - now;
+                    match rx.recv_timeout(duration) {
+                        Ok(d) => Some(d),
+                        Err(RecvTimeoutError::Timeout) => None,
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                } else {
+                    match rx.recv() {
+                        Ok(d) => Some(d),
+                        Err(RecvError) => break,
+                    }
+                };
+
+                if let Some(Detail { expiry, token }) = r {
+                    deadlines.entry(expiry).or_insert_with(Vec::new).push(token);
+                }
+
                 let now = Instant::now();
-                let expired_list = detail.deadlines
-                    .keys()
+                let expired_list = deadlines.keys()
                     .take_while(|&&deadline| deadline < now)
                     .cloned()
                     .collect_vec();
                 for expired in expired_list {
                     // Safe to call `expect()` as we just got the key we're removing from
                     // `deadlines`.
-                    let tokens = detail.deadlines.remove(&expired).expect("Bug in `BTreeMap`.");
+                    let tokens = deadlines.remove(&expired).expect("Bug in `BTreeMap`.");
                     for token in tokens {
                         let _ = sender.send(Action::Timeout(token));
                     }
                 }
-
-                // If we have no deadlines pending, wait indefinitely.  Otherwise wait until the
-                // nearest deadline.
-                if detail.deadlines.is_empty() {
-                    detail = cond_var.wait(detail).expect("Failed to lock.");
-                } else {
-                    // Safe to call `expect()` as `deadlines` has at least one entry.
-                    let nearest = detail.deadlines
-                        .keys()
-                        .next()
-                        .cloned()
-                        .expect("Bug in `BTreeMap`.");
-                    let duration = nearest - now;
-                    detail = cond_var.wait_timeout(detail, duration).expect("Failed to lock.").0;
-                }
             }
-        }
-    }
-
-    impl Drop for Timer {
-        fn drop(&mut self) {
-            let &(ref mutex, ref cond_var) = &*self.detail_and_cond_var;
-            let mut detail = mutex.lock().expect("Failed to lock.");
-            detail.cancelled = true;
-            cond_var.notify_one();
         }
     }
 
@@ -149,7 +154,7 @@ mod implementation {
                         action);
             };
             {
-                let mut timer = Timer::new(sender);
+                let timer = Timer::new(sender);
 
                 // Add deadlines, the first to time out after 2.5s, the second after 2.0s, and so on
                 // down to 500ms.
@@ -201,23 +206,23 @@ mod implementation {
 
 #[cfg(feature = "use-mock-crust")]
 mod implementation {
+    use std::cell::Cell;
     use std::time::Duration;
-
     use types::RoutingActionSender;
 
     // The mock timer currently never raises timeout events.
     pub struct Timer {
-        next_token: u64,
+        next_token: Cell<u64>,
     }
 
     impl Timer {
         pub fn new(_: RoutingActionSender) -> Self {
-            Timer { next_token: 0 }
+            Timer { next_token: Cell::new(0) }
         }
 
-        pub fn schedule(&mut self, _: Duration) -> u64 {
-            let token = self.next_token;
-            self.next_token = token.wrapping_add(1);
+        pub fn schedule(&self, _: Duration) -> u64 {
+            let token = self.next_token.get();
+            self.next_token.set(token.wrapping_add(1));
             token
         }
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -103,11 +103,15 @@ mod implementation {
                 };
 
                 if let Some(Detail { expiry, token }) = r {
-                    deadlines.entry(expiry).or_insert_with(Vec::new).push(token);
+                    deadlines
+                        .entry(expiry)
+                        .or_insert_with(Vec::new)
+                        .push(token);
                 }
 
                 let now = Instant::now();
-                let expired_list = deadlines.keys()
+                let expired_list = deadlines
+                    .keys()
                     .take_while(|&&deadline| deadline < now)
                     .cloned()
                     .collect_vec();

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -92,7 +92,8 @@ impl Tunnels {
             .filter(|pair| pair.0 == *peer_id || pair.1 == *peer_id)
             .cloned()
             .collect_vec();
-        pairs.into_iter()
+        pairs
+            .into_iter()
             .map(|pair| {
                      self.clients.remove(&pair);
                      if pair.0 == *peer_id { pair.1 } else { pair.0 }

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -106,7 +106,11 @@ struct TestNode {
 impl TestNode {
     // If `index` is `0`, this will be treated as the first node of the network.
     fn new(index: usize, min_section_size: usize) -> Self {
-        TestNode { node: unwrap!(Node::builder().first(index == 0).create(min_section_size)) }
+        TestNode {
+            node: unwrap!(Node::builder()
+                              .first(index == 0)
+                              .create(min_section_size)),
+        }
     }
 
     fn name(&self) -> XorName {
@@ -217,10 +221,9 @@ fn wait_for_nodes_to_connect(nodes: &mut [TestNode],
                 connection_counts[index] += 1;
 
                 let k = nodes.len();
-                let all_events_received =
-                    (0..k).map(|i| connection_counts[i]).all(|n| {
-                                                                 n >= k - 1 || n >= min_section_size
-                                                             });
+                let all_events_received = (0..k)
+                    .map(|i| connection_counts[i])
+                    .all(|n| n >= k - 1 || n >= min_section_size);
                 if all_events_received {
                     break;
                 }
@@ -278,7 +281,8 @@ fn closest_nodes(node_names: &[XorName],
                  target: &XorName,
                  min_section_size: usize)
                  -> Vec<XorName> {
-    node_names.iter()
+    node_names
+        .iter()
         .sorted_by(|a, b| target.cmp_distance(a, b))
         .into_iter()
         .take(min_section_size)
@@ -312,7 +316,9 @@ fn core() {
                     TestEvent(index, Event::Connected) if index == client.index => {
                         // The client is connected now. Send some request.
                         let src = Authority::ClientManager(*client.name());
-                        let result = client.client.send_put_request(src, data.clone(), message_id);
+                        let result = client
+                            .client
+                            .send_put_request(src, data.clone(), message_id);
                         assert!(result.is_ok());
                     }
 
@@ -325,8 +331,10 @@ fn core() {
                         }
                     }
 
-                    TestEvent(index, Event::Response { response: Response::PutSuccess(data_id, id),
-                                                .. }) if index == client.index => {
+                    TestEvent(index,
+                              Event::Response {
+                                  response: Response::PutSuccess(data_id, id), ..
+                              }) if index == client.index => {
                         // The client received response to its request. We are done.
                         assert_eq!(message_id, id);
                         assert_eq!(data_id.name(), data.name());
@@ -399,27 +407,32 @@ fn core() {
                             .is_ok());
                     }
                     TestEvent(index,
-                              Event::Request { request: Request::Put(data, id),
-                                               src: Authority::Client { .. },
-                                               dst: Authority::ClientManager(name) }) => {
+                              Event::Request {
+                                  request: Request::Put(data, id),
+                                  src: Authority::Client { .. },
+                                  dst: Authority::ClientManager(name),
+                              }) => {
                         let src = Authority::ClientManager(name);
                         let dst = Authority::NaeManager(*data.name());
-                        unwrap!(nodes[index].node.send_put_request(src,
-                                                                   dst,
-                                                                   data.clone(),
-                                                                   id.clone()));
+                        unwrap!(nodes[index]
+                                    .node
+                                    .send_put_request(src, dst, data.clone(), id.clone()));
                     }
                     TestEvent(index, Event::Request { request, src, dst }) => {
                         if let Request::Put(data, id) = request {
-                            unwrap!(nodes[index].node.send_put_failure(dst,
-                                                                       src,
-                                                                       data.identifier(),
-                                                                       vec![],
-                                                                       id));
+                            unwrap!(nodes[index]
+                                        .node
+                                        .send_put_failure(dst,
+                                                          src,
+                                                          data.identifier(),
+                                                          vec![],
+                                                          id));
                         }
                     }
                     TestEvent(index,
-                              Event::Response { response: Response::PutFailure { .. }, .. }) => {
+                              Event::Response {
+                                  response: Response::PutFailure { .. }, ..
+                              }) => {
                         close_group.retain(|&name| name != nodes[index].name());
 
                         if close_group.is_empty() {
@@ -438,7 +451,9 @@ fn core() {
 
     {
         // leaving nodes cause churn
-        let mut churns = iter::repeat(false).take(nodes.len() - 1).collect::<Vec<_>>();
+        let mut churns = iter::repeat(false)
+            .take(nodes.len() - 1)
+            .collect::<Vec<_>>();
         // a node leaves...
         let node = unwrap!(nodes.pop(), "No more nodes left.");
         let name = node.name();
@@ -469,7 +484,9 @@ fn core() {
     {
         // joining nodes cause churn
         let nodes_len = nodes.len();
-        let mut churns = iter::repeat(false).take(nodes_len + 1).collect::<Vec<_>>();
+        let mut churns = iter::repeat(false)
+            .take(nodes_len + 1)
+            .collect::<Vec<_>>();
         // a node joins...
         nodes.push(TestNode::new(nodes_len, min_section_size));
 
@@ -505,28 +522,35 @@ fn core() {
                                                      Duration::from_secs(5)) {
             match test_event {
                 TestEvent(index, Event::Connected) if index == client.index => {
-                    assert!(client.client
+                    assert!(client
+                                .client
                                 .send_put_request(Authority::ClientManager(*client.name()),
                                                   data.clone(),
                                                   MessageId::new())
                                 .is_ok());
                 }
                 TestEvent(index,
-                          Event::Request { request: Request::Put(data, id),
-                                           src: Authority::Client { .. },
-                                           dst: Authority::ClientManager(name) }) => {
+                          Event::Request {
+                              request: Request::Put(data, id),
+                              src: Authority::Client { .. },
+                              dst: Authority::ClientManager(name),
+                          }) => {
                     let src = Authority::ClientManager(name);
                     let dst = Authority::NaeManager(*data.name());
-                    unwrap!(nodes[index].node.send_put_request(src, dst, data.clone(), id.clone()));
+                    unwrap!(nodes[index]
+                                .node
+                                .send_put_request(src, dst, data.clone(), id.clone()));
                 }
                 TestEvent(index, Event::Request { request, src, dst }) => {
                     if let Request::Put(data, id) = request {
                         if 2 * (index + 1) < min_section_size {
-                            unwrap!(nodes[index].node.send_put_failure(dst,
-                                                                       src,
-                                                                       data.identifier(),
-                                                                       vec![],
-                                                                       id));
+                            unwrap!(nodes[index]
+                                        .node
+                                        .send_put_failure(dst,
+                                                          src,
+                                                          data.identifier(),
+                                                          vec![],
+                                                          id));
                         }
                     }
                 }
@@ -557,7 +581,9 @@ fn core() {
                         // The client is connected now. Send some request.
                         let src = Authority::ClientManager(*client.name());
                         let message_id = MessageId::new();
-                        let result = client.client.send_put_request(src, data.clone(), message_id);
+                        let result = client
+                            .client
+                            .send_put_request(src, data.clone(), message_id);
                         assert!(result.is_ok());
                         sent_ids.insert(message_id);
                     }
@@ -569,8 +595,9 @@ fn core() {
                         }
                     }
                     TestEvent(index,
-                              Event::Response { response: Response::PutSuccess(name, id), .. })
-                        if index == client.index => {
+                              Event::Response {
+                                  response: Response::PutSuccess(name, id), ..
+                              }) if index == client.index => {
                         // TODO: assert!(received_ids.insert(id));
                         let _ = received_ids.insert(id);
                         assert_eq!(name, data.identifier());

--- a/tests/mock_crust/accumulate.rs
+++ b/tests/mock_crust/accumulate.rs
@@ -33,7 +33,9 @@ fn messages_accumulate_with_quorum() {
     sort_nodes_by_distance_to(&mut nodes, &src.name());
 
     let send = |node: &mut TestNode, dst: &Authority<XorName>, message_id: MessageId| {
-        assert!(node.inner.send_get_success(src, *dst, data.clone(), message_id).is_ok());
+        assert!(node.inner
+                    .send_get_success(src, *dst, data.clone(), message_id)
+                    .is_ok());
     };
 
     let dst = Authority::ManagedNode(nodes[0].name()); // The closest node.

--- a/tests/mock_crust/cache.rs
+++ b/tests/mock_crust/cache.rs
@@ -68,9 +68,11 @@ fn response_caching() {
     for node in &mut *nodes {
         loop {
             match node.try_next_ev() {
-                Ok(Event::Request { request: Request::Get(req_data_id, req_message_id),
-                                    src: req_src,
-                                    dst: req_dst }) => {
+                Ok(Event::Request {
+                       request: Request::Get(req_data_id, req_message_id),
+                       src: req_src,
+                       dst: req_dst,
+                   }) => {
                     if req_data_id == data_id && req_message_id == message_id {
                         unwrap!(node.inner.send_get_success(req_dst,
                                                             req_src,

--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -208,7 +208,8 @@ impl ExpectedGets {
     fn expect(&mut self, nodes: &mut [TestNode], dst: Authority<XorName>, key: GetKey) {
         if dst.is_multiple() && !self.sections.contains_key(&dst) {
             let is_recipient = |n: &&TestNode| n.is_recipient(&dst);
-            let section = nodes.iter()
+            let section = nodes
+                .iter()
                 .filter(is_recipient)
                 .map(TestNode::name)
                 .collect();
@@ -226,7 +227,8 @@ impl ExpectedGets {
             .iter_mut()
             .map(|(dst, section)| {
                 let is_recipient = |n: &&TestNode| n.is_recipient(dst);
-                let new_section = nodes.iter()
+                let new_section = nodes
+                    .iter()
                     .filter(is_recipient)
                     .map(TestNode::name)
                     .collect_vec();
@@ -239,11 +241,16 @@ impl ExpectedGets {
         let mut unexpected_receive = BTreeSet::new();
         for node in nodes {
             while let Ok(event) = node.try_next_ev() {
-                if let Event::Request { request: Request::Get(data_id, msg_id), src, dst } = event {
+                if let Event::Request {
+                           request: Request::Get(data_id, msg_id),
+                           src,
+                           dst,
+                       } = event {
                     let key = (data_id, msg_id, src, dst);
                     if dst.is_multiple() {
-                        if !self.sections.get(&key.3).map_or(false,
-                                                             |entry| entry.contains(&node.name())) {
+                        if !self.sections
+                                .get(&key.3)
+                                .map_or(false, |entry| entry.contains(&node.name())) {
                             // Unexpected receive shall only happen for group (only used NaeManager
                             // in this test), and shall have at most one for each message.
                             if let Authority::NaeManager(_) = dst {
@@ -272,7 +279,11 @@ impl ExpectedGets {
         }
         for client in clients {
             while let Ok(event) = client.inner.try_next_ev() {
-                if let Event::Request { request: Request::Get(data_id, msg_id), src, dst } = event {
+                if let Event::Request {
+                           request: Request::Get(data_id, msg_id),
+                           src,
+                           dst,
+                       } = event {
                     let key = (data_id, msg_id, src, dst);
                     assert!(self.messages.remove(&key),
                             "Unexpected request for client {}: {:?}",
@@ -348,11 +359,7 @@ fn client_gets(network: &mut Network, mut nodes: &mut [TestNode], min_section_si
     let cl_auth = Authority::Client {
         client_key: *clients[0].full_id.public_id().signing_public_key(),
         proxy_node_name: nodes[0].name(),
-        peer_id: clients[0]
-            .handle
-            .0
-            .borrow()
-            .peer_id,
+        peer_id: clients[0].handle.0.borrow().peer_id,
     };
 
     let mut rng = network.new_rng();
@@ -496,11 +503,7 @@ fn messages_during_churn() {
     let cl_auth = Authority::Client {
         client_key: *clients[0].full_id.public_id().signing_public_key(),
         proxy_node_name: nodes[0].name(),
-        peer_id: clients[0]
-            .handle
-            .0
-            .borrow()
-            .peer_id,
+        peer_id: clients[0].handle.0.borrow().peer_id,
     };
 
     for i in 0..100 {

--- a/tests/mock_crust/drop.rs
+++ b/tests/mock_crust/drop.rs
@@ -29,7 +29,9 @@ fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {
 
     let _ = poll_all(nodes, &mut []);
 
-    for node in nodes.iter_mut().filter(|n| close_names.contains(&n.name())) {
+    for node in nodes
+            .iter_mut()
+            .filter(|n| close_names.contains(&n.name())) {
         loop {
             match node.try_next_ev() {
                 Ok(Event::NodeLost(lost_name, _)) if lost_name == name => break,

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -51,10 +51,15 @@ fn disconnect_on_rebootstrap() {
     let mut nodes = create_connected_nodes(&network, 2);
     // Try to bootstrap to another than the first node. With network size 2, this should fail.
     let config = Config::with_contacts(&[nodes[1].handle.endpoint()]);
-    nodes.push(TestNode::builder(&network).config(config).endpoint(Endpoint(2)).create());
+    nodes.push(TestNode::builder(&network)
+                   .config(config)
+                   .endpoint(Endpoint(2))
+                   .create());
     let _ = poll_all(&mut nodes, &mut []);
     // When retrying to bootstrap, we should have disconnected from the bootstrap node.
-    assert!(!unwrap!(nodes.last()).handle.is_connected(&nodes[1].handle));
+    assert!(!unwrap!(nodes.last())
+                 .handle
+                 .is_connected(&nodes[1].handle));
     expect_next_event!(unwrap!(nodes.last_mut()), Event::Terminate);
 }
 
@@ -108,7 +113,9 @@ fn multiple_joining_nodes() {
         // can handle this, either by adding the nodes in sequence or by rejecting some.
         let count = 5;
         for _ in 0..count {
-            nodes.push(TestNode::builder(&network).config(config.clone()).create());
+            nodes.push(TestNode::builder(&network)
+                           .config(config.clone())
+                           .create());
         }
 
         poll_and_resend(&mut nodes, &mut []);
@@ -148,11 +155,15 @@ fn simultaneous_joining_nodes() {
         }
     }
 
-    let node = TestNode::builder(&network).config(config.clone()).create();
+    let node = TestNode::builder(&network)
+        .config(config.clone())
+        .create();
     let prefix = Prefix::new(1, node.name());
     nodes.push(node);
     loop {
-        let node = TestNode::builder(&network).config(config.clone()).create();
+        let node = TestNode::builder(&network)
+            .config(config.clone())
+            .create();
         if !prefix.matches(&node.name()) {
             nodes.push(node);
             break;
@@ -169,7 +180,9 @@ fn check_close_names_for_min_section_size_nodes() {
     let min_section_size = 8;
     let nodes = create_connected_nodes(&Network::new(min_section_size, None), min_section_size);
     let close_sections_complete =
-        nodes.iter().all(|n| nodes.iter().all(|m| m.close_names().contains(&n.name())));
+        nodes
+            .iter()
+            .all(|n| nodes.iter().all(|m| m.close_names().contains(&n.name())));
     assert!(close_sections_complete);
 }
 
@@ -187,11 +200,15 @@ fn whitelist() {
             .whitelist_peer(PeerId(min_section_size));
     }
     // The next node has peer ID `min_section_size`: It should be able to join.
-    nodes.push(TestNode::builder(&network).config(config.clone()).create());
+    nodes.push(TestNode::builder(&network)
+                   .config(config.clone())
+                   .create());
     let _ = poll_all(&mut nodes, &mut []);
     verify_invariant_for_all_nodes(&nodes);
     // The next node has peer ID `min_section_size + 1`: It is not whitelisted.
-    nodes.push(TestNode::builder(&network).config(config.clone()).create());
+    nodes.push(TestNode::builder(&network)
+                   .config(config.clone())
+                   .create());
     let _ = poll_all(&mut nodes, &mut []);
     assert!(!unwrap!(nodes.pop()).inner.is_node());
     // A client should be able to join anyway, regardless of the whitelist.

--- a/tests/mock_crust/requests.rs
+++ b/tests/mock_crust/requests.rs
@@ -79,7 +79,11 @@ fn successful_get_request() {
     for node in nodes.iter_mut().filter(|n| n.is_recipient(&dst)) {
         loop {
             match node.try_next_ev() {
-                Ok(Event::Request { request: Request::Get(ref request, id), src, dst }) => {
+                Ok(Event::Request {
+                       request: Request::Get(ref request, id),
+                       src,
+                       dst,
+                   }) => {
                     request_received_count += 1;
                     if data_request == *request && message_id == id {
                         if let Err(err) = node.inner.send_get_success(dst, src, data.clone(), id) {
@@ -105,9 +109,8 @@ fn successful_get_request() {
         loop {
             match client.inner.try_next_ev() {
                 Ok(Event::Response {
-                    response: Response::GetSuccess(ref immutable, ref id),
-                    ..
-                }) => {
+                       response: Response::GetSuccess(ref immutable, ref id), ..
+                   }) => {
                     response_received_count += 1;
                     if data == *immutable && message_id == *id {
                         break;
@@ -144,14 +147,15 @@ fn failed_get_request() {
     for node in nodes.iter_mut().filter(|n| n.is_recipient(&dst)) {
         loop {
             match node.try_next_ev() {
-                Ok(Event::Request { request: Request::Get(ref data_id, ref id), src, dst }) => {
+                Ok(Event::Request {
+                       request: Request::Get(ref data_id, ref id),
+                       src,
+                       dst,
+                   }) => {
                     request_received_count += 1;
                     if data_request == *data_id && message_id == *id {
-                        if let Err(err) = node.inner.send_get_failure(dst,
-                                                                      src,
-                                                                      *data_id,
-                                                                      vec![],
-                                                                      *id) {
+                        if let Err(err) = node.inner
+                               .send_get_failure(dst, src, *data_id, vec![], *id) {
                             trace!("Failed to send GetFailure response: {:?}", err);
                         }
                         break;
@@ -211,7 +215,11 @@ fn disconnect_on_get_request() {
     for node in nodes.iter_mut().filter(|n| n.is_recipient(&dst)) {
         loop {
             match node.try_next_ev() {
-                Ok(Event::Request { request: Request::Get(ref request, ref id), src, dst }) => {
+                Ok(Event::Request {
+                       request: Request::Get(ref request, ref id),
+                       src,
+                       dst,
+                   }) => {
                     request_received_count += 1;
                     if data_request == *request && message_id == *id {
                         if let Err(err) = node.inner.send_get_success(dst, src, data.clone(), *id) {
@@ -233,20 +241,12 @@ fn disconnect_on_get_request() {
         .handle
         .0
         .borrow_mut()
-        .disconnect(&nodes[0]
-                         .handle
-                         .0
-                         .borrow()
-                         .peer_id);
+        .disconnect(&nodes[0].handle.0.borrow().peer_id);
     nodes[0]
         .handle
         .0
         .borrow_mut()
-        .disconnect(&clients[0]
-                         .handle
-                         .0
-                         .borrow()
-                         .peer_id);
+        .disconnect(&clients[0].handle.0.borrow().peer_id);
 
     let _ = poll_all(&mut nodes, &mut clients);
 

--- a/tests/mock_crust/tunnel.rs
+++ b/tests/mock_crust/tunnel.rs
@@ -65,7 +65,8 @@ fn failing_connections_unidirectional() {
 fn remove_nodes_from_section_till_merge(prefix_name: &XorName,
                                         nodes: &mut Vec<TestNode>,
                                         min_section_size: usize) {
-    let section_indexes: Vec<usize> = nodes.iter()
+    let section_indexes: Vec<usize> = nodes
+        .iter()
         .enumerate()
         .rev()
         .filter_map(|(index, node)| if node.routing_table().our_prefix().matches(prefix_name) {
@@ -74,7 +75,8 @@ fn remove_nodes_from_section_till_merge(prefix_name: &XorName,
                         None
                     })
         .collect();
-    section_indexes.iter()
+    section_indexes
+        .iter()
         .take(section_indexes.len() - min_section_size + 1)
         .foreach(|index| { let _ = nodes.remove(*index); });
     poll_and_resend(nodes, &mut []);
@@ -90,12 +92,20 @@ fn add_a_pair(network: &Network,
               -> (Endpoint, Endpoint) {
     let config = Config::with_contacts(&[nodes[0].handle.endpoint()]);
 
-    nodes.iter_mut().foreach(|node| node.inner.set_next_node_name(name0));
-    nodes.push(TestNode::builder(network).config(config.clone()).create());
+    nodes
+        .iter_mut()
+        .foreach(|node| node.inner.set_next_node_name(name0));
+    nodes.push(TestNode::builder(network)
+                   .config(config.clone())
+                   .create());
     poll_and_resend(nodes, &mut []);
 
-    nodes.iter_mut().foreach(|node| node.inner.set_next_node_name(name1));
-    nodes.push(TestNode::builder(network).config(config.clone()).create());
+    nodes
+        .iter_mut()
+        .foreach(|node| node.inner.set_next_node_name(name1));
+    nodes.push(TestNode::builder(network)
+                   .config(config.clone())
+                   .create());
 
     let endpoints = (Endpoint(nodes.len() - 2), Endpoint(nodes.len() - 1));
     if is_tunnel {
@@ -108,7 +118,8 @@ fn add_a_pair(network: &Network,
 }
 
 fn locate_tunnel_node(nodes: &[TestNode], client_1: PeerId, client_2: PeerId) -> Option<usize> {
-    let tunnel_node_indexes: Vec<usize> = nodes.iter()
+    let tunnel_node_indexes: Vec<usize> = nodes
+        .iter()
         .enumerate()
         .filter_map(|(index, node)| if node.inner.has_tunnel_clients(client_1, client_2) {
                         Some(index)


### PR DESCRIPTION
Improve timer maintainence by removing manual work which uses cond-var and drop impl. Use std lib features instead and RAII objects (so we don't have to implement drop manually)