### PR TITLE
NeighbourInfo cleanup and send ParsecPoke to all members

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -948,23 +948,16 @@ impl Chain {
                     return Some(*pfx);
                 }
 
-                let is_newer =
-                    |other: &NeighbourSigs| other.sec_info().version() > nsigs.sec_info().version();
+                // Remove older compatible neighbour prefixes.
+                let is_newer = |(other_pfx, other_sigs): (&Prefix<XorName>, &NeighbourSigs)| {
+                    other_pfx.is_compatible(pfx)
+                        && other_sigs.sec_info().version() > nsigs.sec_info().version()
+                };
 
-                // Check if we have a newer version of parent pfx.
-                let ppfx = pfx.popped();
-                if self.neighbour_infos.get(&ppfx).map_or(false, &is_newer) {
+                if self.neighbour_infos.iter().any(is_newer) {
                     return Some(*pfx);
                 }
 
-                // Check if we have a newer version of either child pfx.
-                let pfx0 = pfx.pushed(false);
-                let pfx1 = pfx.pushed(true);
-                if self.neighbour_infos.get(&pfx0).map_or(false, &is_newer)
-                    || self.neighbour_infos.get(&pfx1).map_or(false, &is_newer)
-                {
-                    return Some(*pfx);
-                }
                 None
             })
             .collect();


### PR DESCRIPTION
- Remove old compatible neighbour pfx not restricted to a strict parent/child prefix in Chain on updating neighbour_infos.
- Send ParsecPoke to all section members to prevent connection timeouts triggering invalid Offline votes while JoiningNode is getting established. This prevents invalid test failures with unaccumulated Parsec::Remove blocks.