### PR TITLE
New direct message: ParsecPoke

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -130,6 +130,8 @@ pub enum DirectMessage {
     ResourceProofResponseReceipt,
     /// Sent from a proxy node to its client to indicate that the client exceeded its rate limit.
     ProxyRateLimitExceeded { ack: Ack },
+    /// Poke a node to send us the first gossip request
+    ParsecPoke(u64),
     /// Parsec request message
     ParsecRequest(u64, parsec::Request<NetworkEvent, PublicId>),
     /// Parsec response message
@@ -696,6 +698,7 @@ impl Debug for DirectMessage {
             }
             ParsecRequest(ref v, _) => write!(formatter, "ParsecRequest({}, _)", v),
             ParsecResponse(ref v, _) => write!(formatter, "ParsecResponse({}, _)", v),
+            ParsecPoke(ref v) => write!(formatter, "ParsecPoke({})", v),
         }
     }
 }


### PR DESCRIPTION
The purpose of this messase is that a newly joined node can ask for a gossip request with the same version it is on, even when all other members might have already moved to another version due to split.