### PR TITLE
fix/bootstrapping: Also start listening as JoiningNode before bootstrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/maidsafe/routing"
 version = "0.30.0"
 
 [dependencies]
-crust = "~0.25.0"
+crust = "~0.26.0"
 fake_clock = "~0.1.0"
 hex = "~0.2.0"
 itertools = "~0.6.0"

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -541,12 +541,9 @@ impl RoutingMessage {
 /// to A and also attempts to connect to A via Crust. A does the same, once it receives the
 /// `ConnectionInfo`.
 ///
-/// Once the connection between A and Z is established and a Crust `OnConnect` event is raised,
-/// they exchange `NodeIdentify` messages.
-///
 ///
 /// ### Resource Proof Evaluation to approve
-/// When nodes Z of section Y receive `NodeIdentify` from A, they respond with a `ResourceProof`
+/// When nodes Z of section Y receive `CandidateIdentify` from A, they reply with a `ResourceProof`
 /// request. Node A needs to answer these requests (resolving a hashing challenge) with
 /// `ResourceProofResponse`. Members of Y will send out `CandidateApproval` messages to vote for the
 /// approval in their section. Once the vote succeeds, the members of Y send `NodeApproval` to A and

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -100,6 +100,12 @@ impl<UID: Uid> Service<UID> {
         trace!(target: "crust", "[MOCK] set_service_discovery_listen not implemented in mock");
     }
 
+    /// Allow (or disallow) peers from bootstrapping off us.
+    pub fn set_accept_bootstrap(&mut self, accept: bool) -> Result<(), CrustError> {
+        self.lock().set_accept_bootstrap(accept);
+        Ok(())
+    }
+
     /// Check if we have peers on LAN
     pub fn has_peers_on_lan(&self) -> bool {
         // This will allow mock crust test to have multiple nodes on the same machine

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -309,6 +309,7 @@ pub struct ServiceImpl<UID: Uid> {
     endpoint: Endpoint,
     pub uid: Option<UID>,
     config: Config,
+    pub accept_bootstrap: bool,
     pub listening_tcp: bool,
     event_sender: Option<CrustEventSender<UID>>,
     pending_bootstraps: u64,
@@ -323,6 +324,7 @@ impl<UID: Uid> ServiceImpl<UID> {
             endpoint: endpoint,
             uid: None,
             config: config,
+            accept_bootstrap: false,
             listening_tcp: false,
             event_sender: None,
             pending_bootstraps: 0,
@@ -412,6 +414,10 @@ impl<UID: Uid> ServiceImpl<UID> {
         self.send_packet(their_info.endpoint, packet);
     }
 
+    pub fn set_accept_bootstrap(&mut self, accept: bool) {
+        self.accept_bootstrap = accept;
+    }
+
     pub fn start_listening_tcp(&mut self, port: u16) {
         self.listening_tcp = true;
         self.send_event(CrustEvent::ListenerStarted(port));
@@ -435,7 +441,7 @@ impl<UID: Uid> ServiceImpl<UID> {
     }
 
     fn handle_bootstrap_request(&mut self, peer_endpoint: Endpoint, uid: UID, kind: CrustUser) {
-        if self.is_listening() {
+        if self.is_listening() && self.accept_bootstrap {
             self.handle_bootstrap_accept(peer_endpoint, uid, kind);
             self.send_packet(peer_endpoint, Packet::BootstrapSuccess(unwrap!(self.uid)));
         } else {

--- a/src/mock_crust/tests.rs
+++ b/src/mock_crust/tests.rs
@@ -76,6 +76,7 @@ fn start_two_services_bootstrap_communicate_exit() {
     expect_event!(event_rx_0, CrustEvent::ListenerStarted::<PublicId>(..));
 
     service_0.start_service_discovery();
+    let _ = service_0.set_accept_bootstrap(true);
 
     let mut service_1 =
         unwrap!(Service::with_handle(&handle1, event_sender_1, *FullId::new().public_id()));
@@ -246,6 +247,7 @@ fn drop() {
 
     unwrap!(service_0.start_listening_tcp());
     expect_event!(event_rx_0, CrustEvent::ListenerStarted::<PublicId>(_));
+    let _ = service_0.set_accept_bootstrap(true);
 
     let mut service_1 =
         unwrap!(Service::with_handle(&handle1, event_sender_1, *FullId::new().public_id()));

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -730,7 +730,7 @@ impl PeerManager {
                          -> (Vec<PublicId>, Option<Prefix<XorName>>) {
         let (names_to_drop, our_new_prefix) = self.routing_table.split(ver_pfx);
         for name in &names_to_drop {
-            info!("{:?} Dropped {:?} from the routing table.", self, name);
+            info!("{:?} Dropped {} from the routing table.", self, name);
         }
 
         let mut ids_to_drop = names_to_drop
@@ -769,6 +769,10 @@ impl PeerManager {
     /// the list of peers that have been dropped and need to be disconnected.
     pub fn add_prefix(&mut self, ver_pfx: VersionedPrefix<XorName>) -> Vec<PublicId> {
         let names_to_drop = self.routing_table.add_prefix(ver_pfx);
+        for name in &names_to_drop {
+            info!("{:?} Dropped {} from the routing table.", self, name);
+        }
+
         let ids_to_drop = names_to_drop
             .iter()
             .filter_map(|name| self.get_peer_by_name(name))

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -81,9 +81,7 @@ impl Bootstrapping {
             TargetState::Client => {
                 let _ = crust_service.start_bootstrap(HashSet::new(), CrustUser::Client);
             }
-            TargetState::JoiningNode => {
-                let _ = crust_service.start_bootstrap(HashSet::new(), CrustUser::Node);
-            }
+            TargetState::JoiningNode |
             TargetState::Node { .. } => {
                 if let Err(error) = crust_service.start_listening_tcp() {
                     error!("Failed to start listening: {:?}", error);
@@ -156,7 +154,6 @@ impl Bootstrapping {
                     return Transition::Terminate;
                 }
                 trace!("{:?} Listener started on port {}.", self, port);
-                self.crust_service.set_service_discovery_listen(true);
                 let _ = self.crust_service
                     .start_bootstrap(HashSet::new(), CrustUser::Node);
                 Transition::Stay

--- a/src/states/joining_node.rs
+++ b/src/states/joining_node.rs
@@ -41,7 +41,7 @@ use timer::Timer;
 use types::{MessageId, RoutingActionSender};
 use xor_name::XorName;
 
-/// Time (in seconds) after which a `Relocate` request is resent.
+/// Total time (in seconds) to wait for `RelocateResponse`.
 const RELOCATE_TIMEOUT_SECS: u64 = 60 + RESOURCE_PROOF_DURATION_SECS;
 
 pub struct JoiningNode {

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -311,9 +311,8 @@ impl Node {
     fn print_rt_size(&self) {
         const TABLE_LVL: LogLevel = LogLevel::Info;
         if log_enabled!(TABLE_LVL) {
-            let status_str = format!("{:?} {} - Routing Table size: {:3}",
+            let status_str = format!("{:?} - Routing Table size: {:3}",
                                      self,
-                                     self.full_id.public_id(),
                                      self.stats.cur_routing_table_size);
             let network_estimate = match self.routing_table().network_size_estimate() {
                 (n, true) => format!("Exact network size: {}", n),
@@ -406,7 +405,16 @@ impl Node {
             }
             CrustEvent::ListenerStarted(port) => {
                 trace!("{:?} Listener started on port {}.", self, port);
-                self.crust_service.set_service_discovery_listen(true);
+                // If first node, allow other peers to bootstrap via us
+                // else wait until NodeApproval.
+                if self.is_first_node {
+                    if let Err(err) = self.crust_service.set_accept_bootstrap(true) {
+                        warn!("{:?} Unable to accept bootstrap connections. {:?}",
+                              self,
+                              err);
+                    }
+                    self.crust_service.set_service_discovery_listen(true);
+                }
                 return Transition::Stay;
             }
             CrustEvent::ListenerFailed => {
@@ -491,16 +499,7 @@ impl Node {
         }
 
         self.peer_mgr.connected_to(&pub_id);
-
-        let id_type = if self.is_approved {
-            "NodeIdentify"
-        } else {
-            "CandidateIdentify"
-        };
-        debug!("{:?} Received ConnectSuccess from {}. Sending {}.",
-               self,
-               pub_id,
-               id_type);
+        debug!("{:?} Received ConnectSuccess from {}.", self, pub_id);
         self.process_connection(pub_id, outbox);
     }
 
@@ -1273,6 +1272,15 @@ impl Node {
         trace!("{:?} Node approval completed. Prefixes: {:?}",
                self,
                self.routing_table().prefixes());
+
+        // Allow other peers to bootstrap via us.
+        if let Err(err) = self.crust_service.set_accept_bootstrap(true) {
+            warn!("{:?} Unable to accept bootstrap connections. {:?}",
+                  self,
+                  err);
+        }
+        self.crust_service.set_service_discovery_listen(true);
+
         self.print_rt_size();
         self.stats.enable_logging();
 
@@ -1476,9 +1484,6 @@ impl Node {
         if self.peer_mgr
                .get_peer(new_pub_id)
                .map_or(false, |peer| peer.valid()) {
-            debug!("{:?} Switching CandidateIdentify received from {} to NodeIdentify.",
-                   self,
-                   new_pub_id);
             self.process_connection(*new_pub_id, outbox);
             return;
         }
@@ -1601,7 +1606,7 @@ impl Node {
             self.merge_if_necessary(outbox);
         }
 
-        debug!("{:?} Added {:?} to routing table.", self, pub_id);
+        info!("{:?} Added {} to routing table.", self, pub_id);
         if self.is_first_node && self.routing_table().len() == 1 {
             trace!("{:?} Node approval completed. Prefixes: {:?}",
                    self,
@@ -2183,14 +2188,18 @@ impl Node {
                              -> Result<(), RoutingError> {
         trace!("{:?} Got section update for {:?}", self, ver_pfx);
 
+        let old_prefixes = self.routing_table().prefixes();
         // Perform splits and merges that we missed, according to the section update.
         for pub_id in self.peer_mgr.add_prefix(ver_pfx) {
             self.disconnect_peer(&pub_id, Some(outbox));
-            info!("{:?} Dropped {} from the routing table.", self, pub_id);
         }
-        info!("{:?} SectionUpdate handled. Prefixes: {:?}",
-              self,
-              self.routing_table().prefixes());
+
+        let new_prefixes = self.routing_table().prefixes();
+        if old_prefixes != new_prefixes {
+            info!("{:?} SectionUpdate handled. Prefixes: {:?}",
+                  self,
+                  new_prefixes);
+        }
         // Filter list of members to just those we don't know about:
         let members = if let Some(section) = self.routing_table()
                .section_with_prefix(ver_pfx.prefix()) {
@@ -3050,7 +3059,7 @@ impl Node {
                             details: RemovalDetails<XorName>,
                             outbox: &mut EventBox)
                             -> bool {
-        info!("{:?} Dropped {:?} from the routing table.",
+        info!("{:?} Dropped {} from the routing table.",
               self,
               details.name);
 


### PR DESCRIPTION
- This will allow external reachability check to succeed when bootstrapping as a CrustUser::Node role.
- Enable Service discovery as first node on startup and in other cases only after NodeApproval completes successfully.
- Also fix log format for node add/remove to RT and RT size msg.
- Remove redundant log/comments about NodeIdentify.