### PR TITLE
 Flow tests: simplify ProcessElderChange subprocess

### DIFF
--- a/routing_model/src/lib.rs
+++ b/routing_model/src/lib.rs
@@ -21,6 +21,7 @@ mod scenario_tests;
 
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
 extern crate unwrap;
 
 #[macro_use]

--- a/routing_model/src/scenario_tests.rs
+++ b/routing_model/src/scenario_tests.rs
@@ -611,10 +611,11 @@ mod dst_tests {
                 action_our_votes: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.1.clone(),
                 action_our_nodes: vec![SET_ONLINE_NODE_1],
                 check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: Some(ProcessElderChangeState {
-                        change_elder: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone(),
+                    sub_routine_process_elder_change: ProcessElderChangeState {
+                        is_active: true,
+                        change_elder: Some(SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone()),
                         wait_votes: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.1.clone(),
-                    }),
+                    },
                     ..Default::default()
                 },
                 ..AssertState::default()
@@ -644,10 +645,11 @@ mod dst_tests {
             ],
             &AssertState {
                 check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: Some(ProcessElderChangeState {
-                        change_elder: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone(),
+                    sub_routine_process_elder_change: ProcessElderChangeState {
+                        is_active: true,
+                        change_elder: Some(SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone()),
                         wait_votes: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.1.clone(),
-                    }),
+                    },
                     ..Default::default()
                 },
                 ..AssertState::default()
@@ -672,13 +674,14 @@ mod dst_tests {
             &[ParsecVote::RemoveElderNode(NODE_ELDER_109).to_event()],
             &AssertState {
                 check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: Some(ProcessElderChangeState {
-                        change_elder: SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone(),
+                    sub_routine_process_elder_change: ProcessElderChangeState {
+                        is_active: true,
+                        change_elder: Some(SWAP_ELDER_109_NODE_1_SECTION_INFO_1.0.clone()),
                         wait_votes: vec![
                             ParsecVote::AddElderNode(NODE_1),
                             ParsecVote::NewSectionInfo(SECTION_INFO_1),
                         ],
-                    }),
+                    },
                     ..Default::default()
                 },
                 ..AssertState::default()
@@ -885,10 +888,11 @@ mod dst_tests {
             &AssertState {
                 action_our_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
                 check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: Some(ProcessElderChangeState {
-                        change_elder: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.0.clone(),
+                    sub_routine_process_elder_change: ProcessElderChangeState {
+                        is_active: true,
+                        change_elder: Some(SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.0.clone()),
                         wait_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
-                    }),
+                    },
                     ..Default::default()
                 },
                 ..AssertState::default()
@@ -1051,10 +1055,11 @@ mod src_tests {
                 )],
                 action_our_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
                 check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                    sub_routine_process_elder_change: Some(ProcessElderChangeState {
-                        change_elder: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.0.clone(),
+                    sub_routine_process_elder_change: ProcessElderChangeState {
+                        is_active: true,
+                        change_elder: Some(SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.0.clone()),
                         wait_votes: SWAP_ELDER_130_YOUNG_205_SECTION_INFO_1.1.clone(),
-                    }),
+                    },
                     ..Default::default()
                 },
                 ..AssertState::default()

--- a/routing_model/src/state.rs
+++ b/routing_model/src/state.rs
@@ -14,15 +14,16 @@ use crate::flows_node::*;
 use crate::flows_src::*;
 use crate::utilities::*;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct ProcessElderChangeState {
+    pub is_active: bool,
     pub wait_votes: Vec<ParsecVote>,
-    pub change_elder: ChangeElder,
+    pub change_elder: Option<ChangeElder>,
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct CheckAndProcessElderChangeState {
-    pub sub_routine_process_elder_change: Option<ProcessElderChangeState>,
+    pub sub_routine_process_elder_change: ProcessElderChangeState,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -78,7 +79,7 @@ impl MemberState {
         if self
             .check_and_process_elder_change_routine
             .sub_routine_process_elder_change
-            .is_some()
+            .is_active
         {
             if let Some(next) = self.as_process_elder_change().try_next(event) {
                 return Some(next);
@@ -162,19 +163,6 @@ impl MemberState {
             dst_routine: DstRoutineState {
                 sub_routine_accept_as_candidate,
                 ..self.dst_routine.clone()
-            },
-            ..self.clone()
-        }
-    }
-
-    pub fn with_check_and_process_elder_change_sub_routine_process_elder_change(
-        &self,
-        sub_routine_process_elder_change: Option<ProcessElderChangeState>,
-    ) -> Self {
-        Self {
-            check_and_process_elder_change_routine: CheckAndProcessElderChangeState {
-                sub_routine_process_elder_change,
-                ..self.check_and_process_elder_change_routine.clone()
             },
             ..self.clone()
         }


### PR DESCRIPTION
Implemented the suggested simplification from https://github.com/maidsafe/routing/pull/1601#discussion_r274847539