### PR TITLE
refactor/config: get config from Crust statically

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -15,7 +15,6 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use BootstrapConfig;
 use error::InterfaceError;
 use id::PublicId;
 use messages::{Request, UserMessage};
@@ -47,7 +46,6 @@ pub enum Action {
         priority: u8,
         result_tx: Sender<Result<(), InterfaceError>>,
     },
-    Config { result_tx: Sender<BootstrapConfig> },
     Id { result_tx: Sender<PublicId> },
     Timeout(u64),
     ResourceProofResult(PublicId, Vec<DirectMessage>),
@@ -72,7 +70,6 @@ impl Debug for Action {
                        content,
                        dst)
             }
-            Action::Config { .. } => write!(formatter, "Action::Config"),
             Action::Id { .. } => write!(formatter, "Action::Id"),
             Action::Timeout(token) => write!(formatter, "Action::Timeout({})", token),
             Action::ResourceProofResult(pub_id, _) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,8 @@
 use BootstrapConfig;
 use action::Action;
 use cache::NullCache;
+#[cfg(not(feature = "use-mock-crust"))]
+use crust::read_config_file;
 use data::{EntryAction, ImmutableData, MutableData, PermissionSet, User};
 use error::{InterfaceError, RoutingError};
 use event::Event;
@@ -485,11 +487,8 @@ impl Client {
     }
 
     /// Returns the bootstrap config that this client was created with.
-    pub fn bootstrap_config(&self) -> Result<BootstrapConfig, InterfaceError> {
-        let (result_tx, result_rx) = channel();
-        self.action_sender
-            .send(Action::Config { result_tx: result_tx })?;
-        Ok(result_rx.recv()?)
+    pub fn bootstrap_config() -> Result<BootstrapConfig, RoutingError> {
+        Ok(read_config_file()?)
     }
 
     fn send_request(&self,

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -30,6 +30,11 @@ use std::rc::Rc;
 /// TCP listener port
 pub const LISTENER_PORT: u16 = 5485;
 
+/// Mock version of config reader
+pub fn read_config_file() -> Result<Config, CrustError> {
+    Ok(Config::new())
+}
+
 /// Mock version of `crust::Service`
 pub struct Service<UID: Uid>(Rc<RefCell<ServiceImpl<UID>>>, Network<UID>);
 
@@ -183,11 +188,6 @@ impl<UID: Uid> Service<UID> {
     /// Our `UID`.
     pub fn id(&self) -> UID {
         unwrap!(self.lock().uid)
-    }
-
-    /// Returns the `Config` (which is unused anyway).
-    pub fn config(&self) -> Config {
-        Config::new()
     }
 
     fn lock(&self) -> RefMut<ServiceImpl<UID>> {

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -275,17 +275,6 @@ impl StateMachine {
         (action_sender, machine)
     }
 
-    // /// Returns the `crust::Config` associated with the `Service` (if any).
-    // #[cfg(feature = "use-mock-crust")]
-    // pub fn bootstrap_config(&self) -> Option<Config> {
-    //     match self.state {
-    //         State::Bootstrapping(ref s) => Some(s.config()),
-    //         State::Client(ref s) => Some(s.config()),
-    //         State::Node(ref s) => Some(s.config()),
-    //         State::Terminated => None,
-    //     }
-    // }
-
     fn handle_event(&mut self, category: MaidSafeEventCategory, outbox: &mut EventBox) {
         let transition = match category {
             MaidSafeEventCategory::Routing => {

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -115,9 +115,6 @@ impl Bootstrapping {
             Action::Id { result_tx } => {
                 let _ = result_tx.send(*self.id());
             }
-            Action::Config { result_tx } => {
-                let _ = result_tx.send(self.crust_service.config());
-            }
             Action::Timeout(token) => self.handle_timeout(token),
             Action::ResourceProofResult(..) => {
                 warn!("{:?} Cannot handle {:?} - not bootstrapped.", self, action);

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -107,9 +107,6 @@ impl Client {
             Action::Id { result_tx } => {
                 let _ = result_tx.send(*self.id());
             }
-            Action::Config { result_tx } => {
-                let _ = result_tx.send(self.crust_service.config());
-            }
             Action::Timeout(token) => self.handle_timeout(token),
             Action::ResourceProofResult(..) => {
                 error!("Action::ResourceProofResult received by Client state");

--- a/src/states/joining_node.rs
+++ b/src/states/joining_node.rs
@@ -106,9 +106,6 @@ impl JoiningNode {
             Action::Id { result_tx } => {
                 let _ = result_tx.send(*self.id());
             }
-            Action::Config { result_tx } => {
-                let _ = result_tx.send(self.crust_service.config());
-            }
             Action::Timeout(token) => {
                 if let Transition::Terminate = self.handle_timeout(token, outbox) {
                     return Transition::Terminate;

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -355,9 +355,6 @@ impl Node {
             Action::Id { result_tx } => {
                 let _ = result_tx.send(*self.id());
             }
-            Action::Config { result_tx } => {
-                let _ = result_tx.send(self.crust_service.config());
-            }
             Action::Timeout(token) => {
                 if let Transition::Terminate = self.handle_timeout(token, outbox) {
                     return Transition::Terminate;


### PR DESCRIPTION
Now the Crust config is resolved by using the new exposed function `crust::read_config_file`, so we don't
need to exchange `Action::Config` messages and get the bootstrap config from Crust services anymore.