### PR TITLE
Future-proof a dependency on type inference

### DIFF
--- a/src/routing_table/xorable.rs
+++ b/src/routing_table/xorable.rs
@@ -285,7 +285,7 @@ macro_rules! impl_xorable {
                     x <<= 4;
                     x <<= 4;
                     result = x.0;
-                    result |= From::from(*elem);
+                    result |= Into::<$t>::into(*elem);
                 }
                 result
             }


### PR DESCRIPTION
In the Rust compiler, a pull request is being considered (see GitHub PR rust-lang/rust#41336) that will add support for `a |= &b` (instead of only `a |= b`) for numeric types like `u64`.

Unfortunately, this breaks the build of routing, because routing currently does the following in xorable.rs:

`result |= From::from(*elem);`

Rust is currently able to infer that the result of the `From::from()` must be `$t`, because it gets bitor-ed to a `$t`. But if the PR on the compiler is accepted, this type inference will no longer be possible, because the type of the right-hand side could then also be `&'a $t` for some lifetime `'a`.

This commit specifies the output type of the conversion explicitly, so that it doesn't require any type inference.