### PR TITLE
Make mutable data validation more strict

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -20,8 +20,8 @@ mod mutable_data;
 
 pub use self::immutable_data::{ImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES};
 pub use self::mutable_data::{Action, EntryAction, EntryActions, MAX_MUTABLE_DATA_ENTRIES,
-                             MAX_MUTABLE_DATA_ENTRY_ACTIONS, MAX_MUTABLE_DATA_SIZE_IN_BYTES,
-                             MutableData, PermissionSet, User, Value};
+                             MAX_MUTABLE_DATA_SIZE_IN_BYTES, MutableData, PermissionSet, User,
+                             Value};
 use rust_sodium::crypto::sign::{self, PublicKey};
 
 /// A signing key with no matching private key. Passing ownership to it will make a chunk

--- a/src/data/mutable_data.rs
+++ b/src/data/mutable_data.rs
@@ -30,9 +30,6 @@ pub const MAX_MUTABLE_DATA_SIZE_IN_BYTES: u64 = 1024 * 1024;
 /// Maximum allowed entries in `MutableData`
 pub const MAX_MUTABLE_DATA_ENTRIES: u64 = 100;
 
-/// Manimum number of entries that can be mutated simulaneously.
-pub const MAX_MUTABLE_DATA_ENTRY_ACTIONS: u64 = 10;
-
 /// Mutable data.
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct MutableData {
@@ -307,10 +304,6 @@ impl MutableData {
                           actions: BTreeMap<Vec<u8>, EntryAction>,
                           requester: PublicKey)
                           -> Result<(), ClientError> {
-        if actions.len() > MAX_MUTABLE_DATA_ENTRY_ACTIONS as usize {
-            return Err(ClientError::TooManyEntries);
-        }
-
         // Deconstruct actions into inserts, updates, and deletes
         let (insert, update, delete) = actions
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,9 +222,8 @@ pub use client::Client;
 pub use client_error::ClientError;
 pub use common_types::AccountPacket;
 pub use data::{Action, EntryAction, EntryActions, ImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES,
-               MAX_MUTABLE_DATA_ENTRIES, MAX_MUTABLE_DATA_ENTRY_ACTIONS,
-               MAX_MUTABLE_DATA_SIZE_IN_BYTES, MutableData, NO_OWNER_PUB_KEY, PermissionSet, User,
-               Value};
+               MAX_MUTABLE_DATA_ENTRIES, MAX_MUTABLE_DATA_SIZE_IN_BYTES, MutableData,
+               NO_OWNER_PUB_KEY, PermissionSet, User, Value};
 pub use error::{InterfaceError, RoutingError};
 pub use event::Event;
 pub use event_stream::EventStream;


### PR DESCRIPTION
It should no longer be possible to exceed the limits using the operations that perform validation (`mutate_entries`, `set_user_permissions`, ...).