### PR TITLE
Version change to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Routing - Change Log
 
+## [0.29.0]
+- Integration with templatised Crust where now routing specifies what to use as a UID so that crust and routing use a common UID to identify peer.
+- Peer manager clean up as connect success now tells us everything about the peer. Previously we needed to wait additionally for NodeIdentify for instance as crust-uid (PeerId) and routing-uid (PublicId) were separate and each layer informed about the id specific to that layer only.
+
 ## [0.28.5]
 - Add section update requests to make merges more stable.
 - Don't approve new node if routing table is invalid.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "routing"
 readme = "README.md"
 repository = "https://github.com/maidsafe/routing"
-version = "0.28.5"
+version = "0.29.0"
 
 [dependencies]
 crust = "~0.25.0"

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1929,12 +1929,17 @@ impl Node {
 
     /// Handles a `TunnelSelect` message from `src`: `dst`.
     fn handle_tunnel_select(&mut self, src: PublicId, dst: PublicId) {
-        if src < dst && self.tunnels.accept_clients(src, dst) {
+        if src < dst && self.peer_mgr.can_tunnel_for(&src, &dst) &&
+           self.tunnels.accept_clients(src, dst) {
             debug!("{:?} Agreed to act as tunnel node for {:?} - {:?}",
                    self,
                    src,
                    dst);
             self.send_direct_message(dst, DirectMessage::TunnelSuccess(src));
+        } else {
+            debug!("{:?} Rejecting TunnelSelect from {} - {}.", self, src, dst);
+            let message = DirectMessage::TunnelClosed(dst);
+            self.send_direct_message(src, message);
         }
     }
 


### PR DESCRIPTION
Give a fresh timestamp for newly connected peers else remove_expired_peers would remove them immediately if the existing timestamp indicated >60 <90secs.
Fix bug where the tunnel node split off from the tunnel client and would never deliver TunnelSuccess message to it.