### PR TITLE
feat/mutable-data: make errors more descriptive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ pub const ACC_LOGIN_ENTRY_KEY: &'static [u8] = b"Login";
 
 pub use cache::{Cache, NullCache};
 pub use client::Client;
-pub use client_error::ClientError;
+pub use client_error::{ClientError, EntryError};
 pub use common_types::AccountPacket;
 pub use data::{Action, EntryAction, EntryActions, ImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES,
                MAX_MUTABLE_DATA_ENTRIES, MAX_MUTABLE_DATA_SIZE_IN_BYTES, MutableData,


### PR DESCRIPTION
This PR improves the errors returned from operations on `MutableData`:

- `ClientError::InvalidSuccessor` now contains the current version, so if the client want's to re-send the request with the correct version, it doesn't have to first send additional request to fetch the version.
- new variant `ClientError::InvalidEntryActions` is returned from `mutate_entries` and it contains breakdown of the errors per entry. This makes it easier to re-send the request with corrected actions.