### PR TITLE
Hop signatures

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -119,6 +119,9 @@ pub enum RoutingError {
     FailedResourceProofValidation,
     /// Candidate is connected via a tunnel
     CandidateIsTunnelling,
+    /// Could not find a signed section list for some prefix in our cache. This might just be
+    /// because we didn't get enough signatures from neighbouring nodes yet.
+    NoSectionSigInCache,
 }
 
 impl From<RoutingTableError> for RoutingError {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -824,9 +824,11 @@ impl Debug for HopMessage {
 impl Debug for SignedMessage {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter,
-               "SignedMessage {{ content: {:?}, sending nodes: {:?}, signatures: {:?} }}",
+               "SignedMessage {{ content: {:?}, sending sections: {:?}, relaying sections: {:?}, \
+                    signatures: {:?} }}",
                self.content,
                self.src_sections,
+               self.relay_sections,
                self.signatures.keys().collect_vec())
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -301,10 +301,63 @@ impl SignedMessage {
     }
 
     /// Confirms the signatures.
-    // TODO (MAID-1677): verify the sending SectionLists via each hop's signed lists
-    pub fn check_integrity(&self, min_section_size: usize) -> Result<(), RoutingError> {
-        // TODO: verify relay and sending section lists
+    ///
+    /// `min_section_size` is required when the message is from a _group_ (see doc on `Authority`).
+    ///
+    /// `known_section` is used to kick-start hop-by-hop verification. It is required to verify
+    /// the source section/group; it should be mandatory but currently clients don't know who
+    /// the members of their proxy's section are (TODO).
+    pub fn check_integrity(&self,
+                           min_section_size: usize,
+                           known_section: Option<&SectionList>)
+                           -> Result<(), RoutingError> {
+        fn check_enough_sigs(ssl: &SignedSectionList,
+                             last_verified: &SectionList)
+                             -> Result<(), RoutingError> {
+            let bytes = serialise(&ssl.list)?;
+            // Now find all signatures of bytes from ssl which are valid and from a node
+            // mentioned by last_verified, and check that this is a quorum of last_verified.
+            let valid_sigs = ssl.signatures
+                .iter()
+                .filter(|&(pub_id, sig): &(&PublicId, &sign::Signature)| {
+                    last_verified.pub_ids.contains(pub_id) &&
+                    sign::verify_detached(sig, &bytes, pub_id.signing_public_key())
+                })
+                .count();
+            if QUORUM * last_verified.pub_ids.len() > 100 * valid_sigs {
+                return Err(RoutingError::NotEnoughSignatures);
+            }
+            Ok(())
+        }
 
+        // -----  first, verify the route  -----
+        if let Some(known_section) = known_section {
+            let mut last_verified = known_section;
+            for prev_hop in self.relay_sections.iter().rev() {
+                check_enough_sigs(prev_hop, last_verified)?;
+                last_verified = &prev_hop.list;
+            }
+
+            // Now last_verified should correspond to the accumulating section. We could directly
+            // use this to verify all source sections, but the accumulating node's signed lists of
+            // these sections may only include a quorum of signatures from its own understanding
+            // of its section, so we resolve that and use that to verify the rest.
+            for src in &self.src_sections {
+                if src.list.prefix == last_verified.prefix {
+                    check_enough_sigs(src, last_verified)?;
+                    last_verified = &src.list;
+                }
+            }
+            for src in &self.src_sections {
+                if src.list.prefix == last_verified.prefix {
+                    // we already verified this section list
+                    continue;
+                }
+                check_enough_sigs(src, last_verified)?;
+            }
+        }
+
+        // -----  second, verify the message was signed by a quorum of original senders  -----
         let signed_bytes = serialise(&self.content)?;
         if !self.find_invalid_sigs(signed_bytes).is_empty() {
             return Err(RoutingError::FailedSignature);
@@ -366,9 +419,6 @@ impl SignedMessage {
         // We also check (again) that all messages are from valid senders, because the message
         // may have been sent from another node, and we cannot trust that that node correctly
         // controlled which signatures were added.
-        // TODO (MAID-1677): we also need to check that the src_sections list corresponds to the
-        // section(s) at some point in recent history; i.e. that it was valid; but we shouldn't
-        // force it to match our own because our routing table may have changed since.
 
         let signed_bytes = match serialise(&self.content) {
             Ok(serialised) => serialised,
@@ -412,8 +462,10 @@ impl SignedMessage {
         invalid
     }
 
-    // Returns true iff there are enough signatures (note that this method does not verify the
-    // signatures, it only counts them; it also does not verify `self.src_sections`).
+    // Returns true iff there are a quorum of signatures from `self.src_sections`.
+    //
+    // Note that this method does not verify the signatures, it only counts them.
+    // It also does not verify anything about `self.src_sections`.
     fn has_enough_sigs(&self, min_section_size: usize) -> bool {
         use Authority::*;
         match self.content.src {
@@ -1240,6 +1292,8 @@ mod tests {
 
     #[test]
     fn signed_message_check_integrity() {
+        // TODO: update to test the new route and sender validation in check_integrity
+
         let min_section_size = 1000;
         let name: XorName = rand::random();
         let full_id = FullId::new();
@@ -1262,7 +1316,7 @@ mod tests {
         assert_eq!(Some(full_id.public_id()),
                    signed_message.signatures.keys().next());
 
-        unwrap!(signed_message.check_integrity(min_section_size));
+        unwrap!(signed_message.check_integrity(min_section_size, None));
 
         let full_id = FullId::new();
         let bytes_to_sign = unwrap!(serialise(&(&routing_message, full_id.public_id())));
@@ -1271,7 +1325,7 @@ mod tests {
         signed_message.signatures = iter::once((*full_id.public_id(), signature)).collect();
 
         // Invalid because it's not signed by the sender:
-        assert!(signed_message.check_integrity(min_section_size).is_err());
+        assert!(signed_message.check_integrity(min_section_size, None).is_err());
         // However, the signature itself should be valid:
         assert!(signed_message.has_enough_sigs(min_section_size));
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -236,7 +236,6 @@ impl HopMessage {
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable, Debug)]
 pub struct SectionList {
     pub prefix: Prefix<XorName>,
-    // TODO(MAID-1677): pub signatures: BTreeSet<(PublicId, sign::Signature)>,
     pub_ids: BTreeSet<PublicId>,
 }
 
@@ -255,15 +254,25 @@ impl SectionList {
     }
 }
 
+/// A collection of signatures of the contents of a `SectionList`.
+pub type SectionListSignatures = BTreeMap<PublicId, sign::Signature>;
+
+/// A list of signatures of a section list
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable, Debug)]
+pub struct SignedSectionList {
+    pub list: SectionList,
+    pub signatures: SectionListSignatures,
+}
+
 /// Wrapper around a routing message, signed by the originator of the message.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable)]
 pub struct SignedMessage {
     /// A request or response type message.
     content: RoutingMessage,
     /// Nodes sending the message (those expected to sign it)
-    src_sections: Vec<SectionList>,
-    /// The lists of the sections involved in routing this message, in chronological order.
-    // TODO: implement (MAID-1677): sec_lists: Vec<SectionList>,
+    src_sections: Vec<SignedSectionList>,
+    /// The message was relayed by a node from each of these sections:
+    relay_sections: Vec<SignedSectionList>,
     /// The IDs and signatures of the source authority's members.
     signatures: BTreeMap<PublicId, sign::Signature>,
 }
@@ -274,20 +283,28 @@ impl SignedMessage {
     /// Requires the list `src_sections` of nodes who should sign this message.
     pub fn new(content: RoutingMessage,
                full_id: &FullId,
-               mut src_sections: Vec<SectionList>)
+               mut src_sections: Vec<SignedSectionList>)
                -> Result<SignedMessage, RoutingError> {
-        src_sections.sort_by_key(|list| list.prefix);
+        src_sections.sort_by_key(|list| list.list.prefix);
         let sig = sign::sign_detached(&serialise(&content)?, full_id.signing_private_key());
         Ok(SignedMessage {
             content: content,
             src_sections: src_sections,
+            relay_sections: vec![],
             signatures: iter::once((*full_id.public_id(), sig)).collect(),
         })
+    }
+
+    /// Add list of members of a relaying section
+    pub fn add_relaying_section(&mut self, section: SignedSectionList) {
+        self.relay_sections.push(section);
     }
 
     /// Confirms the signatures.
     // TODO (MAID-1677): verify the sending SectionLists via each hop's signed lists
     pub fn check_integrity(&self, min_section_size: usize) -> Result<(), RoutingError> {
+        // TODO: verify relay and sending section lists
+
         let signed_bytes = serialise(&self.content)?;
         if !self.find_invalid_sigs(signed_bytes).is_empty() {
             return Err(RoutingError::FailedSignature);
@@ -305,7 +322,7 @@ impl SignedMessage {
 
     /// Returns the number of nodes in the source authority.
     pub fn src_size(&self) -> usize {
-        self.src_sections.iter().map(|sl| sl.pub_ids.len()).sum()
+        self.src_sections.iter().map(|sl| sl.list.pub_ids.len()).sum()
     }
 
     /// Adds the given signature if it is new, without validating it. If the collection of section
@@ -369,7 +386,7 @@ impl SignedMessage {
 
     // Returns true iff `pub_id` is in self.section_lists
     fn is_sender(&self, pub_id: &PublicId) -> bool {
-        self.src_sections.iter().any(|list| list.pub_ids.contains(pub_id))
+        self.src_sections.iter().any(|list| list.list.pub_ids.contains(pub_id))
     }
 
     // Returns a list of all invalid signatures (not from an expected key or not cryptographically
@@ -404,7 +421,7 @@ impl SignedMessage {
                 // Note: there should be exactly one source section, but we use safe code:
                 let valid_names: HashSet<_> = self.src_sections
                     .iter()
-                    .flat_map(|list| list.pub_ids.iter().map(PublicId::name))
+                    .flat_map(|list| list.list.pub_ids.iter().map(PublicId::name))
                     .sorted_by(|lhs, rhs| self.content.src.name().cmp_distance(lhs, rhs))
                     .into_iter()
                     .take(min_section_size)
@@ -422,7 +439,7 @@ impl SignedMessage {
             Section(_) => {
                 // Note: there should be exactly one source section, but we use safe code:
                 let num_sending =
-                    self.src_sections.iter().fold(0, |count, list| count + list.pub_ids.len());
+                    self.src_sections.iter().fold(0, |count, list| count + list.list.pub_ids.len());
                 let valid_sigs = self.signatures.len();
                 QUORUM * num_sending <= 100 * valid_sigs
             }
@@ -431,9 +448,9 @@ impl SignedMessage {
                 self.src_sections.iter().all(|list| {
                     let valid_sigs = self.signatures
                         .keys()
-                        .filter(|pub_id| list.pub_ids.contains(pub_id))
+                        .filter(|pub_id| list.list.pub_ids.contains(pub_id))
                         .count();
-                    QUORUM * list.pub_ids.len() <= 100 * valid_sigs
+                    QUORUM * list.list.pub_ids.len() <= 100 * valid_sigs
                 })
             }
             ManagedNode(_) | Client { .. } => self.signatures.len() == 1,
@@ -1281,10 +1298,14 @@ mod tests {
             content: part,
         };
 
-        let src_sections = vec![SectionList::from(prefix,
-                                                  vec![*full_id_0.public_id(),
-                                                       *full_id_1.public_id(),
-                                                       *full_id_2.public_id()])];
+        let list = SectionList::from(prefix,
+                                     vec![*full_id_0.public_id(),
+                                          *full_id_1.public_id(),
+                                          *full_id_2.public_id()]);
+        let src_sections = vec![SignedSectionList {
+                                    list: list,
+                                    signatures: Default::default(),
+                                }];
         let mut signed_msg = unwrap!(SignedMessage::new(routing_message, &full_id_0, src_sections));
         assert_eq!(signed_msg.signatures.len(), 1);
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -258,10 +258,20 @@ impl SectionList {
 pub type SectionListSignatures = BTreeMap<PublicId, sign::Signature>;
 
 /// A list of signatures of a section list
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, RustcEncodable, RustcDecodable)]
 pub struct SignedSectionList {
     pub list: SectionList,
     pub signatures: SectionListSignatures,
+}
+
+impl Debug for SignedSectionList {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Printing out signatures is not very useful to us, and makes messages a lot longer
+        write!(f,
+               "SignedSectionList {{ list: {:?}, signatures: {} }}",
+               self.list,
+               self.signatures.len())
+    }
 }
 
 /// Wrapper around a routing message, signed by the originator of the message.

--- a/src/node.rs
+++ b/src/node.rs
@@ -467,7 +467,7 @@ impl Node {
     /// Returns a quorum of signatures for the neighbouring section's list or `None` if we don't
     /// have one
     pub fn section_list_signatures(&self,
-                                   prefix: Prefix<XorName>)
+                                   prefix: &Prefix<XorName>)
                                    -> Option<BTreeMap<PublicId, sign::Signature>> {
         self.machine.current().section_list_signatures(prefix)
     }

--- a/src/section_list_cache.rs
+++ b/src/section_list_cache.rs
@@ -33,7 +33,7 @@ pub struct SectionListCache {
     // Section lists signed by a given public id
     signed_by: HashMap<PublicId, PrefixMap<SectionList>>,
     // The latest section list for each prefix with a quorum of signatures
-    lists_cache: PrefixMap<(SectionList, SectionListSignatures)>,
+    lists_cache: PrefixMap<SignedSectionList>,
 }
 
 impl SectionListCache {
@@ -78,13 +78,7 @@ impl SectionListCache {
 
     /// Returns the currently signed section list for `prefix` along with a quorum of signatures.
     pub fn get_signed_list(&self, prefix: &Prefix<XorName>) -> Option<SignedSectionList> {
-        // TODO: why not store this type directly? And do we need to clone?
-        self.lists_cache.get(prefix).cloned().map(|(list, sigs)| {
-            SignedSectionList {
-                list: list,
-                signatures: sigs,
-            }
-        })
+        self.lists_cache.get(prefix).cloned()
     }
 
     fn prune(&mut self) {
@@ -132,7 +126,11 @@ impl SectionListCache {
                 if 100 * sig_count >= QUORUM * our_section_size {
                     // we have a list with a quorum of signatures
                     let signatures = unwrap!(map.get(list));
-                    let _ = self.lists_cache.insert(*prefix, (list.clone(), signatures.clone()));
+                    let _ = self.lists_cache.insert(*prefix,
+                                                    SignedSectionList {
+                                                        list: list.clone(),
+                                                        signatures: signatures.clone(),
+                                                    });
                 }
             }
         }

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -126,7 +126,8 @@ impl SignatureAccumulator {
 mod tests {
     use id::{FullId, PublicId};
     use itertools::Itertools;
-    use messages::{DirectMessage, MessageContent, RoutingMessage, SectionList, SignedMessage};
+    use messages::{DirectMessage, MessageContent, RoutingMessage, SectionList, SignedMessage,
+                   SignedSectionList};
     use rand;
     use routing_table::Authority;
     use routing_table::Prefix;
@@ -152,8 +153,11 @@ mod tests {
                                                       rand::random()),
             };
             let prefix = Prefix::new(0, *unwrap!(all_ids.iter().next()).name());
-            let lists = vec![SectionList::new(prefix, all_ids)];
-            let signed_msg = unwrap!(SignedMessage::new(routing_msg, msg_sender_id, lists));
+            let ssl = vec![SignedSectionList {
+                               list: SectionList::new(prefix, all_ids),
+                               signatures: Default::default(),
+                           }];
+            let signed_msg = unwrap!(SignedMessage::new(routing_msg, msg_sender_id, ssl));
             let signature_msgs = other_ids.map(|id| {
                     unwrap!(signed_msg.routing_message().to_signature(id.signing_private_key()))
                 })

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -247,7 +247,7 @@ mod tests {
             assert!(sig_accumulator.msgs.is_empty());
             assert_eq!(route, returned_route);
             assert_eq!(signed_msg.routing_message(), returned_msg.routing_message());
-            unwrap!(returned_msg.check_integrity(1000));
+            unwrap!(returned_msg.check_integrity(1000, None));
             assert!(returned_msg.check_fully_signed(env.num_nodes()));
             env.senders
                 .iter()
@@ -290,7 +290,7 @@ mod tests {
                         assert_eq!(route as u8, returned_route);
                         assert_eq!(msg_and_sigs.signed_msg.routing_message(),
                                    returned_msg.routing_message());
-                        unwrap!(returned_msg.check_integrity(1000));
+                        unwrap!(returned_msg.check_integrity(1000, None));
                         assert!(returned_msg.check_fully_signed(env.num_nodes()));
                     }
                 });

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -158,7 +158,7 @@ impl State {
     }
 
     pub fn section_list_signatures(&self,
-                                   prefix: Prefix<XorName>)
+                                   prefix: &Prefix<XorName>)
                                    -> Option<BTreeMap<PublicId, sign::Signature>> {
         match *self {
             State::Node(ref state) => state.section_list_signatures(prefix).ok(),

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -177,7 +177,8 @@ impl Client {
         }
 
         let signed_msg = hop_msg.content;
-        signed_msg.check_integrity(self.min_section_size())?;
+        // TODO: verify with proxy's section list
+        signed_msg.check_integrity(self.min_section_size(), None)?;
 
         let routing_msg = signed_msg.routing_message();
         let in_authority = self.in_authority(&routing_msg.dst);

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -177,8 +177,17 @@ impl Client {
         }
 
         let signed_msg = hop_msg.content;
-        // TODO: verify with proxy's section list
-        signed_msg.check_integrity(self.min_section_size(), None)?;
+        // TODO: verify with proxy's section list instead of passing None here:
+        match signed_msg.check_integrity(self.min_section_size(), None) {
+            Ok(()) => {}
+            Err(e) => {
+                warn!("{:?} Verification of {:?} failed: {:?}",
+                      self,
+                      signed_msg,
+                      e);
+                return Err(e.into());
+            }
+        }
 
         let routing_msg = signed_msg.routing_message();
         let in_authority = self.in_authority(&routing_msg.dst);

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -750,7 +750,11 @@ impl Node {
             .routing_table()
             .find_section_prefix(&hop_name)
             .ok_or(RoutingTableError::NoSuchPeer)?;
-        let section_list = if signed_msg.routing_message().src.is_client() {
+        let section_list = if signed_msg.routing_message().src.is_client() ||
+                              self.in_authority(&signed_msg.routing_message().src) {
+            // No point verifying the route if from a client; we also don't need to verify if the
+            // message is from our own section.
+            // TODO: possibly we should if the message is from a PrefixSection.
             None
         } else {
             let list = self.section_list_sigs.get_signed_list(&hop_prefix);

--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -325,7 +325,7 @@ fn verify_section_list_signatures(nodes: &[TestNode]) {
         let section_size = rt.our_section().len();
         for prefix in rt.prefixes() {
             if prefix != *rt.our_prefix() {
-                let sigs = unwrap!(node.inner.section_list_signatures(prefix),
+                let sigs = unwrap!(node.inner.section_list_signatures(&prefix),
                                    "{:?} Tried to unwrap None returned from \
                                     section_list_signatures({:?})",
                                    node.name(),


### PR DESCRIPTION
Tests don't all pass.

Hop signature verification can be disabled in `Node::handle_signed_message` by not passing a section list to `check_integrity`.