### PR TITLE
Add mock_parsec feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1.0.8"
 
 [features]
 mock = ["lru_time_cache/fake_clock", "safe_crypto/mock"]
+mock_parsec = ["mock"]
 
 [[example]]
 bench = false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ build_script:
   - cargo check --verbose --release --lib --tests
 
 test_script:
-  - cargo test --verbose --release --features=mock
+  - cargo test --verbose --release --features=mock_parsec

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -9,3 +9,4 @@ cargo check --verbose --example ci_test
 cargo check --verbose --example key_value_store
 cargo clippy --verbose --all-targets
 cargo clippy --verbose --all-targets --features=mock
+cargo clippy --verbose --all-targets --features=mock_parsec

--- a/scripts/tests
+++ b/scripts/tests
@@ -2,5 +2,7 @@
 
 set -x -e
 export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
+DIR=`dirname "$0"`
 
-cargo test --release --features=mock_parsec
+cargo test --verbose --release --features=mock_parsec -- --skip aggressive_churn
+$DIR/travis_wait -l 1800 cargo test --verbose --release --features=mock_parsec aggressive_churn

--- a/scripts/tests
+++ b/scripts/tests
@@ -3,4 +3,4 @@
 set -x -e
 export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
 
-cargo test --release --features=mock
+cargo test --release --features=mock_parsec

--- a/scripts/travis_wait
+++ b/scripts/travis_wait
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+
+# The MIT License (MIT)
+
+# Copyright (c) 2015
+# m3t (96bd6c8bb869fe632b3650fb7156c797ef8c2a055d31dde634565f3edda485b) <mlt [at] posteo [dot] de>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Available from           https://github.com/m3t/travis_wait
+# Please report bugs at    https://github.com/m3t/travis_wait/issues
+
+# Coding (Style) Guidelines:
+# https://www.chromium.org/chromium-os/shell-style-guidelines
+# http://mywiki.wooledge.org/BashGuide/Practices
+# http://wiki.bash-hackers.org/scripting/style
+
+
+# bash available?
+if [ -z "$BASH_VERSINFO" ]; then
+  echo "Please make sure you're using bash!"
+  exit 1
+fi
+
+
+# INITIALIZE CONSTANTS AND GLOBALS
+# Only lower case, esp. for export!
+# That ensures that system vars stay untouched in any case
+readonly prog_name=$(basename "$0")
+
+
+is_writeable() {
+  local var="$1"
+
+  is_writeable_empty "${var}" 0
+}
+
+is_writeable_empty() {
+  local var="$1"
+  local empty="$2"
+  [[ -z "${empty}" ]] && empty=1
+
+  # http://mywiki.wooledge.org/BashGuide/TestsAndConditionals
+  # "touch" creates file, if it doesn't exist,
+  # so further tests won't fail at the beginning
+  if { touch -a "${var}" >/dev/null 2>&1; }; then
+    if [[ ! -s "${var}" ]]; then
+      if [[ ! -w "${var}" ]]; then
+        #show_warning "${var} is not writeable"
+        return 1
+      fi
+    else
+      #show_warning "${var} is not empty"
+      [[ "${empty}" -eq 1 ]] && return 1
+    fi
+  else
+    #show_warning "Destination for ${var} is not accessible at all"
+    return 1
+  fi
+
+  return 0
+}
+
+is_number() {
+  local int="$1"
+  # http://mywiki.wooledge.org/BashFAQ/054
+  [[ "$int" != *[!0-9]* ]]
+}
+
+is_empty() {
+  local var="$1"
+
+  [[ -z "$var" ]]
+}
+
+show_error() {
+  printf "\n%s\n" "${prog_name}: error: $*" >&2
+  exit 1
+}
+
+show_warning() {
+  printf "\n%s\n" "${prog_name}: $*" >&2
+}
+
+show_help() {
+  # http://wiki.bash-hackers.org/syntax/redirection#here_documents
+  cat <<- EOF
+
+  Usage: ${prog_name} [options] <command> [<logfile>]
+
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+  non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+  Arguments:
+    <command>       Slowpoke command
+    <logfile>       Where <command>'s output will be saved
+                    Default: \$RANDOM-output.log
+
+  Options:
+    -i, --interval <int>   Refresh interval in sec.
+                           Default: 30
+
+    -l, --limit <int>      Limit execution time in sec.
+                           Default: 0 (Off)
+
+    -x, --exit-code <int>  Force the exit code
+                           Default: -1 (Off)
+
+    -a, --append <int>     PRN append output to existing logfile
+                           Off: 0 (Default)
+                           On:  1
+
+    -h                          This help screen
+
+
+  Copyright (C) 2015 m3t
+  The MIT License (MIT)
+
+EOF
+
+  exit 0
+}
+
+cleanup() {
+  kill -0 ${pid_slowpoke} >/dev/null 2>&1 && kill ${pid_slowpoke} >/dev/null 2>&1
+}
+
+main() {
+
+  # INITIALIZE LOCAL VARIABLES
+  # Variables to be evaluated as shell arithmetic should be initialized
+  # to a default or validated beforehand.
+  # CAUTION: Arguments' (not options) default values will be overwritten here anyway
+  #          So they are set in VALIDATE INPUT
+  local i=0
+  local msg=""
+  local time_passed=0
+  local pid_slowpoke=0
+  local exit_slowpoke=0
+  # Options:
+  local interval=30
+  local time_limit=0
+  local exit_force=-1
+  local append=0
+  # Arguments:
+  local cmd_slowpoke=""
+  local file_log=""
+
+
+  # SIGNAL HANDLING
+  # http://mywiki.wooledge.org/SignalTrap
+  # http://mywiki.wooledge.org/SignalTrap#Special_Note_On_SIGINT
+  trap 'cleanup; trap - INT; kill -INT $$' INT QUIT # CTRL+C OR CTRL+\
+  trap 'cleanup; exit 1' TERM # kill's default signal
+
+
+  # COMMAND-LINE ARGUMENTS AND OPTIONS
+  # http://mywiki.wooledge.org/BashFAQ/035
+  msg="requires a non-empty option argument."
+  while :; do
+    case "$1" in
+      -h|-\?|--help)
+        show_help
+        exit
+        ;;
+      -l|--limit)
+        if [ -n "$2" ]; then
+          time_limit="$2"
+          shift 2
+          continue
+        else
+          show_error "--limit ${msg}"
+        fi
+        ;;
+      --limit=?*)
+        time_limit="${1#*=}"
+        ;;
+      --limit=)
+        show_error "--limit ${msg}"
+        ;;
+      -i|--interval)
+        if [ -n "$2" ]; then
+          interval="$2"
+          shift 2
+          continue
+        else
+          show_error "--interval ${msg}"
+        fi
+        ;;
+      --interval=?*)
+        interval="${1#*=}"
+        ;;
+      --interval=)
+        show_error "--interval ${msg}"
+        ;;
+      -x|--exit-code)
+        if [ -n "$2" ]; then
+          exit_force="$2"
+          shift 2
+          continue
+        else
+          show_error "--exit-code ${msg}"
+        fi
+        ;;
+      --exit-code=?*)
+        exit_force="${1#*=}"
+        ;;
+      --exit-code=)
+        show_error "--exit-code ${msg}"
+        ;;
+      -a|--append)
+        if [ -n "$2" ]; then
+          append="$2"
+          shift 2
+          continue
+        else
+          show_error "--append ${msg}"
+        fi
+        ;;
+      --append=?*)
+        append="${1#*=}"
+        ;;
+      --append=)
+        show_error "--append ${msg}"
+        ;;
+      --) # End of all options.
+        shift
+        break
+        ;;
+      -?*)
+        show_warning "Unknown option (ignored): $1"
+        ;;
+      *) # Default case: If no more options then break out of the loop.
+        break
+    esac
+
+    shift
+  done
+  # Arguments following the options
+  # will remain in the "$@" positional parameters.
+  cmd_slowpoke="$1"
+  file_log="$2"
+
+
+  # VALIDATE INPUT
+  is_number "${interval}" || show_error "Interval is not a valid number"
+  is_number "${time_limit}" || show_error "Limit is not a valid number"
+  is_empty "${cmd_slowpoke}" && show_error "Command to execute is not given. See --help."
+  is_empty "${file_log}" && file_log="$RANDOM-output.log" # http://mywiki.wooledge.org/BashFAQ/062
+
+  # START CMD
+  # http://mywiki.wooledge.org/ProcessManagement
+  if [[ "${append}" -ne 1 ]]; then
+    is_writeable_empty "${file_log}" || show_error "${file_log} is not writeable or not empty."
+    ${cmd_slowpoke} > "${file_log}" & pid_slowpoke=$!
+  else
+    is_writeable "${file_log}" || show_error "${file_log} is not writeable."
+    ${cmd_slowpoke} >> "${file_log}" & pid_slowpoke=$!
+  fi
+
+
+  # WAIT
+  # Terminates when $cmd_slowpoke is finished
+  # OR
+  # $time_limit has reached
+  i=0
+  while kill -0 ${pid_slowpoke} >/dev/null 2>&1; do
+    : $(( time_passed = i * interval ))
+
+    printf "%s\n" \
+      "Still waiting for about ${time_passed} seconds" \
+      "Used disk space: $(du -sh .)"
+
+    # Output last line from $file_log
+    tail -1 "${file_log}"
+
+    # $time_limit
+    if [[ "${time_limit}" -ne 0 ]] && [[ "${time_passed}" -ge "${time_limit}" ]]; then
+      cleanup
+      break
+    fi
+
+    sleep ${interval}
+
+    : $(( i += 1 ))
+  done
+
+
+  # FINISHED
+  # Shall I fake the exit code?
+  if ! is_number "${exit_force}"; then
+    # Get exit code from child process that is terminated already, see above
+    wait ${pid_slowpoke}; exit_slowpoke=$?
+  else
+    exit_slowpoke=${exit_force}
+  fi
+  show_warning "Your given command has terminated with exit code $exit_slowpoke. So do I."
+  exit ${exit_slowpoke}
+
+}
+
+main "$@"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ mod event_stream;
 mod id;
 mod message_filter;
 mod messages;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_parsec")]
 mod mock_parsec;
 mod node;
 mod outbox;
@@ -247,7 +247,7 @@ pub use crate::id::{FullId, PublicId};
 pub use crate::messages::{AccountInfo, Request, Response};
 #[cfg(feature = "mock")]
 pub use crate::mock_crust::crust;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_parsec")]
 pub(crate) use crate::mock_parsec as parsec;
 pub use crate::node::{Node, NodeBuilder};
 #[cfg(feature = "mock")]
@@ -260,7 +260,7 @@ pub use crate::routing_table::Error as RoutingTableError;
 pub use crate::routing_table::{Authority, Prefix, RoutingTable, VersionedPrefix, Xorable};
 pub use crate::types::MessageId;
 pub use crate::xor_name::{XorName, XorNameFromHexError, XOR_NAME_BITS, XOR_NAME_LEN};
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_parsec"))]
 pub(crate) use parsec;
 
 type Service = crust::Service<PublicId>;

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -15,6 +15,7 @@ use super::crust::{
 };
 use crate::id::PublicId;
 use crate::messages::{DirectMessage, Message};
+#[cfg(feature = "mock_parsec")]
 use crate::parsec;
 use crate::CrustEvent;
 use maidsafe_utilities::{serialisation, SeededRng};
@@ -50,7 +51,9 @@ impl<UID: Uid> Network<UID> {
         };
 
         unwrap!(safe_crypto::init_with_rng(&mut rng));
-        parsec::init();
+
+        #[cfg(feature = "mock_parsec")]
+        parsec::init_mock();
 
         Network(Rc::new(RefCell::new(NetworkImpl {
             services: HashMap::new(),

--- a/src/mock_parsec/mod.rs
+++ b/src/mock_parsec/mod.rs
@@ -29,7 +29,7 @@ use std::{
 
 /// Initialise mock parsec. Call this function at the beginning of each test.
 #[allow(unused)]
-pub fn init() {
+pub fn init_mock() {
     state::reset()
 }
 

--- a/src/mock_parsec/tests.rs
+++ b/src/mock_parsec/tests.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    init, Block, ConsensusMode, NetworkEvent, Observation, Parsec, PublicId, Request, Response,
-    SecretId,
+    init_mock, Block, ConsensusMode, NetworkEvent, Observation, Parsec, PublicId, Request,
+    Response, SecretId,
 };
 use maidsafe_utilities::SeededRng;
 use rand::Rng;
@@ -21,7 +21,7 @@ use std::{
 
 #[test]
 fn smoke() {
-    init();
+    init_mock();
 
     let alice_id = PeerId(0);
     let bob_id = PeerId(1);
@@ -76,7 +76,7 @@ fn smoke() {
 
 #[test]
 fn add_peer() {
-    init();
+    init_mock();
 
     let alice_id = PeerId(0);
     let bob_id = PeerId(1);
@@ -153,7 +153,7 @@ fn add_peer() {
 
 #[test]
 fn consensus_mode_single() {
-    init();
+    init_mock();
 
     let alice_id = PeerId(0);
     let bob_id = PeerId(1);
@@ -206,7 +206,7 @@ fn consensus_mode_single() {
 
 #[test]
 fn randomized_static_network() {
-    init();
+    init_mock();
 
     let num_peers = 10;
     let num_votes = 10;

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1546,7 +1546,7 @@ impl Node {
             let genesis_ver = *genesis_info.first_info.version();
             let consensus_mode = parsec::ConsensusMode::Single;
 
-            #[cfg(not(feature = "mock"))]
+            #[cfg(not(feature = "mock_parsec"))]
             let parsec = if genesis_info.first_info.members().contains(self.id()) {
                 Parsec::from_genesis(full_id, &genesis_info.first_info.members(), consensus_mode)
             } else {
@@ -1558,7 +1558,7 @@ impl Node {
                 )
             };
 
-            #[cfg(feature = "mock")]
+            #[cfg(feature = "mock_parsec")]
             let parsec = {
                 let section_hash = *genesis_info.first_info.hash();
 


### PR DESCRIPTION
So mock crust / mock crypto can be enabled independently from mock parsec.

Also rename `mock_parsec::init` to `mock_parsec::init_mock` for more explicitness.