### PR TITLE
chore/ci: update deprecated item as per clippy

### DIFF
--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -143,7 +143,7 @@ Options:
             let _ = stdin.read_line(&mut command);
 
             let parts = command
-                .trim_right_matches(|c| c == '\r' || c == '\n')
+                .trim_end_matches(|c| c == '\r' || c == '\n')
                 .split(' ')
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
To fix clippy error in CI
"error: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`"