### PR TITLE
feat/quorum: allow fractional quorum; use strict greater than

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,8 +193,12 @@ pub const TYPE_TAG_SESSION_PACKET: u64 = 0;
 /// Structured Data Tag for DNS Packet Type
 pub const TYPE_TAG_DNS_PACKET: u64 = 5;
 
-/// The quorum, as a percentage of the number of members of the authority.
-pub const QUORUM: usize = 51;
+/// Quorum is defined as having strictly greater than `QUORUM_NUM / QUORUM_DENOM` agreement;
+/// using only integer arithmatic a quorum can be checked with
+/// `votes * QUORUM_DENOM > voters * QUORUM_NUM`.
+pub const QUORUM_NUM: usize = 1;
+/// See QUORUM_NUM
+pub const QUORUM_DENOM: usize = 2;
 
 pub use cache::{Cache, NullCache};
 pub use client::Client;
@@ -220,12 +224,13 @@ pub use xor_name::{XOR_NAME_BITS, XOR_NAME_LEN, XorName, XorNameFromHexError};
 
 #[cfg(test)]
 mod tests {
-    use super::QUORUM;
+    use super::{QUORUM_DENOM, QUORUM_NUM};
 
     #[test]
     #[cfg_attr(feature="cargo-clippy", allow(eq_op))]
-    fn quorum_percentage() {
-        assert!(QUORUM <= 100 && QUORUM > 50,
-                "Quorum percentage isn't between 51 and 100");
+    fn quorum_check() {
+        assert!(QUORUM_NUM < QUORUM_DENOM, "Quorum impossible to achieve");
+        assert!(QUORUM_NUM * 2 >= QUORUM_DENOM,
+                "Quorum does not guarantee agreement");
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use super::QUORUM;
+use super::{QUORUM_DENOM, QUORUM_NUM};
 use ack_manager::Ack;
 #[cfg(not(feature = "use-mock-crust"))]
 use crust::PeerId;
@@ -435,7 +435,7 @@ impl SignedMessage {
                 // cmp::min(routing_table.len(), min_section_size)
                 // (or just min_section_size, but in that case we will not be able to handle user
                 // messages during boot-up).
-                QUORUM * valid_names.len() <= 100 * valid_sigs
+                valid_sigs * QUORUM_DENOM > valid_names.len() * QUORUM_NUM
             }
             Section(_) => {
                 // Note: there should be exactly one source section, but we use safe code:
@@ -443,7 +443,7 @@ impl SignedMessage {
                     .iter()
                     .fold(0, |count, list| count + list.pub_ids.len());
                 let valid_sigs = self.signatures.len();
-                QUORUM * num_sending <= 100 * valid_sigs
+                valid_sigs * QUORUM_DENOM > num_sending * QUORUM_NUM
             }
             PrefixSection(_) => {
                 // Each section must have enough signatures:
@@ -454,7 +454,7 @@ impl SignedMessage {
                                  .keys()
                                  .filter(|pub_id| list.pub_ids.contains(pub_id))
                                  .count();
-                             QUORUM * list.pub_ids.len() <= 100 * valid_sigs
+                             valid_sigs * QUORUM_DENOM > list.pub_ids.len() * QUORUM_NUM
                          })
             }
             ManagedNode(_) | Client { .. } => self.signatures.len() == 1,

--- a/src/section_list_cache.rs
+++ b/src/section_list_cache.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use super::QUORUM;
+use super::{QUORUM_DENOM, QUORUM_NUM};
 use super::XorName;
 use id::PublicId;
 use itertools::Itertools;
@@ -149,7 +149,7 @@ impl SectionListCache {
                 .sorted_by(|lhs, rhs| rhs.1.cmp(&lhs.1));
             if let Some(&(list, sig_count)) = entries.first() {
                 // entry.0 = list, entry.1 = num of signatures
-                if 100 * sig_count >= QUORUM * our_section_size {
+                if sig_count * QUORUM_DENOM > our_section_size * QUORUM_NUM {
                     // we have a list with a quorum of signatures
                     let signatures = unwrap!(map.get(list));
                     let _ = self.lists_cache

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use super::common::{Base, Bootstrapped, USER_MSG_CACHE_EXPIRY_DURATION_SECS};
-use QUORUM;
+use {QUORUM_DENOM, QUORUM_NUM};
 use ack_manager::{Ack, AckManager};
 use action::Action;
 use cache::Cache;
@@ -879,7 +879,7 @@ impl Node {
         // TODO(MAID-1677): Remove this once messages are fully validated.
         // Expect group/section messages to be sent by at least a quorum of `min_section_size`.
         if self.our_prefix().bit_count() > 0 && signed_msg.routing_message().src.is_multiple() &&
-           signed_msg.src_size() * 100 < QUORUM * self.min_section_size() {
+           signed_msg.src_size() * QUORUM_DENOM <= self.min_section_size() * QUORUM_NUM {
             warn!("{:?} Not enough signatures in {:?}.", self, signed_msg);
             return Err(RoutingError::NotEnoughSignatures);
         }

--- a/tests/mock_crust/accumulate.rs
+++ b/tests/mock_crust/accumulate.rs
@@ -17,7 +17,8 @@
 
 use super::{TestNode, create_connected_nodes, gen_immutable_data, poll_all,
             sort_nodes_by_distance_to};
-use routing::{Authority, Event, EventStream, MessageId, QUORUM, Response, XorName};
+use routing::{Authority, Event, EventStream, MessageId, QUORUM_DENOM, QUORUM_NUM, Response,
+              XorName};
 use routing::mock_crust::Network;
 use std::sync::mpsc;
 
@@ -39,8 +40,8 @@ fn messages_accumulate_with_quorum() {
     };
 
     let dst = Authority::ManagedNode(nodes[0].name()); // The closest node.
-    // The smallest number such that `quorum * 100 >= len * QUORUM`:
-    let quorum = (min_section_size * QUORUM - 1) / 100 + 1;
+    // The smallest number such that `quorum * QUORUM_DENOM > min_section_size * QUORUM_NUM`:
+    let quorum = 1 + (min_section_size * QUORUM_NUM) / QUORUM_DENOM;
 
     // Send a message from the section `src` to the node `dst`.
     // Only the `quorum`-th sender should cause accumulation and a

--- a/tests/mock_crust/churn.rs
+++ b/tests/mock_crust/churn.rs
@@ -19,7 +19,8 @@ use super::{TestClient, TestNode, create_connected_clients, create_connected_nod
             gen_range_except, poll_and_resend, verify_invariant_for_all_nodes};
 use itertools::Itertools;
 use rand::Rng;
-use routing::{Authority, DataIdentifier, Event, EventStream, MessageId, QUORUM, Request, XorName};
+use routing::{Authority, DataIdentifier, Event, EventStream, MessageId, QUORUM_DENOM, QUORUM_NUM,
+              Request, XorName};
 use routing::mock_crust::{Config, Network};
 use std::cmp;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -31,8 +32,7 @@ use std::iter;
 fn drop_random_nodes<R: Rng>(rng: &mut R, nodes: &mut Vec<TestNode>, min_section_size: usize) {
     let len = nodes.len();
     // Nodes needed for quorum with minimum section size. Round up.
-    let min_quorum = (min_section_size * QUORUM + 99) / 100;
-
+    let min_quorum = 1 + (min_section_size * QUORUM_NUM) / QUORUM_DENOM;
     if rng.gen_weighted_bool(3) {
         // Pick a section then remove as many nodes as possible from it without breaking quorum.
         let i = gen_range(rng, 0, len);
@@ -185,7 +185,7 @@ impl ExpectedGets {
             sent_count += 1;
         }
         if src.is_multiple() {
-            assert!(100 * sent_count >= QUORUM * min_section_size);
+            assert!(sent_count * QUORUM_DENOM > min_section_size * QUORUM_NUM);
         } else {
             assert_eq!(sent_count, 1);
         }
@@ -297,7 +297,7 @@ impl ExpectedGets {
             assert!(key.3.is_multiple(), "Failed to receive request {:?}", key);
             let section_size = section_sizes[&key.3];
             let count = section_msgs_received.remove(&key).unwrap_or(0);
-            assert!(100 * count >= QUORUM * section_size,
+            assert!(count * QUORUM_DENOM > section_size * QUORUM_NUM,
                     "Only received {} out of {} messages {:?}.",
                     count,
                     section_size,
@@ -399,7 +399,7 @@ fn verify_section_list_signatures(nodes: &[TestNode]) {
                                     section_list_signatures({:?})",
                                    node.name(),
                                    prefix);
-                assert!(sigs.len() * 100 >= section_size * QUORUM,
+                assert!(sigs.len() * QUORUM_DENOM > section_size * QUORUM_NUM,
                         "{:?} Not enough signatures for prefix {:?} - {}/{}\n\tSignatures from: \
                          {:?}",
                         node.name(),


### PR DESCRIPTION
**This requires discussion**

@dirvine requested that we use strict > 50% for quorum, as in his RFC. This implements that, while also making it easy to use exact fractions such as 2/3.

Further changes may be needed for node ageing; however they may not touch exactly the same code; quorum may then be calculated the same way but by weighting votes and voters first.