### PR TITLE
CI Test Run Refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,8 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-os:
-  - linux
-  - osx
 branches:
-  except:
-  - fleming
+  only: ci_test_run_refactor
 language: rust
 rust:
   - stable
@@ -18,15 +14,19 @@ before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
   - rustup component add rustfmt clippy
-script:
-  - export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
-  - set -x;
-    cargo fmt -- --check &&
-    cargo check --verbose --lib --tests &&
-    cargo check --verbose --example ci_test &&
-    cargo check --verbose --example key_value_store &&
-    cargo clippy --verbose --all-targets &&
-    cargo clippy --verbose --all-targets --features=mock &&
-    cargo test --verbose --release --features=mock
+jobs:
+  include:
+    - script: scripts/clippy
+      os: linux
+      env: CACHE_NAME=clippy_linux
+    - script: scripts/clippy
+      os: osx
+      env: CACHE_NAME=clippy_osx
+    - script: scripts/tests
+      os: linux
+      env: CACHE_NAME=tests_linux
+    - script: scripts/tests
+      os: osx
+      env: CACHE_NAME=tests_osx
 before_cache:
   - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-branches:
-  only: ci_test_run_refactor
 language: rust
 rust:
   - stable

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -142,7 +142,7 @@ Options:
             let _ = stdin.read_line(&mut command);
 
             let parts = command
-                .trim_right_matches(|c| c == '\r' || c == '\n')
+                .trim_end_matches(|c| c == '\r' || c == '\n')
                 .split(' ')
                 .collect::<Vec<_>>();
 

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x -e
+export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
+
+cargo fmt -- --check
+cargo check --verbose --lib --tests
+cargo check --verbose --example ci_test
+cargo check --verbose --example key_value_store
+cargo clippy --verbose --all-targets
+cargo clippy --verbose --all-targets --features=mock

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x -e
+export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
+
+cargo test --release --features=mock -- \
+    --skip mock_crust::churn::aggressive_churn \
+    --skip mock_crust::churn::messages_during_churn


### PR DESCRIPTION
Hi Jean/Pierre,

This now runs 4 jobs in parallel:

* Clippy on Linux
* Clippy on OSX
* Tests on Linux
* Tests on OSX

As we discussed, the 2 long-running tests have been disabled.

Here is a log with timings for the 2nd run, where the cache takes effect: 
https://travis-ci.com/jacderida/routing/builds/103562433

There is also a small fix for something clippy flagged up.

Cheers,

Chris