### PR TITLE
fix/bootstrap: enforce one client per IP only on bootstrap request

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -1056,7 +1056,6 @@ impl PeerManager {
     pub fn can_accept_client(&self, client_ip: IpAddr) -> bool {
         self.disable_client_rate_limiter ||
             !self.peers.values().any(|peer| match *peer.state() {
-                PeerState::Bootstrapper { ip, .. } |
                 PeerState::Client { ip, .. } => client_ip == ip,
                 _ => false,
             })

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -543,20 +543,6 @@ impl Node {
                 self.ban_and_disconnect_peer(&pub_id);
                 return;
             }
-            if !self.peer_mgr.can_accept_client(ip) {
-                debug!(
-                    "{:?} Client {:?} rejected: We cannot accept more clients.",
-                    self,
-                    pub_id
-                );
-                self.send_direct_message(
-                    pub_id,
-                    DirectMessage::BootstrapResponse(Err(BootstrapResponseError::ClientLimit)),
-                );
-                self.disconnect_peer(&pub_id, None);
-                let _ = self.dropped_clients.insert(pub_id, ());
-                return;
-            }
         }
         self.peer_mgr.insert_peer(Peer::new(
             pub_id,
@@ -1715,6 +1701,8 @@ impl Node {
         signature: sign::Signature,
         outbox: &mut EventBox,
     ) -> Result<(), RoutingError> {
+        self.remove_expired_peers(outbox);
+
         let peer_kind = if let Some(peer) = self.peer_mgr.get_peer(&pub_id) {
             match *peer.state() {
                 PeerState::Bootstrapper { peer_kind, .. } => peer_kind,
@@ -1726,12 +1714,36 @@ impl Node {
             return Err(RoutingError::UnknownConnection(pub_id));
         };
 
+        let ip = if let Ok(ip) = self.crust_service.get_peer_ip_addr(&pub_id) {
+            ip
+        } else {
+            debug!(
+                "{:?} Can't get IP address of bootstrapper {:?}.",
+                self,
+                pub_id
+            );
+            self.disconnect_peer(&pub_id, None);
+            return Err(RoutingError::UnknownConnection(pub_id));
+        };
+
+        if peer_kind == CrustUser::Client && !self.peer_mgr.can_accept_client(ip) {
+            debug!(
+                "{:?} Client {:?} rejected: We cannot accept more clients.",
+                self,
+                pub_id
+            );
+            self.send_direct_message(
+                pub_id,
+                DirectMessage::BootstrapResponse(Err(BootstrapResponseError::ClientLimit)),
+            );
+            self.disconnect_peer(&pub_id, None);
+            return Ok(());
+        }
+
         let ser_pub_id = serialisation::serialise(&pub_id)?;
         if !sign::verify_detached(&signature, &ser_pub_id, pub_id.signing_public_key()) {
             return Err(RoutingError::FailedSignature);
         }
-
-        self.remove_expired_peers(outbox);
 
         if !self.is_approved {
             debug!(


### PR DESCRIPTION
Due to the nature of parallel bootstrap attempts by crust it can happen that two clients with same IP successfully trigger a bootstrap accept in the same proxy but one of them decides to choose another proxy. That client will have disconnected from this proxy but the other client, C, could have decided to choose this one. So C gets a bootstrap connect. However if C was the latter of the two for this proxy and if this proxy hasn't yet realised that the first client has disconnected before it got the bootstrap accept for C, it is going to reject C on basis of one-client-per-IP rule. So C will get a disconnect event after it has received a bootstrap connect.
Moving this check to Bootstrap request should prevent this as only the ones who are interested in this proxy will be sending the bootstrap request and hence get promoted to a client.