### PR TITLE
routing_model: fix merge when receive Merge RPC first.

### DIFF
--- a/routing_model/index.html
+++ b/routing_model/index.html
@@ -1057,17 +1057,12 @@
   </div>
   <div class="mermaid">
       graph TB
-      ProcessMerge["ProcessMerge<br/>(shared state)"]
       EndRoutine["End of ProcessMerge<br/>(shared state)"]
-      style ProcessMerge fill:#f9f,stroke:#333,stroke-width:4px
       style EndRoutine fill:#f9f,stroke:#333,stroke-width:4px
 
-      ProcessMerge -->  SendMergeRpc
-      SendMergeRpc["send_rpc(Rpc::Merge)"]
-      SendMergeRpc --> LoopStart
 
-      WaitFor(("Wait for 8:"))
       LoopStart --> WaitFor
+      WaitFor(("Wait for 8:"))
 
       Consensus((Consensus))
       WaitFor-- Parsec<br/>consensus --> Consensus
@@ -1081,6 +1076,12 @@
       Consensus -- "Parsec::NeighbourMerge" --> SetNeighbourMerge
       SetNeighbourMerge["store_merge_infos(Parsec::NeighbourMerge info)"]
       SetNeighbourMerge --> CheckMerge
+
+      ProcessMerge["ProcessMerge<br/>(shared state)"]
+      style ProcessMerge fill:#f9f,stroke:#333,stroke-width:4px
+      ProcessMerge -->  SendMergeRpc
+      SendMergeRpc["send_rpc(Rpc::Merge)"]
+      SendMergeRpc --> CheckMerge
 
       CheckMerge((Check))
       CheckMerge -- "has_sibling_merge_info()" --> VotForNewSectionInfo


### PR DESCRIPTION
If receiving the Merge RPC from our sibling trigger the merge, then
we need to proceed with voting the new section imediatly and not wait
forever.

Rendered: https://raw.githack.com/maidsafe/routing/90d6cb146bf4fdbb2730971606d8f68f8f32ad43/routing_model/index.html