### PR TITLE
Routing model handle replay,loss,trust and split

### DIFF
--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -262,11 +262,10 @@
     Note that we could also see consensus on ParsecExpectCandidate before we ourselves voted for it in PARSEC, as long as enough members of our section did.
     </p>
   </div>
-  </div>
   <button class="collapsible">waiting_proofing_or_hop</button>
   <div class="content">
     <p>We want to accept at most one incoming relocation at a time into our section.<br/>
-    The waiting_proofing_or_hop function returns the list of nodes that we have yet to resource proof or relocated through a new hop, (States from WaitingCandidateInfo until it reaches OnlineState  or RelocatedState).<br/>
+    The waiting_proofing_or_hop function returns the list of nodes that we have yet to resource proof or relocate through a new hop, (States from WaitingCandidateInfo until it reaches OnlineState  or RelocatedState).<br/>
     When the output of this function is not empty and we reach consensus on ParsecExpectCandidate, we send a RefuseCandidate RPC to the would-be-incoming-node so they can try another section or try again later.
     </p>
   </div>
@@ -386,7 +385,7 @@
       ParsecConsensus -- "ParsecCandidateConnected<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> Balanced
       Balanced(("Check"))
       Balanced -- "shorter_prefix_section(<br/>).is_some()" --> RelocateToShorterPrefix
-      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingState(Hop)"]
+      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingState(Hop))"]
       RelocateToShorterPrefix --> SetConnected
 
       Balanced -- "Otherwise" --> SetWaitingProof
@@ -680,12 +679,12 @@
     Returns the best node to relocate and the target address to send it to<br/>
     There may be mutliple nodes relocating, for example because of a merge. Take the best one (oldest), and choose a target address.<br/>
     The target address is one managed by one of our neighbours. This could be random, or the current old_public_id with a single bit of the prefix flipped.<br/>
-    This would would help ensure that source and destination remain neighbours, even if the source splits.<br/>
+    This would help ensure that source and destination remain neighbours, even if the source splits.<br/>
     Using a target address instead of a section ensures we deliver the message even if the destination splits or merges.<br/>
     <br/>
     There are 3 states the node may be: RelocatingState(AgeIncrease), RelocatingState(Hop), and RelocatingState(BackOnline).<br/>
-    Node will be selected in this order: Relocating(AgeIncrease), RelocatingState(Hop) and then RelocatingState(BackOnline).<br/>
-    This ensures that we prioritizing good node relocation.
+    Nodes will be selected in this order: RelocatingState(AgeIncrease), RelocatingState(Hop) and then RelocatingState(BackOnline).<br/>
+    This ensures that we prioritize good node relocation.
     <br/>
     Note: It may be possible for a node to relocate to its sibling, and complete relocation after a merge occured.
     </p>
@@ -1099,7 +1098,7 @@
   <button class="collapsible">WAITED_VOTES</button>
   <div class="content">
     <p>Wait for all these votes to reach consensus before reflecting the status change in our chain.<br>
-      Both section need to be consensused before we move on so we do not leave one behind with not enough voters.
+      Both sections need to be consensused before we move on so we do not leave one behind with not enough voters.
     </p>
   </div>
   <button class="collapsible">complete_split</button>

--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -342,7 +342,7 @@
     If it is Some, we will relay the RPC to them instead of accepting the rellocation to our own section.
     </p>
   </div>
-  <button class="collapsible">RelocatingState(Hop)</button>
+  <button class="collapsible">RelocatingHopState</button>
   <div class="content">
     <p>A nodes state indicating that it is relocated without ageing further.<br/>
        Also returned as part of waiting_proofing_or_hop().
@@ -385,7 +385,7 @@
       ParsecConsensus -- "ParsecCandidateConnected<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> Balanced
       Balanced(("Check"))
       Balanced -- "shorter_prefix_section(<br/>).is_some()" --> RelocateToShorterPrefix
-      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingState(Hop))"]
+      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingHopState)"]
       RelocateToShorterPrefix --> SetConnected
 
       Balanced -- "Otherwise" --> SetWaitingProof
@@ -579,7 +579,7 @@
   <div class=description>
   <p>In these diagrams, we are modeling the simple version of node ageing that we decided to implement for Fleming:<br/>
   Work units are incremented for all nodes in the section every time a timeout reaches consenus. Because a quorum of elders must have voted for this timeout, the malicious nodes can't arbitrarily speed up the ageing of their nodes.<br/>
-  Once a node has accumulated enough work units to be relocated, if no other node is currently relocating we set its state to RelocatingState(AgeIncrease). This node will then be actually relocated in StartRelocateSrc (see StartRelocateSrc).
+  Once a node has accumulated enough work units to be relocated, if no other node is currently relocating we set its state to RelocatingAgeIncreaseState. This node will then be actually relocated in StartRelocateSrc (see StartRelocateSrc).
   </p>
   <button class="collapsible">WorkUnitTimeout</button>
   <div class="content">
@@ -596,7 +596,7 @@
   </div>
   <button class="collapsible">nodes_relocating</button>
   <div class="content">
-    <p>The collection of nodes currently relocating: With node state RelocatingState(AgeIncrease) only.<br/>
+    <p>The collection of nodes currently relocating: With node state RelocatingAgeIncreaseState only.<br/>
       It will most often be empty or have one element, unless a merge occurs in which case it may contain more than one element.
       Nodes coming back online, or needing an extra hop are not considered here.
     </p>
@@ -611,7 +611,7 @@
   </div>
   <button class="collapsible">set_node_state</button>
   <div class="content">
-    <p>This function mutates our peer_list to set the state (for example set RelocatingState(AgeIncrease) for the node).<br/>
+    <p>This function mutates our peer_list to set the state (for example set RelocatingAgeIncreaseState for the node).<br/>
     inputs:<br/>
     - node<br/>
     - state<br/>
@@ -652,7 +652,7 @@
       AlreadyRelocating --"nodes_relocating().is_empty()"--> SetRelocatingNodeState
       AlreadyRelocating --"Otherwise"--> LoopEnd
 
-      SetRelocatingNodeState["set_node_state(get_node_to_relocate(), RelocatingState(AgeIncrease))"]
+      SetRelocatingNodeState["set_node_state(get_node_to_relocate(), RelocatingAgeIncreaseState)"]
       SetRelocatingNodeState --> LoopEnd
   </div>
 
@@ -663,8 +663,8 @@
   All in all, we have the certainty that eventually, exactly one of these two RPCs will make it to our section.<br/>
   When it does, it will be voted in PARSEC, regardless of the order of operations, so it will eventually make it through PARSEC.<br/>
   <br/>
-  If a node in RelocatingState(AgeIncrease), is a non-elder adult node, we can try to relocate it. If they are an elder node, we will first wait for the Adult/Elder promotion/demotion flow to kick in and demote them to an adult. This will happen because we changed their state from OnlineState to RelocatingState, which means that they will get demoted.<br/>
-  Nodes in RelocatingState(Hop) and then RelocatingState(BackOnline) are relocated after RelocatingState(AgeIncrease). Neither are full adults.
+  If a node in RelocatingAgeIncreaseState, is a non-elder adult node, we can try to relocate it. If they are an elder node, we will first wait for the Adult/Elder promotion/demotion flow to kick in and demote them to an adult. This will happen because we changed their state from OnlineState to RelocatingAgeIncreaseState, which means that they will get demoted.<br/>
+  Nodes in RelocatingHopState and then RelocatingBackOnlineState are relocated after RelocatingAgeIncreaseState. Neither are full adults.
   <br/>
   If they refused our candidate, our job ends there: the candidate will simply be a candidate for relocation again later, so we will try to relocate it then.<br/>
   If they accepted the node and sent us a RelocateResponse RPC, so the ParsecRelocateResponse event reached consensus, we will send to the node that is being relocated the RelocatedInfo they will need.<br/>
@@ -682,8 +682,8 @@
     This would help ensure that source and destination remain neighbours, even if the source splits.<br/>
     Using a target address instead of a section ensures we deliver the message even if the destination splits or merges.<br/>
     <br/>
-    There are 3 states the node may be: RelocatingState(AgeIncrease), RelocatingState(Hop), and RelocatingState(BackOnline).<br/>
-    Nodes will be selected in this order: RelocatingState(AgeIncrease), RelocatingState(Hop) and then RelocatingState(BackOnline).<br/>
+    There are 3 states the node may be: RelocatingAgeIncreaseState, RelocatingHopState, and RelocatingBackOnlineState.<br/>
+    Nodes will be selected in this order: RelocatingAgeIncreaseState, RelocatingHopState and then RelocatingBackOnlineState.<br/>
     This ensures that we prioritize good node relocation.
     <br/>
     Note: It may be possible for a node to relocate to its sibling, and complete relocation after a merge occured.
@@ -697,7 +697,7 @@
   </div>
   <button class="collapsible">is_our_relocating_node</button>
   <div class="content">
-    <p>Is it a valid node that is not yet relocated (i.e State is RelocatingState(AgeIncrease), RelocatingState(Hop) or RelocatingState(BackOnline)).
+    <p>Is it a valid node that is not yet relocated (i.e State is RelocatingAgeIncreaseState, RelocatingHopState or RelocatingBackOnlineState).
     </p>
   </div>
   <button class="collapsible">RefuseCandidate/<br/>RelocateResponse</button>
@@ -1149,7 +1149,7 @@
 
   <h2>Handling members of our section going Online or Offline</h2>
   <div class=description>
-  <button class="collapsible">RelocatingState(BackOnline)</button>
+  <button class="collapsible">RelocatingBackOnlineState</button>
   <div class="content">
     <p>A nodes state indicating that it is relocated with age reduced as it went offline.<br/>
     </p>
@@ -1183,7 +1183,7 @@
       SetOfflineState -->LoopEnd
 
       Consensus -- "ParsecBackOnline" --> SetRelocating
-      SetRelocating["set_node_state(<br/>node,<br/>RelocatingState(BackOnline))"]
+      SetRelocating["set_node_state(<br/>node,<br/>RelocatingBackOnlineState)"]
 
       SetRelocating --> LoopEnd
       LoopEnd --> LoopStart

--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -263,10 +263,10 @@
     </p>
   </div>
   </div>
-  <button class="collapsible">waiting_proofing</button>
+  <button class="collapsible">waiting_proofing_or_hop</button>
   <div class="content">
     <p>We want to accept at most one incoming relocation at a time into our section.<br/>
-    The waiting_proofing function returns the list of nodes that we have yet to resource proof, (States from WaitingCandidateInfo until it reaches OnlineState).<br/>
+    The waiting_proofing_or_hop function returns the list of nodes that we have yet to resource proof or relocated through a new hop, (States from WaitingCandidateInfo until it reaches OnlineState  or RelocatedState).<br/>
     When the output of this function is not empty and we reach consensus on ParsecExpectCandidate, we send a RefuseCandidate RPC to the would-be-incoming-node so they can try another section or try again later.
     </p>
   </div>
@@ -296,8 +296,8 @@
       VoteParsecExpectCandidate --> LoopEnd
 
       Balanced(("Check?<br/>(shared state)"))
-      Balanced -- "waiting_proofing().contains(candidate)" --> SendIdenticalRelocateResponse
-      Balanced -- "waiting_proofing().is_empty()" --> SendRelocateResponse
+      Balanced -- "waiting_proofing_or_hop().contains(candidate)" --> SendIdenticalRelocateResponse
+      Balanced -- "waiting_proofing_or_hop().is_empty()" --> SendRelocateResponse
       Balanced -- "Otherwise" --> SendRefuse
 
       SendIdenticalRelocateResponse["send_rpc(RelocateResponse)<br/>again to source section<br/>with original info"]
@@ -343,6 +343,12 @@
     If it is Some, we will relay the RPC to them instead of accepting the rellocation to our own section.
     </p>
   </div>
+  <button class="collapsible">RelocatingState(Hop)</button>
+  <div class="content">
+    <p>A nodes state indicating that it is relocated without ageing further.<br/>
+       Also returned as part of waiting_proofing_or_hop().
+    </p>
+  </div>
   <button class="collapsible">RelocatedNodeConnection_Reset</button>
   <div class="content">
     <p>Provides and external entry point to reset the currently processed nodes: Do not reject a node because it took longer than expected.<br/>
@@ -380,7 +386,7 @@
       ParsecConsensus -- "ParsecCandidateConnected<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> Balanced
       Balanced(("Check"))
       Balanced -- "shorter_prefix_section(<br/>).is_some()" --> RelocateToShorterPrefix
-      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingState)"]
+      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingState(Hop)"]
       RelocateToShorterPrefix --> SetConnected
 
       Balanced -- "Otherwise" --> SetWaitingProof
@@ -574,7 +580,7 @@
   <div class=description>
   <p>In these diagrams, we are modeling the simple version of node ageing that we decided to implement for Fleming:<br/>
   Work units are incremented for all nodes in the section every time a timeout reaches consenus. Because a quorum of elders must have voted for this timeout, the malicious nodes can't arbitrarily speed up the ageing of their nodes.<br/>
-  Once a node has accumulated enough work units to be relocated, if no other node is currently relocating we set its state to RelocatingState. This node will then be actually relocated in StartRelocateSrc (see StartRelocateSrc).
+  Once a node has accumulated enough work units to be relocated, if no other node is currently relocating we set its state to RelocatingState(AgeIncrease). This node will then be actually relocated in StartRelocateSrc (see StartRelocateSrc).
   </p>
   <button class="collapsible">WorkUnitTimeout</button>
   <div class="content">
@@ -591,8 +597,9 @@
   </div>
   <button class="collapsible">nodes_relocating</button>
   <div class="content">
-    <p>The collection of nodes currently relocating: With node state RelocatingState or WaitRelocateResponseState.<br/>
+    <p>The collection of nodes currently relocating: With node state RelocatingState(AgeIncrease) only.<br/>
       It will most often be empty or have one element, unless a merge occurs in which case it may contain more than one element.
+      Nodes coming back online, or needing an extra hop are not considered here.
     </p>
   </div>
   <button class="collapsible">get_node_to_relocate</button>
@@ -605,7 +612,7 @@
   </div>
   <button class="collapsible">set_node_state</button>
   <div class="content">
-    <p>This function mutates our peer_list to set the state (for example set RelocatingState for the node).<br/>
+    <p>This function mutates our peer_list to set the state (for example set RelocatingState(AgeIncrease) for the node).<br/>
     inputs:<br/>
     - node<br/>
     - state<br/>
@@ -646,7 +653,7 @@
       AlreadyRelocating --"nodes_relocating().is_empty()"--> SetRelocatingNodeState
       AlreadyRelocating --"Otherwise"--> LoopEnd
 
-      SetRelocatingNodeState["set_node_state(get_node_to_relocate(), RelocatingState)"]
+      SetRelocatingNodeState["set_node_state(get_node_to_relocate(), RelocatingState(AgeIncrease))"]
       SetRelocatingNodeState --> LoopEnd
   </div>
 
@@ -657,14 +664,14 @@
   All in all, we have the certainty that eventually, exactly one of these two RPCs will make it to our section.<br/>
   When it does, it will be voted in PARSEC, regardless of the order of operations, so it will eventually make it through PARSEC.<br/>
   <br/>
-  If a node in RelocatingState is a non-elder adult node, we can try to relocate it. If they are an elder node, we will first wait for the Adult/Elder promotion/demotion flow to kick in and demote them to an adult. This will happen because we changed their state from OnlineState to RelocatingState, which means that they will get demoted.<br/>
+  If a node in RelocatingState(AgeIncrease), is a non-elder adult node, we can try to relocate it. If they are an elder node, we will first wait for the Adult/Elder promotion/demotion flow to kick in and demote them to an adult. This will happen because we changed their state from OnlineState to RelocatingState, which means that they will get demoted.<br/>
+  Nodes in RelocatingState(Hop) and then RelocatingState(BackOnline) are relocated after RelocatingState(AgeIncrease). Neither are full adults.
   <br/>
-  On sending an ExpectCandidate RPC, we set the node state to WaitRelocateResponseState so we know after a split or a merge that we are waiting for a response.<br/>
-  If they refused our candidate, our job ends there: We reset the state to RelocatingState and the candidate will simply be a candidate for relocation again later, so we will try to relocate it then.<br/>
+  If they refused our candidate, our job ends there: the candidate will simply be a candidate for relocation again later, so we will try to relocate it then.<br/>
   If they accepted the node and sent us a RelocateResponse RPC, so the ParsecRelocateResponse event reached consensus, we will send to the node that is being relocated the RelocatedInfo they will need.<br/>
   At this point, we will purge their information since this node isn't a member of our section anymore.
   <br/>
-  Also of note: while we are preventing nodes with OnlineState from relocating when we are already relocating node, we may still be actively relocating more than one node away from our section (for instance if two sections with a relocating node each merge).<br/>
+  Also of note: while we are preventing nodes with OnlineState from relocating when we are already relocating one of our Adult. We may still be actively relocating more than one node away from our section (for instance if two sections with a relocating node each merge).<br/>
   However, we will only handle one at a time per CheckRelocateTimeOut event.
   </p>
   <button class="collapsible">get_best_relocating_node_and_target</button>
@@ -675,6 +682,10 @@
     The target address is one managed by one of our neighbours. This could be random, or the current old_public_id with a single bit of the prefix flipped.<br/>
     This would would help ensure that source and destination remain neighbours, even if the source splits.<br/>
     Using a target address instead of a section ensures we deliver the message even if the destination splits or merges.<br/>
+    <br/>
+    There are 3 states the node may be: RelocatingState(AgeIncrease), RelocatingState(Hop), and RelocatingState(BackOnline).<br/>
+    Node will be selected in this order: Relocating(AgeIncrease), RelocatingState(Hop) and then RelocatingState(BackOnline).<br/>
+    This ensures that we prioritizing good node relocation.
     <br/>
     Note: It may be possible for a node to relocate to its sibling, and complete relocation after a merge occured.
     </p>
@@ -687,7 +698,7 @@
   </div>
   <button class="collapsible">is_our_relocating_node</button>
   <div class="content">
-    <p>Is it a valid node that is not yet relocated (i.e State is RelocatingState or WaitRelocateResponseState).
+    <p>Is it a valid node that is not yet relocated (i.e State is RelocatingState(AgeIncrease), RelocatingState(Hop) or RelocatingState(BackOnline)).
     </p>
   </div>
   <button class="collapsible">RefuseCandidate/<br/>RelocateResponse</button>
@@ -1139,6 +1150,11 @@
 
   <h2>Handling members of our section going Online or Offline</h2>
   <div class=description>
+  <button class="collapsible">RelocatingState(BackOnline)</button>
+  <div class="content">
+    <p>A nodes state indicating that it is relocated with age reduced as it went offline.<br/>
+    </p>
+  </div>
   </div>
   <div class="mermaid">
       graph TB
@@ -1168,7 +1184,7 @@
       SetOfflineState -->LoopEnd
 
       Consensus -- "ParsecBackOnline" --> SetRelocating
-      SetRelocating["set_node_state(<br/>node,<br/>RelocatingState)"]
+      SetRelocating["set_node_state(<br/>node,<br/>RelocatingState(BackOnline))"]
 
       SetRelocating --> LoopEnd
       LoopEnd --> LoopStart

--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -336,6 +336,13 @@
     <p>Return true if the given message_src of the current RPC is a one of our nodes and is in WaitingConnectionInfo state.
     </p>
   </div>
+  <button class="collapsible">shorter_prefix_section</button>
+  <div class="content">
+    <p>If we know of a section that has a shorter prefix than ours, we prefer for them to receive this incoming node rather than ourselves as it will help keep the Network's sections tree balanced.<br/>
+    This shorter_prefix_section is a function that will return None if we are the shortest of any section we know, Some if there is a better candidate.<br/>
+    If it is Some, we will relay the RPC to them instead of accepting the rellocation to our own section.
+    </p>
+  </div>
   <button class="collapsible">RelocatedNodeConnection_Reset</button>
   <div class="content">
     <p>Provides and external entry point to reset the currently processed nodes: Do not reject a node because it took longer than expected.<br/>
@@ -370,8 +377,17 @@
       SetCandidateInfo["update_node(<br/>CandidateInfo,<br/>NodeState=WaitingConnectionInfo)"]
       SetCandidateInfo --> LoopEnd
 
-      ParsecConsensus -- "ParsecCandidateConnected<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> SetConnected
-      SetConnected["set_node_state(<br/>candidate,<br/>WaitingProofing)<br/><br/>send_rpc(<br/>NodeConnected)<br/><br/>(All communications now<br/>managed by elder like<br/>for other adults)"]
+      ParsecConsensus -- "ParsecCandidateConnected<br/>and<br/>is_valid_waited_connection(<br/>message_src)" --> Balanced
+      Balanced(("Check"))
+      Balanced -- "shorter_prefix_section(<br/>).is_some()" --> RelocateToShorterPrefix
+      RelocateToShorterPrefix["set_node_state(<br/>candidate,<br/>RelocatingState)"]
+      RelocateToShorterPrefix --> SetConnected
+
+      Balanced -- "Otherwise" --> SetWaitingProof
+      SetWaitingProof["set_node_state(<br/>candidate,<br/>WaitingProofing)"]
+      SetWaitingProof --> SetConnected
+
+      SetConnected["send_rpc(<br/>NodeConnected)<br/><br/>(All communications now<br/>managed by elder like<br/>for other adults)"]
       SetConnected --> LoopEnd
 
       RPC((RPC))

--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -821,6 +821,15 @@
     </p>
   </div>
   </div>
+  <button class="collapsible">split_needed</button>
+  <div class="content">
+    <p>This function indicates that we need splitting.<br>
+    The details for the trigger are still in slight flux, but here are some possibilities:
+    <ul>
+      <li> The number of Online adults plus elders is above our min section size of 10 elder plus 90 Adults + buffer
+    </ul>
+    </p>
+  </div>
   <div class="mermaid">
       graph TB
       CheckAndProcessElderChange["StartCheckAndProcessElderMergeChange:<br/>No exit - Needs killed"]
@@ -856,15 +865,26 @@
       Consensus--"ParsecCheckElderTimeout"-->CheckMergeNeeded
       CheckMergeNeeded(("Check"))
 
-      CheckMergeNeeded--"!merge_needed()<br/> and<br/>!has_merge_infos()"-->CheckElderChange
+      CheckMergeNeeded--"Otherwise"-->CheckElderChange
       CheckElderChange(("Check"))
 
-      CheckElderChange -- "No<br/>changes" --> RestartTimeout
+      CheckElderChange -- "Otherwise" --> CheckNeedSplit
+
+      CheckNeedSplit(("Check"))
+      CheckNeedSplit --"Otherwise" --> RestartTimeout
       RestartTimeout["schedule(<br/>CheckElderTimeout)"]
       RestartTimeout-->LoopEnd
 
-      CheckElderChange --"check_elder_change()<br/><br/>Has elder changes: elder first ordered by:<br/>State=Online then age then name."--> Concurrent0
+      CheckNeedSplit --"split_needed()" --> Concurrent2
+      Concurrent2{"Concurrent<br/>paths"}
+      Concurrent2 --> ProcessSplit
+      Concurrent2 --> LoopEnd
 
+      ProcessSplit["ProcessSplit"]
+      style ProcessSplit fill:#f9f,stroke:#333,stroke-width:4px
+      ProcessSplit --> CancelResourceProof
+
+      CheckElderChange --"check_elder_change()<br/><br/>Has elder changes: elder first ordered by:<br/>State=Online then age then name."--> Concurrent0
       Concurrent0{"Concurrent<br/>paths"}
       Concurrent0 --> ProcessElderChange
       Concurrent0 --> LoopEnd
@@ -883,8 +903,6 @@
       ResetRelocatedNodeConnection --> RestartTimeout
 
       CheckMergeNeeded --"merge_needed()<br/>or<br/>has_merge_infos()"-->Concurrent1
-
-
       Concurrent1{"Concurrent<br/>paths"}
       Concurrent1 --> ProcessMerge
       Concurrent1 --> LoopEnd
@@ -1042,6 +1060,62 @@
 
       CheckMerge -- "Otherwise" --> LoopEnd
 
+      LoopEnd --> LoopStart
+  </div>
+
+  <h2>Handling splits</h2>
+  <div class=description>
+  <p>Vote for the two NewSectionInfo to gather required signatures<br/>
+ </p>
+  <button class="collapsible">WAITED_VOTES</button>
+  <div class="content">
+    <p>Wait for all these votes to reach consensus before reflecting the status change in our chain.<br>
+      Both section need to be consensused before we move on so we do not leave one behind with not enough voters.
+    </p>
+  </div>
+  <button class="collapsible">complete_split</button>
+  <div class="content">
+    <p>With the NewSectionInfo in hands, completing the split process consists on joining the correct newly formed section and leaving the old one behind.
+    </p>
+  </div>
+  <button class="collapsible">new_section_info</button>
+  <div class="content">
+    <p>A list of PublicId.<br>
+    The content of the NewSectionInfo parsec event that reached consensus that we are now a member of.
+    </p>
+  </div>
+  </div>
+  <div class="mermaid">
+      graph TB
+      ProcessElderChange["ProcessElderChange<br/>(Take elder changes)<br/>(shared state)"]
+      style ProcessElderChange fill:#f9f,stroke:#333,stroke-width:4px
+
+      EndRoutine["End of ProcessElderChange<br/>(shared state)"]
+      style EndRoutine fill:#f9f,stroke:#333,stroke-width:4px
+
+      ProcessElderChange -->  VoteNewSections
+      VoteNewSections["vote_for(NewSectionInfo) for the two new sections<br/><br/>WAITED_VOTES.insert(all votes)"]
+      VoteNewSections --> LoopStart
+
+      WaitFor(("Wait for 5:"))
+      LoopStart --> WaitFor
+
+      Consensus((Consensus))
+      WaitFor-- Parsec<br/>consensus --> Consensus
+
+      Consensus -- "WAITED_VOTES.contains(vote)" --> OneVoteConsensused
+      OneVoteConsensused["WAITED_VOTES.remove(vote)"]
+
+      OneVoteConsensused --> WaitComplete
+      WaitComplete(("Check?"))
+      WaitComplete--"WAITED_VOTES<br/>.is_empty()<br/>(Wait complete)"-->CompleteSplit
+      CompleteSplit["complete_split()<br/>(Start parsec with new genesis...)"]
+      CompleteSplit --> MarkNewElderAdults
+
+      MarkNewElderAdults["update_elder_status(new_section_info)"]
+      MarkNewElderAdults--> EndRoutine
+
+      WaitComplete--"!WAITED_VOTES<br/>.is_empty()<br/>(Wait not complete)"--> LoopEnd
       LoopEnd --> LoopStart
   </div>
 

--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -653,7 +653,8 @@
   </p>
   <button class="collapsible">get_best_relocating_node_and_target</button>
   <div class="content">
-    <p>Returns the best node to relocate and the target address to send it to<br/>
+    <p>Takes ALREADY_RELOCATING for the nodes it will ignore.<br/>
+    Returns the best node to relocate and the target address to send it to<br/>
     There may be mutliple nodes relocating, for example because of a merge. Take the best one (oldest), and choose a target address.<br/>
     The target address is one managed by one of our neighbours. This could be random, or the current old_public_id with a single bit of the prefix flipped.<br/>
     This would would help ensure that source and destination remain neighbours, even if the source splits.<br/>
@@ -662,9 +663,10 @@
     Note: It may be possible for a node to relocate to its sibling, and complete relocation after a merge occured.
     </p>
   </div>
-  <button class="collapsible">waiting_node_relocate_response</button>
+  <button class="collapsible">ALREADY_RELOCATING</button>
   <div class="content">
-    <p>Returns our node with state WaitRelocateResponseState.
+    <p>The nodes we ignore when selecting a new node to send ExpectCandidate for.<br/>
+       Local states are not carried over on merge or split, so we will resend ExpectCandidate earlier than we would otherwise.
     </p>
   </div>
   <button class="collapsible">is_our_relocating_node</button>
@@ -724,22 +726,22 @@
       CheckNeedRelocate((Check?))
       CheckNeedRelocate--"Otherwise" -->CheckNeedResend
 
-      CheckNeedRelocate--"get_best_relocating_node_and_target().is_some()" --> SendExpectCandidate
-      SendExpectCandidate["(node, target)=<br/>get_best_relocating_node_and_target()<br/><br/>send_rpc(<br/>ExpectCandidate(node))<br/>to target NaeManager<br/><br/>set_node_state(<br/>node,<br/>WaitRelocateResponseState)"]
+      CheckNeedRelocate--"get_best_relocating_node_and_target(<br/>ALREADY_RELOCATING).is_some()" --> SendExpectCandidate
+      SendExpectCandidate["(node, target)=<br/>get_best_relocating_node_and_target(<br/>ALREADY_RELOCATING)<br/><br/>send_rpc(<br/>ExpectCandidate(node))<br/>to target NaeManager<br/><br/>ALREADY_RELOCATING<br/>.insert(node)"]
       SendExpectCandidate --> CheckNeedResend
 
       CheckNeedResend((Check?))
-      CheckNeedResend -- RESEND_TRIGGER>0 --> DecResendCount
+      CheckNeedResend -- Otherwise --> DecResendCount
       DecResendCount["RESEND_TRIGGER--"]
       DecResendCount --> LoopEnd
 
-      CheckNeedResend -- RESEND_TRIGGER==0 --> AllowResendCandidates
-      AllowResendCandidates["for node in both<br/>-waiting_node_relocate_response()<br/>-WAIT_RESPONSE:<br/><br/>set_node_state(<br/>node,<br/>RelocatingState)<br/><br/>--<br/>RESEND_TRIGGER=3<br/>WAIT_RESPONSE=<br/>waiting_node_relocate_response()"]
+      CheckNeedResend -- "RESEND_TRIGGER==0<br/>or<br/>ALREADY_RELOCATING.is_empty()" --> AllowResendCandidates
+      AllowResendCandidates["ALREADY_RELOCATING.clear()<br/>RESEND_TRIGGER=3"]
       AllowResendCandidates --> LoopEnd
 
 
       ParsecConsensus --"ParsecRefuseCandidate<br/>and<br/>is_our_relocating_node(node)"--> RefusedCandidate
-      RefusedCandidate["set_node_state(<br/>node,<br/>RelocatingState)"]
+      RefusedCandidate["ALREADY_RELOCATING<br/>.remove(node)"]
       RefusedCandidate --> LoopEnd
 
       ParsecConsensus --"ParsecRelocateResponse<br/>and<br/>is_our_relocating_node(node)"--> VoteProvableRelocateInfo

--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -263,13 +263,6 @@
     </p>
   </div>
   </div>
-  <button class="collapsible">shorter_prefix_section</button>
-  <div class="content">
-    <p>If we know of a section that has a shorter prefix than ours, we prefer for them to receive this incoming node rather than ourselves as it will help keep the Network's sections tree balanced.<br/>
-    This shorter_prefix_section is a function that will return None if we are the shortest of any section we know, Some if there is a better candidate.<br/>
-    If it is Some, we will relay the RPC to them instead of accepting the rellocation to our own section.
-    </p>
-  </div>
   <button class="collapsible">waiting_proofing</button>
   <div class="content">
     <p>We want to accept at most one incoming relocation at a time into our section.<br/>
@@ -303,18 +296,19 @@
       VoteParsecExpectCandidate --> LoopEnd
 
       Balanced(("Check?<br/>(shared state)"))
-      Balanced -- "shorter_prefix_section(<br/>).is_some()" --> Resend
-      Balanced -- "shorter_prefix_section().is_none()<br/>!waiting_proofing().is_empty()" --> SendRefuse
-      Balanced -- "shorter_prefix_section().is_none()<br/>waiting_proofing().is_empty()" --> SendRelocateResponse
+      Balanced -- "waiting_proofing().contains(candidate)" --> SendIdenticalRelocateResponse
+      Balanced -- "waiting_proofing().is_empty()" --> SendRelocateResponse
+      Balanced -- "Otherwise" --> SendRefuse
 
-      Resend["send_rpc(<br/>ExpectCandidate)<br/>to shorter_prefix_section()"]
-      Resend --> LoopEnd
+      SendIdenticalRelocateResponse["send_rpc(RelocateResponse)<br/>again to source section<br/>with original info"]
+      SendIdenticalRelocateResponse --> LoopEnd
+
+      SendRelocateResponse["add_node(NodeState=WaitingCandidateInfo)<br/><br/>send_rpc(RelocateResponse)<br/>to source section"]
+      SendRelocateResponse --> LoopEnd
 
       SendRefuse["send_rpc(<br/>RefuseCandidate)<br/>to source section"]
       SendRefuse --> LoopEnd
 
-      SendRelocateResponse["add_node(NodeState=WaitingCandidateInfo)<br/><br/>send_rpc(RelocateResponse)<br/>to source section"]
-      SendRelocateResponse --> LoopEnd
 
   </div>
 
@@ -668,10 +662,30 @@
     Note: It may be possible for a node to relocate to its sibling, and complete relocation after a merge occured.
     </p>
   </div>
+  <button class="collapsible">waiting_node_relocate_response</button>
+  <div class="content">
+    <p>Returns our node with state WaitRelocateResponseState.
+    </p>
+  </div>
+  <button class="collapsible">is_our_relocating_node</button>
+  <div class="content">
+    <p>Is it a valid node that is not yet relocated (i.e State is RelocatingState or WaitRelocateResponseState).
+    </p>
+  </div>
   <button class="collapsible">RefuseCandidate/<br/>RelocateResponse</button>
   <div class="content">
     <p>Exactly one of these RPCs will be sent to us from the destination section as a response to our section's ExpectCandidate RPC.<br/>
-    When this happens, we will immediately vote for it in PARSEC as we need to act in the same order as anyone else in our section.
+    When this happens, we will immediately vote for it in PARSEC as we need to act in the same order as anyone else in our section.<br/>
+    In case we re-sent the ExpectCandidate RPC, we may receive more than one RefuseCandidate and RelocateResponse. In this case we will pass on the first RelocateResponse to our Candidate.<br/>
+    </p>
+  </div>
+  <button class="collapsible">RelocatedInfo</button>
+  <div class="content">
+    <p>Trigger relocation: Candidate will disconnect on receiving that RPC<br/>
+    This RPC contains the RelocateResponse info, and the signatures prooving the source section received it and decided that particular response is the one to relocate to.<br/>
+    In case we re-sent the ExpectCandidate RPC, we may receive more than one RefuseCandidate and RelocateResponse.<br/>
+    In this case we must ensure that no single node could act on that other RelocateResponse and be accepted by the destination. this means the signatures must be provided only once the RelocateResponse is agreed.<br/>
+    RelocatedInfo will contain the RelocateResponse info and the quorum of signatures gathered from PARSEC vote on ParsecRelocatedInfo.
     </p>
   </div>
   </div>
@@ -694,7 +708,7 @@
 
       Event((Event))
       Event -- CheckRelocateTimeOut<br/>Trigger --> VoteParsecCheckRelocate
-      VoteParsecCheckRelocate["vote_for(ParsecCheckRelocate)<br/>schedule(CheckRelocateTimeOut)"]
+      VoteParsecCheckRelocate["vote_for(<br/>ParsecCheckRelocate)<br/>schedule(<br/>CheckRelocateTimeOut)"]
       VoteParsecCheckRelocate --> LoopEnd
 
       RPC((RPC))
@@ -707,21 +721,38 @@
 
       ParsecConsensus((Parsec<br/>consensus))
       ParsecConsensus -- ParsecCheckRelocate<br/>consensused --> CheckNeedRelocate
-
       CheckNeedRelocate((Check?))
-      CheckNeedRelocate--"Otherwise" -->LoopEnd
+      CheckNeedRelocate--"Otherwise" -->CheckNeedResend
 
       CheckNeedRelocate--"get_best_relocating_node_and_target().is_some()" --> SendExpectCandidate
       SendExpectCandidate["(node, target)=<br/>get_best_relocating_node_and_target()<br/><br/>send_rpc(<br/>ExpectCandidate(node))<br/>to target NaeManager<br/><br/>set_node_state(<br/>node,<br/>WaitRelocateResponseState)"]
-      SendExpectCandidate --> LoopEnd
+      SendExpectCandidate --> CheckNeedResend
 
-      ParsecConsensus --"ParsecRefuseCandidate<br/>for our node"--> RefusedCandidate
+      CheckNeedResend((Check?))
+      CheckNeedResend -- RESEND_TRIGGER>0 --> DecResendCount
+      DecResendCount["RESEND_TRIGGER--"]
+      DecResendCount --> LoopEnd
+
+      CheckNeedResend -- RESEND_TRIGGER==0 --> AllowResendCandidates
+      AllowResendCandidates["for node in both<br/>-waiting_node_relocate_response()<br/>-WAIT_RESPONSE:<br/><br/>set_node_state(<br/>node,<br/>RelocatingState)<br/><br/>--<br/>RESEND_TRIGGER=3<br/>WAIT_RESPONSE=<br/>waiting_node_relocate_response()"]
+      AllowResendCandidates --> LoopEnd
+
+
+      ParsecConsensus --"ParsecRefuseCandidate<br/>and<br/>is_our_relocating_node(node)"--> RefusedCandidate
       RefusedCandidate["set_node_state(<br/>node,<br/>RelocatingState)"]
       RefusedCandidate --> LoopEnd
 
-      ParsecConsensus --"ParsecRelocateResponse<br/>for our node"--> SendPovableRelocateInfo
-      SendPovableRelocateInfo["send_rpc(RelocatedInfo)<br/>to node<br/><br/>Includes RelocationResponse<br/>content and consensus<br/>Node may be already gone"]
-      SendPovableRelocateInfo-->PurgeNodeInfos
+      ParsecConsensus --"ParsecRelocateResponse<br/>and<br/>is_our_relocating_node(node)"--> VoteProvableRelocateInfo
+      VoteProvableRelocateInfo["set_node_state(<br/>node,<br/>RelocatedState(RelocateResponse Info)<br/>(Vote for same relocation if merge/split<br/>so only one valid proof exists)<br/><br/>vote_for(<br/>ParsecRelocatedInfo(RelocateResponse Info))"]
+      VoteProvableRelocateInfo --> LoopEnd
+
+      ParsecConsensus --"ParsecRefuseCandidate/<br/>ParsecRelocateResponse<br/>otherwise"--> DiscardVote
+      DiscardVote[Discard<br/>Vote]
+      DiscardVote --> LoopEnd
+
+      ParsecConsensus --"ParsecRelocatedInfo"--> SendProvableRelocateInfo
+      SendProvableRelocateInfo["send_rpc(RelocatedInfo)<br/>to node<br/><br/>ParsecRelocatedInfo proofs for CandidateInfo<br/>Node may be already gone"]
+      SendProvableRelocateInfo-->PurgeNodeInfos
       PurgeNodeInfos["purge_node_info(<br/>node)"]
       PurgeNodeInfos--> LoopEnd
   </div>
@@ -1073,6 +1104,7 @@
     Contains:<br/>
       <ul>
         <li>target_interval: (XorName, XorName) - The interval into which the joining node should join.<br>
+        <li>section_info: SectionInfo - The destination section that the joining node will trust.<br>
       </ul>
     </p>
   </div>
@@ -1088,6 +1120,8 @@
       Contains:<br/>
       <ul>
         <li>target_interval: (XorName, XorName) - The interval into which the joining node should join.<br>
+        <li>section_info: SectionInfo - The destination section that the joining node will trust.<br>
+        <li>proof: Signatures - Quorum of signature for the candidate to prove the source section relocated it with these infos.<br>
       </ul>
     </p>
   </div>
@@ -1101,6 +1135,8 @@
         <li>signature_using_old: Signature - Signature of concatenated PublicIds using the pre-relocation key.<br>
         <li>signature_using_new: Signature - Signature of concatenated PublicIds and signature_using_old using the post-relocation key.<br>
         <li>new_client_auth: Authority - Client authority from after relocation.<br>
+        <li>source_proof: Signatures - Quorum of signature from the source section proving the source approved that relocation.<br>
+            This will be checked against the stored information in the candidate node state.<br/>
       </ul>
     </p>
   </div>
@@ -1114,6 +1150,7 @@
     <p>Sent by the destination section to the joining node when connected<br/>
       Contains:<br/>
       <ul>
+        <li>section_info_proofs: Vec&lt(SectionInfo, ProofSet)&gt - Signed section infos with root starting with the stored SectionInfo in the candidate node state.<br>
         <li>current_info: GenesisPfxInfo - All the info needed when this node becomes an adult or elder.<br>
       </ul>
     </p>
@@ -1137,7 +1174,13 @@
     participant Node as Relocating Node
     participant Dst as Destination Section
 
-    Src->>+Dst: Routing RPC: ExpectCandidate
+
+    loop FindDestination
+      Src->>+Dst: Routing RPC: ExpectCandidate
+      opt Refuse
+        Dst-->>Src: Routing RPC: RefuseCandidate
+      end
+    end
     Dst-->>-Src: Routing RPC: RelocateResponse
     Src->>Node: Direct node-to-node RPC: RelocatedInfo
 


### PR DESCRIPTION
Rendered:
https://raw.githack.com/maidsafe/routing/34a0bb7adbcebafb25c1d923365f6c65bda87677/routing_model/index.html

(first 4 commits: https://raw.githack.com/maidsafe/routing/1b760bc491526a193a94022207450666b9fadd65/routing_model/index.html)

(first 2 commits: https://raw.githack.com/maidsafe/routing/81f5b6043660f59caefb0c19b32e05ca8d0abdd6/routing_model/index.html)

Note:
Initially remove re-send ExpectCandidate to section with shorter_prefix.
It complicates flow by involving unknown number of section in the process.
Re-add this functionality between the connection being established and the resource proof started as an immediate relocate with the same age.

Handles RPC Replay for ExpectCandidate/RelocateResponse:
 - Destination only trust a CandidateInfo if it has proof that the source decided on that relocation
 - Source only generate proof for a single relocation per node it relocates (The first one it consensus).

Handle Loss:
- Because we can now have multiple ExpectCandidate/RelocateResponse: Resend ExpectCandidate if it takes too long (We don't think it will come back), until we get a valid RelocateResponse.

Handle Trust:
- This only address the trust a node has in the new section it joins. In Alpha2, it already has the public Id of the elder it needs to connect too, so that was not an issue. But to handle merge/split, the node will not know the elder it needs to connect to. The Same public Id are given to the node as the initial SectionInfo, and the current set of elder gives a proof that it is a descendant section to the initial SectionInfo.

Handle Split:
- Handle similarly to merge and elder change: Vote for 2 new section info and wait for them before moving on. 

Different types of relocation are handled differently AgeIncrease, Hop and BackOnline.