### PR TITLE
MAID-2198: improve rate limiter

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -629,6 +629,11 @@ impl Node {
     pub fn get_user_msg_parts_count(&self) -> u64 {
         self.machine.current().get_user_msg_parts_count()
     }
+
+    /// Get the rate limiter's bandwidth usage map.
+    pub fn get_clients_usage(&self) -> BTreeMap<IpAddr, u64> {
+        unwrap!(self.machine.current().get_clients_usage())
+    }
 }
 
 #[cfg(feature = "use-mock-crust")]

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -231,6 +231,13 @@ impl State {
             _ => 0,
         }
     }
+
+    pub fn get_clients_usage(&self) -> Option<BTreeMap<IpAddr, u64>> {
+        match *self {
+            State::Node(ref state) => Some(state.get_clients_usage()),
+            _ => None,
+        }
+    }
 }
 
 /// Enum returned from many message handlers


### PR DESCRIPTION
1. Refund on overcharge for get response
1. Soft-limit for clients - `max(MAX_IMMUT_DATA_SIZE, MAX_SOFT_CAP/clients_in_rate_limiter)`

Incorporates #1508.