### PR TITLE
MAID-2080: update handling of bootstrapping nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
       (
         set -x;
         cargo clippy &&
-        cargo clippy --features=use-mock-crust &&
+        cargo clippy --features="$TEST_FEATURES" &&
         cargo clippy --profile=test &&
-        cargo clippy --profile=test --features=use-mock-crust
+        cargo clippy --profile=test --features="$TEST_FEATURES"
       );
     fi
 before_cache:

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -110,23 +110,15 @@ pub enum DirectMessage {
     MessageSignature(Digest256, sign::Signature),
     /// A signature for the current `BTreeSet` of section's node names
     SectionListSignature(SectionList, sign::Signature),
-    /// Sent from the bootstrap node to a client in response to `ClientIdentify`.
-    BootstrapIdentify,
-    /// Sent to the client to indicate that this node is not available as a bootstrap node.
-    BootstrapDeny,
-    /// Sent from a newly connected client to the bootstrap node to inform it about the client's
-    /// public ID.
-    ClientIdentify {
-        /// Serialised keys and claimed name.
-        serialised_public_id: Vec<u8>,
-        /// Signature of the client.
-        signature: sign::Signature,
-        /// Indicate whether we intend to remain a client, as opposed to becoming a routing node.
-        client_restriction: bool,
-    },
+    /// Sent from a newly connected client to the bootstrap node to prove that it is the owner of
+    /// the client's claimed public ID.
+    BootstrapRequest(sign::Signature),
+    /// Sent from the bootstrap node to a client in response to `BootstrapRequest`. If `true`,
+    /// bootstrapping is successful; if `false` the sender is not available as a bootstrap node.
+    BootstrapResponse(bool),
     /// Sent from a node which is still joining the network to another node, to allow the latter to
     /// add the former to its routing table.
-    CandidateIdentify {
+    CandidateInfo {
         /// `PublicId` from before relocation.
         old_public_id: PublicId,
         /// `PublicId` from after relocation.
@@ -498,12 +490,12 @@ impl RoutingMessage {
 /// ## Bootstrapping a client
 ///
 /// A newly created `Core`, A, starts in `Disconnected` state and tries to establish a connection to
-/// any node B of the network via Crust. When successful, i. e. when receiving an `OnConnect` event,
+/// any node B of the network via Crust. When successful, i.e. when receiving an `OnConnect` event,
 /// it moves to the `Bootstrapping` state.
 ///
-/// A now sends a `ClientIdentify` message to B, containing A's signed public ID. B verifies the
-/// signature and responds with a `BootstrapIdentify`, containing B's public ID. Once it receives
-/// that, A goes into the `Client` state and uses B as its proxy to the network.
+/// A now sends a `BootstrapRequest` message to B, containing the signature of A's public ID. B
+/// responds with a `BootstrapResponse`, indicating success or failure. Once it receives that, A
+/// goes into the `Client` state and uses B as its proxy to the network.
 ///
 /// A can now exchange messages with any `Authority`. This completes the bootstrap process for
 /// clients.
@@ -541,7 +533,7 @@ impl RoutingMessage {
 ///
 ///
 /// ### Resource Proof Evaluation to approve
-/// When nodes Z of section Y receive `CandidateIdentify` from A, they reply with a `ResourceProof`
+/// When nodes Z of section Y receive `CandidateInfo` from A, they reply with a `ResourceProof`
 /// request. Node A needs to answer these requests (resolving a hashing challenge) with
 /// `ResourceProofResponse`. Members of Y will send out `CandidateApproval` messages to vote for the
 /// approval in their section. Once the vote succeeds, the members of Y send `NodeApproval` to A and
@@ -699,15 +691,9 @@ impl Debug for DirectMessage {
             SectionListSignature(ref sec_list, _) => {
                 write!(formatter, "SectionListSignature({:?}, ..)", sec_list.prefix)
             }
-            BootstrapIdentify => write!(formatter, "BootstrapIdentify"),
-            BootstrapDeny => write!(formatter, "BootstrapDeny"),
-            ClientIdentify { client_restriction: true, .. } => {
-                write!(formatter, "ClientIdentify (client only)")
-            }
-            ClientIdentify { client_restriction: false, .. } => {
-                write!(formatter, "ClientIdentify (joining node)")
-            }
-            CandidateIdentify { .. } => write!(formatter, "CandidateIdentify {{ .. }}"),
+            BootstrapRequest(_) => write!(formatter, "BootstrapRequest"),
+            BootstrapResponse(ref result) => write!(formatter, "BootstrapResponse({})", result),
+            CandidateInfo { .. } => write!(formatter, "CandidateInfo {{ .. }}"),
             TunnelRequest(pub_id) => write!(formatter, "TunnelRequest({:?})", pub_id),
             TunnelSuccess(pub_id) => write!(formatter, "TunnelSuccess({:?})", pub_id),
             TunnelSelect(pub_id) => write!(formatter, "TunnelSelect({:?})", pub_id),

--- a/src/mock_crypto.rs
+++ b/src/mock_crypto.rs
@@ -17,11 +17,10 @@
 
 //! Mock cryptographic primitives.
 //!
-//! These primitives are designed to be very fast (several times faster than the
-//! real ones), but they are NOT secure. They are supposed to be used for testing
-//! only.
+//! These primitives are designed to be very fast (several times faster than the real ones), but
+//! they are NOT secure. They are supposed to be used for testing only.
 
-/// Mock version of a subset of the rust_sodium crate.
+/// Mock version of a subset of the `rust_sodium` crate.
 pub mod rust_sodium {
     use rand::{Rng, SeedableRng, XorShiftRng};
     use std::cell::RefCell;
@@ -30,13 +29,13 @@ pub mod rust_sodium {
         static RNG: RefCell<XorShiftRng> = RefCell::new(XorShiftRng::new_unseeded());
     }
 
-    /// Initialize mock rust_sodium.
+    /// Initialise mock `rust_sodium`.
     pub fn init() -> bool {
         true
     }
 
-    /// Initialize mock rust_sodium with the given random number generator.
-    /// This can be used to guarantee reproducible test results.
+    /// Initialise mock `rust_sodium` with the given random number generator. This can be used to
+    /// guarantee reproducible test results.
     pub fn init_with_rng<T: Rng>(other: &mut T) -> Result<(), i32> {
         RNG.with(|rng| rng.borrow_mut().reseed(other.gen()));
         Ok(())
@@ -58,8 +57,8 @@ pub mod rust_sodium {
             pub const SIGNATUREBYTES: usize = 32;
 
             /// Mock signing public key.
-            #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq,
-                     PartialOrd, Serialize)]
+            #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd,
+                     Serialize)]
             pub struct PublicKey(pub [u8; PUBLICKEYBYTES]);
 
             impl Index<RangeFull> for PublicKey {
@@ -74,8 +73,8 @@ pub mod rust_sodium {
             pub struct SecretKey(pub [u8; SECRETKEYBYTES]);
 
             /// Mock signature.
-            #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, Serialize,
-                     PartialEq, PartialOrd)]
+            #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, Serialize, PartialEq,
+                     PartialOrd)]
             pub struct Signature(pub [u8; SIGNATUREBYTES]);
 
             impl AsRef<[u8]> for Signature {
@@ -99,8 +98,7 @@ pub mod rust_sodium {
                 Signature(hash256(&temp))
             }
 
-            /// Verify the mock signature against the message and the signer's mock
-            /// public key.
+            /// Verify the mock signature against the message and the signer's mock public key.
             pub fn verify_detached(signature: &Signature, m: &[u8], pk: &PublicKey) -> bool {
                 let mut temp = m.to_vec();
                 temp.extend(&pk.0);
@@ -118,7 +116,7 @@ pub mod rust_sodium {
             use super::super::with_rng;
             use rand::Rng;
 
-            /// Number of bytes in a 'PublicKey`.
+            /// Number of bytes in a `PublicKey`.
             pub const PUBLICKEYBYTES: usize = 32;
             /// Number of bytes in a `SecretKey`.
             pub const SECRETKEYBYTES: usize = 32;
@@ -126,8 +124,8 @@ pub mod rust_sodium {
             pub const NONCEBYTES: usize = 4;
 
             /// Mock public key for asymmetric encryption/decryption.
-            #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq,
-                     PartialOrd, Serialize)]
+            #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd,
+                     Serialize)]
             pub struct PublicKey(pub [u8; PUBLICKEYBYTES]);
 
             /// Mock secret key for asymmetric encryption/decryption.
@@ -150,8 +148,8 @@ pub mod rust_sodium {
                 with_rng(|rng| Nonce(rng.gen()))
             }
 
-            /// Perform mock encryption of the given message using their public key,
-            /// our secret key and nonce.
+            /// Perform mock encryption of the given message using their public key, our secret key
+            /// and nonce.
             pub fn seal(m: &[u8], nonce: &Nonce, pk: &PublicKey, sk: &SecretKey) -> Vec<u8> {
                 let mut result = Vec::with_capacity(m.len() + nonce.0.len() + pk.0.len() +
                                                     sk.0.len());
@@ -162,8 +160,8 @@ pub mod rust_sodium {
                 result
             }
 
-            /// Perform mock decryption of the given ciphertext using their secret key,
-            /// our public key and nonce.
+            /// Perform mock decryption of the given ciphertext using their secret key, our public
+            /// key and nonce.
             pub fn open(c: &[u8],
                         nonce: &Nonce,
                         pk: &PublicKey,
@@ -185,7 +183,7 @@ pub mod rust_sodium {
                     return Err(());
                 }
 
-                return Ok(c[n + p + s..].to_vec());
+                Ok(c[n + p + s..].to_vec())
             }
         }
     }

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -73,8 +73,6 @@ const SU_MAX_TIMEOUT_SECS: u64 = 300;
 const CANDIDATE_STATUS_INTERVAL_SECS: u64 = 60;
 /// Duration for which `OwnSectionMerge` messages are kept in the cache, in seconds.
 const MERGE_TIMEOUT_SECS: u64 = 300;
-/// Duration for which to hold the bootstrappers, in seconds.
-const BOOTSTRAPPER_HOLD_DUR_SECS: u64 = 300;
 
 pub struct Node {
     ack_mgr: AckManager,
@@ -117,8 +115,6 @@ pub struct Node {
     candidate_timer_token: Option<u64>,
     /// The timer token for displaying the current candidate status.
     candidate_status_token: Option<u64>,
-    /// Hold the kind of bootstrappers.
-    bootstrappers: LruCache<PublicId, CrustUser>,
     resource_prover: ResourceProver,
     joining_prefix: Prefix<XorName>,
 }
@@ -230,8 +226,6 @@ impl Node {
             our_merged_section: Default::default(),
             candidate_timer_token: None,
             candidate_status_token: None,
-            bootstrappers:
-                LruCache::with_expiry_duration(Duration::from_secs(BOOTSTRAPPER_HOLD_DUR_SECS)),
             resource_prover: ResourceProver::new(action_sender, timer, challenger_count),
             joining_prefix: Default::default(),
         }
@@ -458,15 +452,16 @@ impl Node {
                self,
                pub_id,
                peer_kind);
-        if let Some(peer) = self.bootstrappers.insert(pub_id, peer_kind) {
-            trace!("{:?} Replacing Bootstrapper {:?} who was previously registered as {:?}",
-                   self,
-                   pub_id,
-                   peer);
+        if peer_kind == CrustUser::Node && !self.crust_service.is_peer_whitelisted(&pub_id) {
+            warn!("{:?} {:?} is bootstrapping as a node, but is not in whitelist.",
+                  self,
+                  pub_id);
+            self.disconnect_peer(&pub_id, None);
+            return;
         }
         self.peer_mgr
             .insert_peer(Peer::new(pub_id,
-                                   PeerState::Connected(false),
+                                   PeerState::Bootstrapper(peer_kind),
                                    false,
                                    ReconnectingPeer::False));
     }
@@ -598,52 +593,26 @@ impl Node {
                              outbox: &mut EventBox)
                              -> Result<(), RoutingError> {
         use messages::DirectMessage::*;
+        if let Err(error) = self.check_direct_message_sender(&direct_message, &pub_id) {
+            self.disconnect_peer(&pub_id, Some(outbox));
+            return Err(error);
+        }
+
         match direct_message {
             MessageSignature(digest, sig) => self.handle_message_signature(digest, sig, pub_id)?,
             SectionListSignature(section_list, sig) => {
                 self.handle_section_list_signature(pub_id, section_list, sig)?
             }
-            ClientIdentify {
-                ref serialised_public_id,
-                ref signature,
-                client_restriction,
-            } => {
-                let drop = match self.bootstrappers.remove(&pub_id) {
-                    Some(kind) => {
-                        if kind == CrustUser::Client && client_restriction ||
-                           kind == CrustUser::Node && !client_restriction {
-                            false
-                        } else {
-                            debug!("{:?} Peer bootstrapped to us as {:?} but is sending messages \
-                                    as a with client_restriction: {}",
-                                   self,
-                                   kind,
-                                   client_restriction);
-                            true
-                        }
-                    }
-                    None => {
-                        debug!("{:?} No mention of peer {} as a bootstrapper", self, pub_id);
-                        true
-                    }
-                };
-                if drop {
-                    return Ok(self.disconnect_peer(&pub_id, Some(outbox)));
-                }
-
-                match verify_signed_public_id(serialised_public_id, signature) {
-                    Ok(signed_pub_id) if signed_pub_id == pub_id => {
-                        self.handle_client_identify(pub_id, client_restriction, outbox)
-                    }
-                    _ => {
-                        warn!("{:?} Invalid ClientIdentify received, dropping {}.",
-                              self,
-                              pub_id);
-                        self.disconnect_peer(&pub_id, Some(outbox));
-                    }
+            BootstrapRequest(signature) => {
+                if let Err(error) = self.handle_bootstrap_request(pub_id, signature, outbox) {
+                    warn!("{:?} Invalid BootstrapRequest received ({:?}), dropping {}.",
+                          self,
+                          error,
+                          pub_id);
+                    self.disconnect_peer(&pub_id, Some(outbox));
                 }
             }
-            CandidateIdentify {
+            CandidateInfo {
                 ref old_public_id,
                 ref new_public_id,
                 ref signature_using_old,
@@ -651,19 +620,19 @@ impl Node {
                 ref new_client_auth,
             } => {
                 if *new_public_id != pub_id {
-                    error!("{:?} CandidateIdentify(new_public_id: {}) does not match crust id {}.",
+                    error!("{:?} CandidateInfo(new_public_id: {}) does not match crust id {}.",
                            self,
                            new_public_id,
                            pub_id);
                     self.disconnect_peer(&pub_id, Some(outbox));
                     return Err(RoutingError::InvalidSource);
                 }
-                self.handle_candidate_identify(old_public_id,
-                                               &pub_id,
-                                               signature_using_old,
-                                               signature_using_new,
-                                               new_client_auth,
-                                               outbox);
+                self.handle_candidate_info(old_public_id,
+                                           &pub_id,
+                                           signature_using_old,
+                                           signature_using_new,
+                                           new_client_auth,
+                                           outbox);
             }
             TunnelRequest(dst_id) => self.handle_tunnel_request(pub_id, dst_id),
             TunnelSuccess(dst_id) => self.handle_tunnel_success(pub_id, dst_id, outbox),
@@ -696,12 +665,47 @@ impl Node {
                                                     proof,
                                                     leading_zero_bytes);
             }
-            msg @ BootstrapIdentify { .. } |
-            msg @ BootstrapDeny => {
+            msg @ BootstrapResponse(_) => {
                 debug!("{:?} Unhandled direct message: {:?}", self, msg);
             }
         }
         Ok(())
+    }
+
+    /// Returns `Ok` if the peer's state indicates it's allowed to send the given message type.
+    fn check_direct_message_sender(&self,
+                                   direct_message: &DirectMessage,
+                                   pub_id: &PublicId)
+                                   -> Result<(), RoutingError> {
+        use messages::DirectMessage::*;
+        if let Some(peer) = self.peer_mgr.get_peer(pub_id) {
+            match *peer.state() {
+                PeerState::Bootstrapper(_) => {
+                    match *direct_message {
+                        BootstrapRequest(_) => return Ok(()),
+                        CandidateInfo { .. } |
+                        MessageSignature(..) |
+                        SectionListSignature(..) |
+                        BootstrapResponse(_) |
+                        TunnelRequest(_) |
+                        TunnelSuccess(_) |
+                        TunnelSelect(_) |
+                        TunnelClosed(_) |
+                        TunnelDisconnect(_) |
+                        ResourceProof { .. } |
+                        ResourceProofResponse { .. } |
+                        ResourceProofResponseReceipt => (),
+                    }
+                }
+                PeerState::Client => (),
+                _ => return Ok(()),
+            }
+        }
+        debug!("{:?} Illegitimate direct message {:?} from {:?}.",
+               self,
+               direct_message,
+               pub_id);
+        Err(RoutingError::InvalidStateForOperation)
     }
 
     /// Handles a signature of a `SignedMessage`, and if we have enough to verify the signed
@@ -836,24 +840,30 @@ impl Node {
                           hop_msg: HopMessage,
                           pub_id: PublicId)
                           -> Result<(), RoutingError> {
-        let hop_name = if let Some(peer) = self.peer_mgr.get_peer(&pub_id) {
+        let hop_name_result = if let Some(peer) = self.peer_mgr.get_peer(&pub_id) {
             hop_msg.verify(peer.pub_id().signing_public_key())?;
 
             match *peer.state() {
-                PeerState::Client => {
-                    self.check_valid_client_message(hop_msg.content.routing_message())?;
-                    *self.name()
+                PeerState::Bootstrapper(_) => {
+                    warn!("{:?} Hop message received from bootstrapper {:?}, disconnecting.",
+                          self,
+                          pub_id);
+                    Err(RoutingError::InvalidStateForOperation)
                 }
-                PeerState::JoiningNode => *self.name(),
+                PeerState::Client => {
+                    self.check_valid_client_message(hop_msg.content.routing_message())
+                        .map(|_| *self.name())
+                }
+                PeerState::JoiningNode => Ok(*self.name()),
                 PeerState::Candidate(_) |
                 PeerState::Proxy |
-                PeerState::Routing(_) => *peer.name(),
+                PeerState::Routing(_) => Ok(*peer.name()),
                 PeerState::ConnectionInfoPreparing { .. } |
                 PeerState::ConnectionInfoReady(_) |
                 PeerState::CrustConnecting |
                 PeerState::SearchingForTunnel |
                 PeerState::Connected(_) => {
-                    *self.name()
+                    Ok(*self.name())
                     // FIXME - confirm we can return with an error here by running soak tests
                     // debug!("{:?} Invalid sender {} of {:?}", self, pub_id, hop_msg);
                     // return Err(RoutingError::InvalidSource);
@@ -866,17 +876,22 @@ impl Node {
             // //        could be handling a tunnelled message here immediately after the tunnel
             // //        closed. Since we no longer have the peer's name available, we just use our
             // //        own instead, as this is almost equivalent to passing no name at all.
-            *self.name()
+            Ok(*self.name())
             // return Err(RoutingError::UnknownConnection);
         };
 
-        let HopMessage {
-            content,
-            route,
-            sent_to,
-            ..
-        } = hop_msg;
-        self.handle_signed_message(content, route, hop_name, &sent_to)
+        if let Ok(hop_name) = hop_name_result {
+            let HopMessage {
+                content,
+                route,
+                sent_to,
+                ..
+            } = hop_msg;
+            self.handle_signed_message(content, route, hop_name, &sent_to)
+        } else {
+            self.disconnect_peer(&pub_id, None);
+            Err(RoutingError::InvalidStateForOperation)
+        }
     }
 
     // Acknowledge reception of the message and broadcast to our section if necessary
@@ -1351,11 +1366,10 @@ impl Node {
 
     /// Returns `Ok` if a client is allowed to send the given message.
     fn check_valid_client_message(&self, msg: &RoutingMessage) -> Result<(), RoutingError> {
-        match msg.content {
-            MessageContent::Ack(..) => Ok(()),
-            MessageContent::UserMessagePart { priority, .. } if priority >= DEFAULT_PRIORITY => {
-                Ok(())
-            }
+        match (&msg.src, &msg.content) {
+            (&Authority::Client { .. }, &MessageContent::Ack(..)) => Ok(()),
+            (&Authority::Client { .. }, &MessageContent::UserMessagePart { priority, .. })
+                if priority >= DEFAULT_PRIORITY => Ok(()),
             _ => {
                 debug!("{:?} Illegitimate client message {:?}. Refusing to relay.",
                        self,
@@ -1411,15 +1425,26 @@ impl Node {
         Ok(false)
     }
 
-    fn handle_client_identify(&mut self,
-                              pub_id: PublicId,
-                              client_restriction: bool,
-                              outbox: &mut EventBox) {
-        if !client_restriction && !self.crust_service.is_peer_whitelisted(&pub_id) {
-            warn!("{:?} Client is not whitelisted, so dropping connection.",
-                  self);
-            self.disconnect_peer(&pub_id, Some(outbox));
-            return;
+    // If this returns an error, the peer will be dropped.
+    fn handle_bootstrap_request(&mut self,
+                                pub_id: PublicId,
+                                signature: sign::Signature,
+                                outbox: &mut EventBox)
+                                -> Result<(), RoutingError> {
+        let peer_kind = if let Some(peer) = self.peer_mgr.get_peer(&pub_id) {
+            match *peer.state() {
+                PeerState::Bootstrapper(peer_kind) => peer_kind,
+                _ => {
+                    return Err(RoutingError::InvalidStateForOperation);
+                }
+            }
+        } else {
+            return Err(RoutingError::UnknownConnection(pub_id));
+        };
+
+        let ser_pub_id = serialisation::serialise(&pub_id)?;
+        if !sign::verify_detached(&signature, &ser_pub_id, pub_id.signing_public_key()) {
+            return Err(RoutingError::FailedSignature);
         }
 
         self.remove_expired_peers(outbox);
@@ -1428,59 +1453,50 @@ impl Node {
             debug!("{:?} Client {:?} rejected: We are not approved as a node yet.",
                    self,
                    pub_id);
-            self.send_direct_message(pub_id, DirectMessage::BootstrapDeny);
-            return;
+            self.send_direct_message(pub_id, DirectMessage::BootstrapResponse(false));
+            return Ok(());
         }
 
-        if (client_restriction || !self.is_first_node) &&
+        if (peer_kind == CrustUser::Client || !self.is_first_node) &&
            self.routing_table().len() < self.min_section_size() - 1 {
             debug!("{:?} Client {:?} rejected: Routing table has {} entries. {} required.",
                    self,
                    pub_id,
                    self.routing_table().len(),
                    self.min_section_size() - 1);
-            self.send_direct_message(pub_id, DirectMessage::BootstrapDeny);
-            return;
+            self.send_direct_message(pub_id, DirectMessage::BootstrapResponse(false));
+            return Ok(());
         }
 
-        let peer_state = if client_restriction {
-            debug!("{:?} Accepted Client {}.", self, pub_id);
-            PeerState::Client
-        } else {
-            debug!("{:?} Accepted JoiningNode {}.", self, pub_id);
-            PeerState::JoiningNode
-        };
-
-        self.peer_mgr
-            .insert_peer(Peer::new(pub_id, peer_state, false, ReconnectingPeer::False));
-
-        self.send_direct_message(pub_id, DirectMessage::BootstrapIdentify);
+        self.peer_mgr.handle_bootstrap_request(&pub_id);
+        self.send_direct_message(pub_id, DirectMessage::BootstrapResponse(true));
+        Ok(())
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-    fn handle_candidate_identify(&mut self,
-                                 old_pub_id: &PublicId,
-                                 new_pub_id: &PublicId,
-                                 signature_using_old: &sign::Signature,
-                                 signature_using_new: &sign::Signature,
-                                 new_client_auth: &Authority<XorName>,
-                                 outbox: &mut EventBox) {
-        debug!("{:?} Handling CandidateIdentify from {}->{}.",
+    fn handle_candidate_info(&mut self,
+                             old_pub_id: &PublicId,
+                             new_pub_id: &PublicId,
+                             signature_using_old: &sign::Signature,
+                             signature_using_new: &sign::Signature,
+                             new_client_auth: &Authority<XorName>,
+                             outbox: &mut EventBox) {
+        debug!("{:?} Handling CandidateInfo from {}->{}.",
                self,
                old_pub_id,
                new_pub_id);
-        if !self.is_candidate_identify_valid(old_pub_id,
-                                             new_pub_id,
-                                             signature_using_old,
-                                             signature_using_new) {
-            warn!("{:?} Signature check failed in CandidateIdentify, so dropping peer {:?}.",
+        if !self.is_candidate_info_valid(old_pub_id,
+                                         new_pub_id,
+                                         signature_using_old,
+                                         signature_using_new) {
+            warn!("{:?} Signature check failed in CandidateInfo, so dropping peer {:?}.",
                   self,
                   new_pub_id);
             self.disconnect_peer(new_pub_id, Some(outbox));
         }
 
-        // If this is a valid node in peer_mgr but the Candidate has sent us a CandidateIdentify,
-        // it might have not yet handled its NodeApproval message. Check and handle accordingly here
+        // If this is a valid node in peer_mgr but the Candidate has sent us a CandidateInfo, it
+        // might have not yet handled its NodeApproval message. Check and handle accordingly here
         if self.peer_mgr
                .get_peer(new_pub_id)
                .map_or(false, |peer| peer.valid()) {
@@ -1501,12 +1517,12 @@ impl Node {
             rand::thread_rng().gen_iter().take(10).collect()
         };
         match self.peer_mgr
-                  .handle_candidate_identify(old_pub_id,
-                                             new_pub_id,
-                                             new_client_auth,
-                                             target_size,
-                                             difficulty,
-                                             seed.clone()) {
+                  .handle_candidate_info(old_pub_id,
+                                         new_pub_id,
+                                         new_client_auth,
+                                         target_size,
+                                         difficulty,
+                                         seed.clone()) {
             Ok(true) => {
                 let direct_message = DirectMessage::ResourceProof {
                     seed: seed,
@@ -1534,7 +1550,7 @@ impl Node {
                        new_pub_id);
             }
             Err(error) => {
-                debug!("{:?} Ignore CandidateIdentify {}->{}: {:?}.",
+                debug!("{:?} Ignore CandidateInfo {}->{}: {:?}.",
                        self,
                        old_pub_id,
                        new_pub_id,
@@ -1543,12 +1559,12 @@ impl Node {
         }
     }
 
-    fn is_candidate_identify_valid(&self,
-                                   old_pub_id: &PublicId,
-                                   new_pub_id: &PublicId,
-                                   signature_using_old: &sign::Signature,
-                                   signature_using_new: &sign::Signature)
-                                   -> bool {
+    fn is_candidate_info_valid(&self,
+                               old_pub_id: &PublicId,
+                               new_pub_id: &PublicId,
+                               signature_using_old: &sign::Signature,
+                               signature_using_new: &sign::Signature)
+                               -> bool {
         let old_and_new_pub_ids = (old_pub_id, new_pub_id);
         let mut signed_data = match serialisation::serialise(&old_and_new_pub_ids) {
             Ok(result) => result,
@@ -1560,7 +1576,7 @@ impl Node {
         if !sign::verify_detached(signature_using_old,
                                   &signed_data,
                                   old_pub_id.signing_public_key()) {
-            debug!("{:?} CandidateIdentify from {}->{} has invalid old signature.",
+            debug!("{:?} CandidateInfo from {}->{} has invalid old signature.",
                    self,
                    old_pub_id,
                    new_pub_id);
@@ -1570,7 +1586,7 @@ impl Node {
         if !sign::verify_detached(signature_using_new,
                                   &signed_data,
                                   new_pub_id.signing_public_key()) {
-            debug!("{:?} CandidateIdentify from {}->{} has invalid new signature.",
+            debug!("{:?} CandidateInfo from {}->{} has invalid new signature.",
                    self,
                    old_pub_id,
                    new_pub_id);
@@ -2886,9 +2902,8 @@ impl Node {
             return;
         }
 
-        // If we're not approved yet, we need to identify ourselves
-        // with our old and new ids via CandidateIdentify
-        // Serialise the old and new `PublicId`s and sign this using the old key.
+        // If we're not approved yet, we need to identify ourselves with our old and new IDs via
+        // `CandidateInfo`. Serialise the old and new `PublicId`s and sign this using the old key.
         let msg = {
             let old_and_new_pub_ids = (self.old_full_id.public_id(), self.full_id.public_id());
             let mut to_sign = match serialisation::serialise(&old_and_new_pub_ids) {
@@ -2907,7 +2922,7 @@ impl Node {
             let proxy_node_name = if let Some(proxy_node_name) = self.peer_mgr.get_proxy_name() {
                 *proxy_node_name
             } else {
-                warn!("{:?} No proxy found, so unable to send CandidateIdentify.",
+                warn!("{:?} No proxy found, so unable to send CandidateInfo.",
                       self);
                 return;
             };
@@ -2916,7 +2931,7 @@ impl Node {
                 proxy_node_name: proxy_node_name,
             };
 
-            DirectMessage::CandidateIdentify {
+            DirectMessage::CandidateInfo {
                 old_public_id: *self.old_full_id.public_id(),
                 new_public_id: *self.full_id.public_id(),
                 signature_using_old: signature_using_old,
@@ -2939,7 +2954,6 @@ impl Node {
                                     -> Result<(), RoutingError> {
         let their_name = *their_public_id.name();
         self.peer_mgr.allow_connect(&their_name)?;
-
 
         if self.peer_mgr.is_client(&their_public_id) ||
            self.peer_mgr.is_joining_node(&their_public_id) ||
@@ -3394,18 +3408,5 @@ impl Bootstrapped for Node {
 impl Debug for Node {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "Node({}({:b}))", self.name(), self.our_prefix())
-    }
-}
-
-// Verify the serialised public id against the signature.
-fn verify_signed_public_id(serialised_public_id: &[u8],
-                           signature: &sign::Signature)
-                           -> Result<PublicId, RoutingError> {
-    let public_id: PublicId = serialisation::deserialise(serialised_public_id)?;
-    let public_key = public_id.signing_public_key();
-    if sign::verify_detached(signature, serialised_public_id, public_key) {
-        Ok(public_id)
-    } else {
-        Err(RoutingError::FailedSignature)
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -36,7 +36,7 @@ pub struct Stats {
     /// Messages we sent unsuccessfully: unacknowledged on all routes.
     unacked_msgs: usize,
 
-    msg_direct_candidate_identify: usize,
+    msg_direct_candidate_info: usize,
     msg_direct_sig: usize,
     msg_direct_resource_proof: usize,
     msg_direct_resource_proof_rsp: usize,
@@ -248,15 +248,14 @@ impl Stats {
     pub fn count_direct_message(&mut self, msg: &DirectMessage) {
         use messages::DirectMessage::*;
         match *msg {
-            CandidateIdentify { .. } => self.msg_direct_candidate_identify += 1,
+            CandidateInfo { .. } => self.msg_direct_candidate_info += 1,
             MessageSignature(..) => self.msg_direct_sig += 1,
             SectionListSignature(..) => self.msg_direct_sls += 1,
             ResourceProof { .. } => self.msg_direct_resource_proof += 1,
             ResourceProofResponse { .. } => self.msg_direct_resource_proof_rsp += 1,
             ResourceProofResponseReceipt => self.msg_direct_resource_proof_rsp_receipt += 1,
-            BootstrapIdentify { .. } |
-            BootstrapDeny |
-            ClientIdentify { .. } |
+            BootstrapRequest(_) |
+            BootstrapResponse(_) |
             TunnelRequest(_) |
             TunnelSuccess(_) |
             TunnelSelect(_) |
@@ -288,9 +287,9 @@ impl Stats {
                   self.routes,
                   self.unacked_msgs);
             info!(target: "routing_stats",
-                  "Stats - Direct - CandidateIdentify: {}, \
+                  "Stats - Direct - CandidateInfo: {}, \
                    MessageSignature: {}, ResourceProof: {}/{}/{}, SectionListSignature: {}",
-                  self.msg_direct_candidate_identify,
+                  self.msg_direct_candidate_info,
                   self.msg_direct_sig,
                   self.msg_direct_resource_proof,
                   self.msg_direct_resource_proof_rsp,


### PR DESCRIPTION
This adds a new 'PeerState' variant for bootstrapping peers which contains the type of connection
(client or node).  That's used to replace the 'bootstrappers' container in 'Node'.

There are further restrictions placed on the types of messages clients and bootstrappers can send,
and some trivial renaming changes included in this commit.