### PR TITLE
Refactor Node state: extract EstablishingNode state

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ use crate::messages::{Request, CLIENT_GET_PRIORITY, DEFAULT_PRIORITY};
 use crate::outbox::{EventBox, EventBuf};
 use crate::routing_table::Authority;
 use crate::state_machine::{State, StateMachine};
-use crate::states::{Bootstrapping, BootstrappingTargetState};
+use crate::states::{BootstrappingPeer, TargetState};
 use crate::types::{MessageId, RoutingActionSender};
 use crate::xor_name::XorName;
 use crate::{BootstrapConfig, MIN_SECTION_SIZE};
@@ -72,16 +72,16 @@ impl Client {
 
         StateMachine::new(
             move |action_sender, crust_service, timer, _outbox2| {
-                Bootstrapping::new(
+                BootstrappingPeer::new(
                     action_sender,
                     Box::new(NullCache),
-                    BootstrappingTargetState::Client { msg_expiry_dur },
+                    TargetState::Client { msg_expiry_dur },
                     crust_service,
                     full_id,
                     min_section_size,
                     timer,
                 )
-                .map_or(State::Terminated, State::Bootstrapping)
+                .map_or(State::Terminated, State::BootstrappingPeer)
             },
             pub_id,
             bootstrap_config,

--- a/src/client.rs
+++ b/src/client.rs
@@ -81,7 +81,8 @@ impl Client {
                     min_section_size,
                     timer,
                 )
-                .map_or(State::Terminated, State::BootstrappingPeer)
+                .map(State::BootstrappingPeer)
+                .unwrap_or(State::Terminated)
             },
             pub_id,
             bootstrap_config,

--- a/src/mock_parsec/mod.rs
+++ b/src/mock_parsec/mod.rs
@@ -184,10 +184,21 @@ where
         unimplemented!()
     }
 
+    // TODO: rename this to `has_unpolled_observations`
     pub fn has_unconsensused_observations(&self) -> bool {
-        self.observations
-            .iter()
-            .any(|(_, obs)| obs.state != ConsensusState::Polled)
+        state::with(self.section_hash, |state| {
+            state
+                .observations
+                .iter()
+                .any(|(holder, observation_state)| {
+                    !observation_state.consensused()
+                        || self
+                            .observations
+                            .get(&*holder)
+                            .map(|info| info.state != ConsensusState::Polled)
+                            .unwrap_or(true)
+                })
+        })
     }
 
     pub fn our_unpolled_observations(&self) -> impl Iterator<Item = &Observation<T, S::PublicId>> {

--- a/src/mock_parsec/mod.rs
+++ b/src/mock_parsec/mod.rs
@@ -186,19 +186,12 @@ where
 
     // TODO: rename this to `has_unpolled_observations`
     pub fn has_unconsensused_observations(&self) -> bool {
-        state::with(self.section_hash, |state| {
+        state::with::<T, S::PublicId, _, _>(self.section_hash, |state| {
             state
                 .observations
                 .iter()
-                .any(|(holder, observation_state)| {
-                    !observation_state.consensused()
-                        || self
-                            .observations
-                            .get(&*holder)
-                            .map(|info| info.state != ConsensusState::Polled)
-                            .unwrap_or(true)
-                })
-        })
+                .any(|(_, observation_state)| !observation_state.consensused())
+        }) || self.our_unpolled_observations().next().is_some()
     }
 
     pub fn our_unpolled_observations(&self) -> impl Iterator<Item = &Observation<T, S::PublicId>> {

--- a/src/mock_parsec/observation.rs
+++ b/src/mock_parsec/observation.rs
@@ -83,6 +83,10 @@ impl<P: PublicId> ObservationState<P> {
         }
     }
 
+    pub fn consensused(&self) -> bool {
+        self.consensused
+    }
+
     fn compute_consensus<T: NetworkEvent>(
         &mut self,
         peers: &BTreeSet<P>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -616,10 +616,10 @@ impl Node {
     }
 
     /// Indicates if there are any pending observations in the parsec object
-    pub fn has_unconsensused_observations(&self, filter_opaque: bool) -> bool {
+    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
         self.machine
             .current()
-            .has_unconsensused_observations(filter_opaque)
+            .has_unpolled_observations(filter_opaque)
     }
 
     /// Indicates if a given `PublicId` is in the peer manager as a routing peer

--- a/src/node.rs
+++ b/src/node.rs
@@ -141,17 +141,9 @@ impl NodeBuilder {
         StateMachine::new(
             move |action_sender, crust_service, timer, outbox2| {
                 if self.first {
-                    if let Some(state) = states::Node::first(
-                        self.cache,
-                        crust_service,
-                        full_id,
-                        min_section_size,
-                        timer,
-                    ) {
-                        State::Node(state)
-                    } else {
-                        State::Terminated
-                    }
+                    states::Node::first(self.cache, crust_service, full_id, min_section_size, timer)
+                        .map(State::Node)
+                        .unwrap_or(State::Terminated)
                 } else if !dev_config.allow_multiple_lan_nodes && crust_service.has_peers_on_lan() {
                     error!(
                         "More than one routing node found on LAN. Currently this is not supported."
@@ -168,7 +160,8 @@ impl NodeBuilder {
                         min_section_size,
                         timer,
                     )
-                    .map_or(State::Terminated, State::BootstrappingPeer)
+                    .map(State::BootstrappingPeer)
+                    .unwrap_or(State::Terminated)
                 }
             },
             pub_id,

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,7 +22,7 @@ use crate::messages::{
 use crate::outbox::{EventBox, EventBuf};
 use crate::routing_table::Authority;
 use crate::state_machine::{State, StateMachine};
-use crate::states::{self, Bootstrapping, BootstrappingTargetState};
+use crate::states::{self, BootstrappingPeer, TargetState};
 use crate::types::{MessageId, RoutingActionSender};
 use crate::xor_name::XorName;
 #[cfg(feature = "mock_base")]
@@ -159,16 +159,16 @@ impl NodeBuilder {
                     outbox2.send_event(Event::Terminated);
                     State::Terminated
                 } else {
-                    Bootstrapping::new(
+                    BootstrappingPeer::new(
                         action_sender,
                         self.cache,
-                        BootstrappingTargetState::RelocatingNode,
+                        TargetState::RelocatingNode,
                         crust_service,
                         full_id,
                         min_section_size,
                         timer,
                     )
-                    .map_or(State::Terminated, State::Bootstrapping)
+                    .map_or(State::Terminated, State::BootstrappingPeer)
                 }
             },
             pub_id,

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -160,7 +160,7 @@ impl ParsecMap {
     }
 
     #[cfg(feature = "mock_base")]
-    pub fn has_unconsensused_observations(&self, filter_opaque: bool) -> bool {
+    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
         let parsec = if let Some(parsec) = self.map.values().last() {
             parsec
         } else {

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -308,7 +308,6 @@ pub struct PeerManager {
     our_public_id: PublicId,
     candidate: Candidate,
     disable_client_rate_limiter: bool,
-    established: bool,
 }
 
 impl PeerManager {
@@ -320,7 +319,6 @@ impl PeerManager {
             our_public_id: our_public_id,
             candidate: Candidate::None,
             disable_client_rate_limiter: disable_client_rate_limiter,
-            established: false,
         }
     }
 
@@ -633,12 +631,7 @@ impl PeerManager {
     }
 
     /// Remove and return `PublicId`s of expired peers.
-    /// Will only be active once we are established.
     pub fn remove_expired_peers(&mut self) -> Vec<PublicId> {
-        if !self.established {
-            return vec![];
-        }
-
         let remove_candidate = if self.candidate.is_expired() {
             match self.candidate {
                 Candidate::None => None,
@@ -978,17 +971,6 @@ impl PeerManager {
         }
 
         self.peers.remove(pub_id).is_some() || remove_candidate
-    }
-
-    /// Sets this peer as established.
-    /// Expired peers will be purged once established.
-    pub fn set_established(&mut self) {
-        self.established = true;
-    }
-
-    /// Returns whether this peer is established.
-    pub fn is_established(&self) -> bool {
-        self.established
     }
 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -217,17 +217,15 @@ impl State {
         }
     }
 
-    pub fn has_unconsensused_observations(&self, filter_opaque: bool) -> bool {
+    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
         match *self {
             State::Terminated
             | State::Bootstrapping(_)
             | State::Client(_)
             | State::RelocatingNode(_)
             | State::ProvingNode(_) => false,
-            State::EstablishingNode(ref state) => {
-                state.has_unconsensused_observations(filter_opaque)
-            }
-            State::Node(ref state) => state.has_unconsensused_observations(filter_opaque),
+            State::EstablishingNode(ref state) => state.has_unpolled_observations(filter_opaque),
+            State::Node(ref state) => state.has_unpolled_observations(filter_opaque),
         }
     }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -432,12 +432,10 @@ impl StateMachine {
                     _ => unreachable!(),
                 })
             }
-            IntoEstablishingNode { gen_pfx_info } => {
-                self.state.replace_with(|state| match state {
-                    State::ProvingNode(src) => src.into_establishing_node(gen_pfx_info),
-                    _ => unreachable!(),
-                });
-            }
+            IntoEstablishingNode { gen_pfx_info } => self.state.replace_with(|state| match state {
+                State::ProvingNode(src) => src.into_establishing_node(gen_pfx_info, outbox),
+                _ => unreachable!(),
+            }),
             IntoNode { sec_info, old_pfx } => self.state.replace_with(|state| match state {
                 State::EstablishingNode(src) => src.into_node(sec_info, old_pfx, outbox),
                 _ => unreachable!(),

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -6,7 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::common::{proxied, Base, Bootstrapped, NotEstablished, USER_MSG_CACHE_EXPIRY_DURATION};
+use super::{
+    bootstrapping::Bootstrapping,
+    common::{proxied, Base, Bootstrapped, NotEstablished, USER_MSG_CACHE_EXPIRY_DURATION},
+};
 use crate::{
     ack_manager::{Ack, AckManager, UnacknowledgedMessage},
     chain::SectionInfo,
@@ -51,27 +54,23 @@ pub struct Client {
 }
 
 impl Client {
-    #[allow(clippy::too_many_arguments)]
     pub fn from_bootstrapping(
-        crust_service: Service,
-        full_id: FullId,
-        min_section_size: usize,
+        source: Bootstrapping,
         proxy_pub_id: PublicId,
-        timer: Timer,
         msg_expiry_dur: Duration,
         outbox: &mut EventBox,
     ) -> Self {
         let client = Client {
             ack_mgr: AckManager::new(),
-            crust_service: crust_service,
-            full_id: full_id,
-            min_section_size: min_section_size,
-            proxy_pub_id: proxy_pub_id,
+            crust_service: source.crust_service,
+            full_id: source.full_id,
+            min_section_size: source.min_section_size,
+            proxy_pub_id,
             routing_msg_filter: RoutingMessageFilter::new(),
-            timer: timer,
+            timer: source.timer,
             user_msg_cache: UserMessageCache::with_expiry_duration(USER_MSG_CACHE_EXPIRY_DURATION),
             resend_buf: Default::default(),
-            msg_expiry_dur: msg_expiry_dur,
+            msg_expiry_dur,
         };
 
         debug!("{} State changed to Client.", client);

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::common::{unrelocated, Base, Bootstrapped, Unapproved, USER_MSG_CACHE_EXPIRY_DURATION};
+use super::common::{proxied, Base, Bootstrapped, NotEstablished, USER_MSG_CACHE_EXPIRY_DURATION};
 use crate::{
     ack_manager::{Ack, AckManager, UnacknowledgedMessage},
     chain::SectionInfo,
@@ -327,11 +327,11 @@ impl Bootstrapped for Client {
     }
 }
 
-impl Unapproved for Client {
+impl NotEstablished for Client {
     const SEND_ACK: bool = false;
 
     fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId, RoutingError> {
-        unrelocated::get_proxy_public_id(self, &self.proxy_pub_id, proxy_name)
+        proxied::get_proxy_public_id(self, &self.proxy_pub_id, proxy_name)
     }
 }
 

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -6,7 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::common::{proxied, Base, Bootstrapped, NotEstablished, USER_MSG_CACHE_EXPIRY_DURATION};
+use super::common::{
+    proxied, Base, Bootstrapped, BootstrappedNotEstablished, USER_MSG_CACHE_EXPIRY_DURATION,
+};
 use crate::{
     ack_manager::{Ack, AckManager, UnacknowledgedMessage},
     chain::SectionInfo,
@@ -327,7 +329,7 @@ impl Bootstrapped for Client {
     }
 }
 
-impl NotEstablished for Client {
+impl BootstrappedNotEstablished for Client {
     const SEND_ACK: bool = false;
 
     fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId, RoutingError> {

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -1,0 +1,165 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Relocated;
+use crate::{
+    chain::{
+        Chain, ExpectCandidatePayload, NetworkEvent, Proof, ProofSet, ProvingSection, SectionInfo,
+    },
+    error::RoutingError,
+    id::PublicId,
+    outbox::EventBox,
+    parsec::{Block, Observation},
+    routing_table::{Authority, Prefix},
+    state_machine::Transition,
+    xor_name::XorName,
+};
+use maidsafe_utilities::serialisation;
+
+/// Common functionality for node states post resource proof.
+pub trait Approved: Relocated {
+    fn parsec_poll_one(&mut self) -> Option<Block>;
+    fn chain_mut(&mut self) -> &mut Chain;
+
+    /// Handles an accumulated `Online` event.
+    fn handle_online_event(
+        &mut self,
+        new_pub_id: PublicId,
+        new_client_auth: Authority<XorName>,
+        outbox: &mut EventBox,
+    ) -> Result<(), RoutingError>;
+
+    /// Handles an accumulated `Offline` event.
+    fn handle_offline_event(
+        &mut self,
+        pub_id: PublicId,
+        outbox: &mut EventBox,
+    ) -> Result<(), RoutingError>;
+
+    /// Handles an accumulated `OurMerge` event.
+    fn handle_our_merge_event(&mut self) -> Result<(), RoutingError>;
+
+    /// Handles an accumulated `NeighbourMerge` event.
+    fn handle_neighbour_merge_event(&mut self) -> Result<(), RoutingError>;
+
+    /// Handles an accumulated `SectionInfo` event.
+    fn handle_section_info_event(
+        &mut self,
+        sec_info: SectionInfo,
+        old_pfx: Prefix<XorName>,
+        outbox: &mut EventBox,
+    ) -> Result<Transition, RoutingError>;
+
+    // Handles an accumulated `ExpectCandidate` event.
+    // Context: a node is joining our section. Send the node our section. If the
+    // network is unbalanced, send `ExpectCandidate` on to a section with a shorter prefix.
+    fn handle_expect_candidate_event(
+        &mut self,
+        vote: ExpectCandidatePayload,
+    ) -> Result<(), RoutingError>;
+
+    /// Handles an accumulated `ProvingSections` event.
+    fn handle_proving_sections_event(
+        &mut self,
+        proving_secs: Vec<ProvingSection>,
+        sec_info: SectionInfo,
+    ) -> Result<(), RoutingError>;
+
+    fn parsec_poll_all(&mut self, outbox: &mut EventBox) -> Result<Transition, RoutingError> {
+        while let Some(block) = self.parsec_poll_one() {
+            match block.payload() {
+                Observation::Accusation { .. } => {
+                    // FIXME: Handle properly
+                    unreachable!("...")
+                }
+                Observation::Genesis(_) => {
+                    // FIXME: Validate with Chain info.
+                    continue;
+                }
+                Observation::OpaquePayload(event) => {
+                    if let Some(proof) = block.proofs().iter().next().map(|p| Proof {
+                        pub_id: *p.public_id(),
+                        sig: *p.signature(),
+                    }) {
+                        trace!(
+                            "{} Parsec OpaquePayload: {} - {:?}",
+                            self,
+                            proof.pub_id(),
+                            event
+                        );
+                        self.chain_mut().handle_opaque_event(event, proof)?;
+                    }
+                }
+                Observation::Add {
+                    peer_id,
+                    related_info,
+                } => {
+                    let event =
+                        NetworkEvent::Online(*peer_id, serialisation::deserialise(&related_info)?);
+                    let proof_set = to_proof_set(&block);
+                    trace!("{} Parsec Add: - {}", self, peer_id);
+                    self.chain_mut().handle_churn_event(&event, proof_set)?;
+                }
+                Observation::Remove { peer_id, .. } => {
+                    let event = NetworkEvent::Offline(*peer_id);
+                    let proof_set = to_proof_set(&block);
+                    trace!("{} Parsec Remove: - {}", self, peer_id);
+                    self.chain_mut().handle_churn_event(&event, proof_set)?;
+                }
+            }
+
+            match self.chain_poll_all(outbox)? {
+                Transition::Stay => (),
+                transition => return Ok(transition),
+            }
+        }
+
+        Ok(Transition::Stay)
+    }
+
+    fn chain_poll_all(&mut self, outbox: &mut EventBox) -> Result<Transition, RoutingError> {
+        let mut our_pfx = *self.chain_mut().our_prefix();
+        while let Some(event) = self.chain_mut().poll()? {
+            trace!("{} Handle accumulated event: {:?}", self, event);
+
+            match event {
+                NetworkEvent::Online(pub_id, client_auth) => {
+                    self.handle_online_event(pub_id, client_auth, outbox)?;
+                }
+                NetworkEvent::Offline(pub_id) => {
+                    self.handle_offline_event(pub_id, outbox)?;
+                }
+                NetworkEvent::OurMerge => self.handle_our_merge_event()?,
+                NetworkEvent::NeighbourMerge(_) => self.handle_neighbour_merge_event()?,
+                NetworkEvent::SectionInfo(sec_info) => {
+                    match self.handle_section_info_event(sec_info, our_pfx, outbox)? {
+                        Transition::Stay => (),
+                        transition => return Ok(transition),
+                    }
+                }
+                NetworkEvent::ExpectCandidate(vote) => self.handle_expect_candidate_event(vote)?,
+                NetworkEvent::ProvingSections(proving_secs, sec_info) => {
+                    self.handle_proving_sections_event(proving_secs, sec_info)?;
+                }
+            }
+
+            our_pfx = *self.chain_mut().our_prefix();
+        }
+
+        Ok(Transition::Stay)
+    }
+}
+
+fn to_proof_set(block: &Block) -> ProofSet {
+    let sigs = block
+        .proofs()
+        .iter()
+        .map(|proof| (*proof.public_id(), *proof.signature()))
+        .collect();
+    ProofSet { sigs }
+}

--- a/src/states/common/bootstrapped_not_established.rs
+++ b/src/states/common/bootstrapped_not_established.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use std::collections::BTreeSet;
 
-pub trait NotEstablished: Bootstrapped {
+pub trait BootstrappedNotEstablished: Bootstrapped {
     // Whether acknowledge hop messages sent to us.
     const SEND_ACK: bool;
 

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+mod approved;
 mod base;
 mod bootstrapped;
 mod not_established;
@@ -14,7 +15,11 @@ mod relocated;
 mod relocated_not_established;
 
 pub use self::{
-    base::{from_crust_bytes, Base}, bootstrapped::Bootstrapped, not_established::NotEstablished, relocated::Relocated,
+    approved::Approved,
+    base::{from_crust_bytes, Base},
+    bootstrapped::Bootstrapped,
+    not_established::NotEstablished,
+    relocated::Relocated,
     relocated_not_established::RelocatedNotEstablished,
 };
 use crate::time::Duration;

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -8,13 +8,14 @@
 
 mod base;
 mod bootstrapped;
+mod not_established;
+pub mod proxied;
 mod relocated;
-mod unapproved;
-pub mod unrelocated;
+mod relocated_not_established;
 
 pub use self::{
-    base::from_crust_bytes, base::Base, bootstrapped::Bootstrapped, relocated::Relocated,
-    unapproved::Unapproved,
+    base::{from_crust_bytes, Base}, bootstrapped::Bootstrapped, not_established::NotEstablished, relocated::Relocated,
+    relocated_not_established::RelocatedNotEstablished,
 };
 use crate::time::Duration;
 

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -9,7 +9,7 @@
 mod approved;
 mod base;
 mod bootstrapped;
-mod not_established;
+mod bootstrapped_not_established;
 pub mod proxied;
 mod relocated;
 mod relocated_not_established;
@@ -18,7 +18,7 @@ pub use self::{
     approved::Approved,
     base::{from_crust_bytes, Base},
     bootstrapped::Bootstrapped,
-    not_established::NotEstablished,
+    bootstrapped_not_established::BootstrappedNotEstablished,
     relocated::Relocated,
     relocated_not_established::RelocatedNotEstablished,
 };

--- a/src/states/common/not_established.rs
+++ b/src/states/common/not_established.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use std::collections::BTreeSet;
 
-pub trait Unapproved: Bootstrapped {
+pub trait NotEstablished: Bootstrapped {
     // Whether acknowledge hop messages sent to us.
     const SEND_ACK: bool;
 

--- a/src/states/common/not_established.rs
+++ b/src/states/common/not_established.rs
@@ -73,11 +73,17 @@ pub trait NotEstablished: Bootstrapped {
         // Get PublicId of the proxy node
         let proxy_pub_id = match routing_msg.src {
             Authority::Client {
+                ref client_id,
                 ref proxy_node_name,
-                ..
-            } => *self.get_proxy_public_id(proxy_node_name)?,
+            } => {
+                if self.name() != client_id.name() {
+                    return Ok(());
+                }
+
+                *self.get_proxy_public_id(proxy_node_name)?
+            }
             _ => {
-                error!("{} Source should be client if our state is Client", self);
+                error!("{} - Source should be client in this state", self);
                 return Err(RoutingError::InvalidSource);
             }
         };

--- a/src/states/common/proxied.rs
+++ b/src/states/common/proxied.rs
@@ -6,7 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{error::RoutingError, id::PublicId, xor_name::XorName};
+//! Utilities for node states that are connected via proxy.
+
+use crate::{
+    error::RoutingError,
+    id::PublicId,
+    peer_manager::{Peer, PeerManager},
+    xor_name::XorName,
+};
 use std::fmt::Display;
 
 pub fn get_proxy_public_id<'a, T: Display>(
@@ -18,6 +25,27 @@ pub fn get_proxy_public_id<'a, T: Display>(
         Ok(proxy_pub_id)
     } else {
         error!("{} Unable to find connection to proxy node.", label);
+        Err(RoutingError::ProxyConnectionNotFound)
+    }
+}
+
+pub fn find_proxy_public_id<'a, T: Display>(
+    label: &T,
+    peer_mgr: &'a PeerManager,
+    proxy_name: &XorName,
+) -> Result<&'a PublicId, RoutingError> {
+    if let Some(pub_id) = peer_mgr.get_peer_by_name(proxy_name).map(Peer::pub_id) {
+        if peer_mgr.is_connected(pub_id) {
+            Ok(pub_id)
+        } else {
+            error!(
+                "{} - Unable to find connection to proxy in PeerManager.",
+                label
+            );
+            Err(RoutingError::ProxyConnectionNotFound)
+        }
+    } else {
+        error!("{} - Unable to find proxy in PeerManager.", label);
         Err(RoutingError::ProxyConnectionNotFound)
     }
 }

--- a/src/states/common/relocated_not_established.rs
+++ b/src/states/common/relocated_not_established.rs
@@ -8,7 +8,7 @@
 
 use super::Relocated;
 use crate::{
-    error::RoutingError,
+    error::{BootstrapResponseError, RoutingError},
     id::PublicId,
     messages::{DirectMessage, RoutingMessage},
     outbox::EventBox,
@@ -124,6 +124,18 @@ pub trait RelocatedNotEstablished: Relocated {
         self.log_connect_failure(&pub_id);
         let _ = self.dropped_peer(&pub_id);
         Transition::Stay
+    }
+
+    fn handle_bootstrap_request(&mut self, pub_id: PublicId) {
+        debug!(
+            "{} - Client {:?} rejected: We are not an established node yet.",
+            self, pub_id
+        );
+        self.send_direct_message(
+            pub_id,
+            DirectMessage::BootstrapResponse(Err(BootstrapResponseError::NotApproved)),
+        );
+        self.disconnect_peer(&pub_id);
     }
 
     fn dropped_peer(&mut self, pub_id: &PublicId) -> bool {

--- a/src/states/common/relocated_not_established.rs
+++ b/src/states/common/relocated_not_established.rs
@@ -1,0 +1,141 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Relocated;
+use crate::{
+    error::RoutingError,
+    id::PublicId,
+    messages::{DirectMessage, RoutingMessage},
+    outbox::EventBox,
+    peer_manager::{Peer, PeerState},
+    routing_table::Prefix,
+    state_machine::Transition,
+    xor_name::XorName,
+};
+
+pub trait RelocatedNotEstablished: Relocated {
+    fn our_prefix(&self) -> &Prefix<XorName>;
+    fn push_message_to_backlog(&mut self, msg: RoutingMessage);
+
+    fn check_direct_message_sender(
+        &self,
+        msg: &DirectMessage,
+        pub_id: &PublicId,
+    ) -> Result<(), RoutingError> {
+        match self.peer_mgr().get_peer(pub_id).map(Peer::state) {
+            Some(&PeerState::Connected) | Some(&PeerState::Proxy) => Ok(()),
+            _ => {
+                debug!(
+                    "{} Illegitimate direct message {:?} from {:?}.",
+                    self, msg, pub_id
+                );
+                Err(RoutingError::InvalidStateForOperation)
+            }
+        }
+    }
+
+    fn handle_routing_message(
+        &mut self,
+        msg: RoutingMessage,
+        outbox: &mut EventBox,
+    ) -> Result<(), RoutingError> {
+        use crate::{messages::MessageContent::*, routing_table::Authority::*};
+
+        let src_name = msg.src.name();
+
+        match msg {
+            RoutingMessage {
+                content:
+                    ConnectionInfoRequest {
+                        encrypted_conn_info,
+                        pub_id,
+                        msg_id,
+                    },
+                src: ManagedNode(_),
+                dst: ManagedNode(_),
+            } => {
+                if self.our_prefix().matches(&src_name) {
+                    self.handle_connection_info_request(
+                        encrypted_conn_info,
+                        pub_id,
+                        msg_id,
+                        msg.src,
+                        msg.dst,
+                        outbox,
+                    )
+                } else {
+                    self.add_message_to_backlog(RoutingMessage {
+                        content: ConnectionInfoRequest {
+                            encrypted_conn_info,
+                            pub_id,
+                            msg_id,
+                        },
+                        ..msg
+                    });
+                    Ok(())
+                }
+            }
+            RoutingMessage {
+                content:
+                    ConnectionInfoResponse {
+                        encrypted_conn_info,
+                        pub_id,
+                        msg_id,
+                    },
+                src: ManagedNode(src_name),
+                dst: Client { .. },
+            } => self.handle_connection_info_response(
+                encrypted_conn_info,
+                pub_id,
+                msg_id,
+                src_name,
+                msg.dst,
+            ),
+            RoutingMessage {
+                content: Ack(ack, _),
+                ..
+            } => {
+                self.handle_ack_response(ack);
+                Ok(())
+            }
+            _ => {
+                self.add_message_to_backlog(msg);
+                Ok(())
+            }
+        }
+    }
+
+    // Backlog the message to be processed once we are established.
+    fn add_message_to_backlog(&mut self, msg: RoutingMessage) {
+        trace!(
+            "{} Not established yet. Delaying message handling: {:?}",
+            self,
+            msg
+        );
+        self.push_message_to_backlog(msg);
+    }
+
+    fn handle_connect_failure(&mut self, pub_id: PublicId) -> Transition {
+        self.log_connect_failure(&pub_id);
+        let _ = self.dropped_peer(&pub_id);
+        Transition::Stay
+    }
+
+    fn dropped_peer(&mut self, pub_id: &PublicId) -> bool {
+        let was_proxy = self.peer_mgr().is_proxy(pub_id);
+        let _ = self.peer_mgr_mut().remove_peer(pub_id);
+        let _ = self.remove_from_notified_nodes(pub_id);
+
+        if was_proxy {
+            debug!("{} Lost connection to proxy {}.", self, pub_id);
+            false
+        } else {
+            true
+        }
+    }
+}

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -246,6 +246,10 @@ impl Base for EstablishingNode {
             ParsecResponse(version, par_response) => {
                 self.handle_parsec_response(version, par_response, pub_id, outbox)
             }
+            BootstrapRequest(_) => {
+                self.handle_bootstrap_request(pub_id);
+                Ok(Transition::Stay)
+            }
             _ => {
                 debug!("{} Unhandled direct message: {:?}", self, msg);
                 Ok(Transition::Stay)

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -170,9 +170,8 @@ impl EstablishingNode {
         self.timer.get_timed_out_tokens()
     }
 
-    pub fn has_unconsensused_observations(&self, filter_opaque: bool) -> bool {
-        self.parsec_map
-            .has_unconsensused_observations(filter_opaque)
+    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
+        self.parsec_map.has_unpolled_observations(filter_opaque)
     }
 }
 

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -1,0 +1,419 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    common::{
+        proxied, Approved, Base, Bootstrapped, NotEstablished, Relocated, RelocatedNotEstablished,
+    },
+    node::Node,
+};
+use crate::{
+    ack_manager::AckManager,
+    cache::Cache,
+    chain::{Chain, ExpectCandidatePayload, GenesisPfxInfo, ProvingSection, SectionInfo},
+    error::RoutingError,
+    id::{FullId, PublicId},
+    messages::{DirectMessage, HopMessage, Message, RoutingMessage},
+    outbox::EventBox,
+    parsec::ParsecMap,
+    peer_manager::{Peer, PeerManager, PeerState},
+    routing_message_filter::RoutingMessageFilter,
+    routing_table::{Authority, Prefix},
+    state_machine::{State, Transition},
+    time::{Duration, Instant},
+    timer::Timer,
+    xor_name::XorName,
+    Service,
+};
+use itertools::Itertools;
+use std::{
+    collections::BTreeSet,
+    fmt::{self, Display, Formatter},
+};
+
+const POKE_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub struct EstablishingNode {
+    ack_mgr: AckManager,
+    cache: Box<Cache>,
+    chain: Chain,
+    crust_service: Service,
+    full_id: FullId,
+    gen_pfx_info: GenesisPfxInfo,
+    /// Routing messages addressed to us that we cannot handle until we are established.
+    msg_backlog: Vec<RoutingMessage>,
+    notified_nodes: BTreeSet<PublicId>,
+    parsec_map: ParsecMap,
+    peer_mgr: PeerManager,
+    poke_timer_token: u64,
+    routing_msg_filter: RoutingMessageFilter,
+    timer: Timer,
+}
+
+impl EstablishingNode {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_proving_node(
+        ack_mgr: AckManager,
+        cache: Box<Cache>,
+        crust_service: Service,
+        full_id: FullId,
+        gen_pfx_info: GenesisPfxInfo,
+        min_section_size: usize,
+        msg_backlog: Vec<RoutingMessage>,
+        notified_nodes: BTreeSet<PublicId>,
+        peer_mgr: PeerManager,
+        routing_msg_filter: RoutingMessageFilter,
+        timer: Timer,
+    ) -> Self {
+        let public_id = *full_id.public_id();
+        let poke_timer_token = timer.schedule(POKE_TIMEOUT);
+
+        let parsec_map = ParsecMap::new(full_id.clone(), &gen_pfx_info);
+        let chain = Chain::new(min_section_size, public_id, gen_pfx_info.clone());
+
+        let node = Self {
+            ack_mgr,
+            cache,
+            chain,
+            crust_service,
+            full_id,
+            gen_pfx_info,
+            msg_backlog,
+            notified_nodes,
+            parsec_map,
+            peer_mgr,
+            poke_timer_token,
+            routing_msg_filter,
+            timer,
+        };
+
+        debug!("{} - State changed to EstablishingNode.", node);
+        node
+    }
+
+    pub fn into_node(
+        self,
+        sec_info: SectionInfo,
+        old_pfx: Prefix<XorName>,
+        outbox: &mut EventBox,
+    ) -> State {
+        let node = Node::from_establishing_node(
+            self.ack_mgr,
+            self.cache,
+            self.chain,
+            self.crust_service,
+            self.full_id,
+            self.gen_pfx_info,
+            self.msg_backlog.into_iter().collect(),
+            self.notified_nodes,
+            old_pfx,
+            self.parsec_map,
+            self.peer_mgr,
+            self.routing_msg_filter,
+            sec_info,
+            self.timer,
+            outbox,
+        );
+
+        match node {
+            Ok(node) => State::Node(node),
+            Err(_) => State::Terminated,
+        }
+    }
+
+    fn dispatch_routing_message(
+        &mut self,
+        msg: RoutingMessage,
+        outbox: &mut EventBox,
+    ) -> Result<Transition, RoutingError> {
+        self.handle_routing_message(msg, outbox)
+            .map(|()| Transition::Stay)
+    }
+
+    // Sends a `ParsecPoke` message to trigger a gossip request from current section members to us.
+    //
+    // TODO: Should restrict targets to few(counter churn-threshold)/single.
+    // Currently this can result in incoming spam of gossip history from everyone.
+    // Can also just be a single target once node-ageing makes Offline votes Opaque which should
+    // remove invalid test failures for unaccumulated parsec::Remove blocks.
+    fn send_parsec_poke(&mut self) {
+        let version = *self.gen_pfx_info.first_info.version();
+        let recipients = self
+            .gen_pfx_info
+            .latest_info
+            .members()
+            .iter()
+            .cloned()
+            .collect_vec();
+
+        for recipient in recipients {
+            self.send_message(
+                &recipient,
+                Message::Direct(DirectMessage::ParsecPoke(version)),
+            );
+        }
+    }
+}
+
+#[cfg(feature = "mock_base")]
+impl EstablishingNode {
+    pub fn chain(&self) -> &Chain {
+        &self.chain
+    }
+
+    pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
+        self.timer.get_timed_out_tokens()
+    }
+
+    pub fn has_unconsensused_observations(&self, filter_opaque: bool) -> bool {
+        self.parsec_map
+            .has_unconsensused_observations(filter_opaque)
+    }
+}
+
+impl Base for EstablishingNode {
+    fn crust_service(&self) -> &Service {
+        &self.crust_service
+    }
+
+    fn full_id(&self) -> &FullId {
+        &self.full_id
+    }
+
+    fn in_authority(&self, auth: &Authority<XorName>) -> bool {
+        if let Authority::Client { ref client_id, .. } = *auth {
+            client_id == self.full_id.public_id()
+        } else {
+            false
+        }
+    }
+
+    fn min_section_size(&self) -> usize {
+        self.chain.min_sec_size()
+    }
+
+    fn handle_timeout(&mut self, token: u64, _: &mut EventBox) -> Transition {
+        if self.poke_timer_token == token {
+            self.send_parsec_poke();
+            self.poke_timer_token = self.timer.schedule(POKE_TIMEOUT);
+        } else {
+            self.resend_unacknowledged_timed_out_msgs(token);
+        }
+
+        Transition::Stay
+    }
+
+    fn handle_connect_success(&mut self, pub_id: PublicId, outbox: &mut EventBox) -> Transition {
+        Relocated::handle_connect_success(self, pub_id, outbox)
+    }
+
+    fn handle_connect_failure(&mut self, pub_id: PublicId, _: &mut EventBox) -> Transition {
+        RelocatedNotEstablished::handle_connect_failure(self, pub_id)
+    }
+
+    fn handle_direct_message(
+        &mut self,
+        msg: DirectMessage,
+        pub_id: PublicId,
+        outbox: &mut EventBox,
+    ) -> Result<Transition, RoutingError> {
+        self.check_direct_message_sender(&msg, &pub_id)?;
+
+        use crate::messages::DirectMessage::*;
+        match msg {
+            ParsecRequest(version, par_request) => {
+                self.handle_parsec_request(version, par_request, pub_id, outbox)
+            }
+            ParsecResponse(version, par_response) => {
+                self.handle_parsec_response(version, par_response, pub_id, outbox)
+            }
+            _ => {
+                debug!("{} Unhandled direct message: {:?}", self, msg);
+                Ok(Transition::Stay)
+            }
+        }
+    }
+
+    fn handle_hop_message(
+        &mut self,
+        hop_msg: HopMessage,
+        pub_id: PublicId,
+        outbox: &mut EventBox,
+    ) -> Result<Transition, RoutingError> {
+        match self.peer_mgr.get_peer(&pub_id).map(Peer::state) {
+            Some(&PeerState::Connected) | Some(&PeerState::Proxy) => (),
+            _ => return Err(RoutingError::UnknownConnection(pub_id)),
+        }
+
+        if let Some(routing_msg) = self.filter_hop_message(hop_msg, pub_id)? {
+            self.dispatch_routing_message(routing_msg, outbox)
+        } else {
+            Ok(Transition::Stay)
+        }
+    }
+}
+
+impl Bootstrapped for EstablishingNode {
+    fn ack_mgr(&self) -> &AckManager {
+        &self.ack_mgr
+    }
+
+    fn ack_mgr_mut(&mut self) -> &mut AckManager {
+        &mut self.ack_mgr
+    }
+
+    fn routing_msg_filter(&mut self) -> &mut RoutingMessageFilter {
+        &mut self.routing_msg_filter
+    }
+
+    fn timer(&mut self) -> &mut Timer {
+        &mut self.timer
+    }
+
+    fn send_routing_message_via_route(
+        &mut self,
+        routing_msg: RoutingMessage,
+        src_section: Option<SectionInfo>,
+        route: u8,
+        expires_at: Option<Instant>,
+    ) -> Result<(), RoutingError> {
+        self.send_routing_message_via_proxy(routing_msg, src_section, route, expires_at)
+    }
+}
+
+impl Relocated for EstablishingNode {
+    fn peer_mgr(&self) -> &PeerManager {
+        &self.peer_mgr
+    }
+
+    fn peer_mgr_mut(&mut self) -> &mut PeerManager {
+        &mut self.peer_mgr
+    }
+
+    fn process_connection(&mut self, pub_id: PublicId, outbox: &mut EventBox) {
+        if self.chain.is_peer_valid(&pub_id) {
+            self.add_to_routing_table(&pub_id, outbox);
+        }
+    }
+
+    fn is_peer_valid(&self, _pub_id: &PublicId) -> bool {
+        true
+    }
+
+    fn add_to_notified_nodes(&mut self, pub_id: PublicId) -> bool {
+        self.notified_nodes.insert(pub_id)
+    }
+
+    fn remove_from_notified_nodes(&mut self, pub_id: &PublicId) -> bool {
+        self.notified_nodes.remove(pub_id)
+    }
+
+    fn add_to_routing_table_success(&mut self, _: &PublicId) {}
+
+    fn add_to_routing_table_failure(&mut self, pub_id: &PublicId) {
+        self.disconnect_peer(pub_id)
+    }
+}
+
+impl NotEstablished for EstablishingNode {
+    const SEND_ACK: bool = true;
+
+    fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId, RoutingError> {
+        proxied::find_proxy_public_id(self, &self.peer_mgr, proxy_name)
+    }
+}
+
+impl RelocatedNotEstablished for EstablishingNode {
+    fn our_prefix(&self) -> &Prefix<XorName> {
+        self.chain.our_prefix()
+    }
+
+    fn push_message_to_backlog(&mut self, msg: RoutingMessage) {
+        self.msg_backlog.push(msg)
+    }
+}
+
+impl Approved for EstablishingNode {
+    fn parsec_map_mut(&mut self) -> &mut ParsecMap {
+        &mut self.parsec_map
+    }
+
+    fn chain_mut(&mut self) -> &mut Chain {
+        &mut self.chain
+    }
+
+    fn handle_online_event(
+        &mut self,
+        new_pub_id: PublicId,
+        _: Authority<XorName>,
+        _: &mut EventBox,
+    ) -> Result<(), RoutingError> {
+        let _ = self.chain.add_member(new_pub_id)?;
+        Ok(())
+    }
+
+    fn handle_offline_event(
+        &mut self,
+        pub_id: PublicId,
+        _: &mut EventBox,
+    ) -> Result<(), RoutingError> {
+        let _ = self.chain.remove_member(pub_id)?;
+        Ok(())
+    }
+
+    fn handle_expect_candidate_event(
+        &mut self,
+        _: ExpectCandidatePayload,
+    ) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
+    fn handle_section_info_event(
+        &mut self,
+        sec_info: SectionInfo,
+        old_pfx: Prefix<XorName>,
+        _: &mut EventBox,
+    ) -> Result<Transition, RoutingError> {
+        if self.chain.is_member() {
+            Ok(Transition::IntoNode { sec_info, old_pfx })
+        } else {
+            debug!("{} - Unhandled SectionInfo event", self);
+            Ok(Transition::Stay)
+        }
+    }
+
+    fn handle_our_merge_event(&mut self) -> Result<(), RoutingError> {
+        debug!("{} - Unhandled OurMerge event", self);
+        Ok(())
+    }
+
+    fn handle_neighbour_merge_event(&mut self) -> Result<(), RoutingError> {
+        debug!("{} - Unhandled NeighbourMerge event", self);
+        Ok(())
+    }
+
+    fn handle_proving_sections_event(
+        &mut self,
+        _: Vec<ProvingSection>,
+        _: SectionInfo,
+    ) -> Result<(), RoutingError> {
+        debug!("{} - Unhandled ProvingSections event", self);
+        Ok(())
+    }
+}
+
+impl Display for EstablishingNode {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "EstablishingNode({}({:b}))",
+            self.name(),
+            self.chain.our_prefix()
+        )
+    }
+}

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -8,7 +8,8 @@
 
 use super::{
     common::{
-        proxied, Approved, Base, Bootstrapped, NotEstablished, Relocated, RelocatedNotEstablished,
+        proxied, Approved, Base, Bootstrapped, BootstrappedNotEstablished, Relocated,
+        RelocatedNotEstablished,
     },
     node::{Node, NodeDetails},
 };
@@ -342,7 +343,7 @@ impl Relocated for EstablishingNode {
     }
 }
 
-impl NotEstablished for EstablishingNode {
+impl BootstrappedNotEstablished for EstablishingNode {
     const SEND_ACK: bool = true;
 
     fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId, RoutingError> {

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -53,17 +53,17 @@ pub use self::{
 //
 //
 // # Common traits
-//                           Bootstrapping
-//                           │   Client
-//                           │   │   RelocatingNode
-//                           │   │   │   ProvingNode
-//                           │   │   │   │   EstablishingNode
-//                           │   │   │   │   │   Node
-//                           │   │   │   │   │   │
-// Base                      *   *   *   *   *   *
-// Bootstrapped                  *   *   *   *   *
-// NotEstablished                *   *   *   *
-// Relocated                             *   *   *
-// RelocatedNotEstablished               *   *
-// Approved                                  *   *
+//                              Bootstrapping
+//                              │   Client
+//                              │   │   RelocatingNode
+//                              │   │   │   ProvingNode
+//                              │   │   │   │   EstablishingNode
+//                              │   │   │   │   │   Node
+//                              │   │   │   │   │   │
+// Base                         *   *   *   *   *   *
+// Bootstrapped                     *   *   *   *   *
+// BootstrappedNotEstablished       *   *   *   *
+// Relocated                                *   *   *
+// RelocatedNotEstablished                  *   *
+// Approved                                     *   *
 //

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod bootstrapping;
+mod bootstrapping_peer;
 mod client;
 pub mod common;
 mod establishing_node;
@@ -15,7 +15,7 @@ mod proving_node;
 mod relocating_node;
 
 pub use self::{
-    bootstrapping::{Bootstrapping, TargetState as BootstrappingTargetState},
+    bootstrapping_peer::{BootstrappingPeer, TargetState},
     client::{Client, RATE_EXCEED_RETRY},
     establishing_node::EstablishingNode,
     node::Node,

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -9,6 +9,7 @@
 mod bootstrapping;
 mod client;
 pub mod common;
+mod establishing_node;
 mod node;
 mod proving_node;
 mod relocating_node;
@@ -16,6 +17,7 @@ mod relocating_node;
 pub use self::{
     bootstrapping::{Bootstrapping, TargetState as BootstrappingTargetState},
     client::{Client, RATE_EXCEED_RETRY},
+    establishing_node::EstablishingNode,
     node::Node,
     proving_node::ProvingNode,
     relocating_node::RelocatingNode,
@@ -38,8 +40,30 @@ pub use self::{
 //        │   └────────────────┘ └─────────────┘
 //        │                        │
 //        │                        │
+//        │                        ▼
+//        │                      ┌──────────────────┐
+//        │                      │ EstablishingNode │
+//        │                      └──────────────────┘
+//        │                        │
+//        │                        │
 //        ▼                        ▼
 // ┌────────┐                    ┌──────┐
 // │ Client │                    │ Node │
 // └────────┘                    └──────┘
+//
+//
+// # Common traits
+//                           Bootstrapping
+//                           │   Client
+//                           │   │   RelocatingNode
+//                           │   │   │   ProvingNode
+//                           │   │   │   │   EstablishingNode
+//                           │   │   │   │   │   Node
+//                           │   │   │   │   │   │
+// Base                      *   *   *   *   *   *
+// Bootstrapped                  *   *   *   *   *
+// NotEstablished                *   *   *   *
+// Relocated                             *   *   *
+// RelocatedNotEstablished               *   *
+// Approved                                  *   *
 //

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -994,7 +994,10 @@ impl Node {
                 Section(_),
             ) => self.handle_neighbour_confirm(digest, proofs, sec_infos_and_proofs),
             (Merge(digest), PrefixSection(_), PrefixSection(_)) => self.handle_merge(digest),
-            (Ack(ack, _), _, _) => self.handle_ack_response(ack),
+            (Ack(ack, _), _, _) => {
+                self.handle_ack_response(ack);
+                Ok(())
+            }
             (
                 UserMessagePart {
                     hash,
@@ -1754,11 +1757,6 @@ impl Node {
 
     fn handle_merge(&mut self, digest: Digest256) -> Result<(), RoutingError> {
         self.vote_for_event(NetworkEvent::NeighbourMerge(digest));
-        Ok(())
-    }
-
-    fn handle_ack_response(&mut self, ack: Ack) -> Result<(), RoutingError> {
-        self.ack_mgr.receive(ack);
         Ok(())
     }
 
@@ -2693,7 +2691,11 @@ impl Bootstrapped for Node {
 }
 
 impl Relocated for Node {
-    fn peer_mgr(&mut self) -> &mut PeerManager {
+    fn peer_mgr(&self) -> &PeerManager {
+        &self.peer_mgr
+    }
+
+    fn peer_mgr_mut(&mut self) -> &mut PeerManager {
         &mut self.peer_mgr
     }
 
@@ -2720,6 +2722,10 @@ impl Relocated for Node {
 
     fn add_to_notified_nodes(&mut self, pub_id: PublicId) -> bool {
         self.notified_nodes.insert(pub_id)
+    }
+
+    fn remove_from_notified_nodes(&mut self, pub_id: &PublicId) -> bool {
+        self.notified_nodes.remove(pub_id)
     }
 }
 

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -7,7 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    common::{proxied, Base, Bootstrapped, NotEstablished, Relocated, RelocatedNotEstablished},
+    common::{
+        proxied, Base, Bootstrapped, BootstrappedNotEstablished, Relocated, RelocatedNotEstablished,
+    },
     establishing_node::{EstablishingNode, EstablishingNodeDetails},
 };
 use crate::{
@@ -440,7 +442,7 @@ impl Relocated for ProvingNode {
     }
 }
 
-impl NotEstablished for ProvingNode {
+impl BootstrappedNotEstablished for ProvingNode {
     const SEND_ACK: bool = true;
 
     fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId, RoutingError> {

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -150,7 +150,7 @@ impl ProvingNode {
         self,
         gen_pfx_info: GenesisPfxInfo,
         outbox: &mut EventBox,
-    ) -> State {
+    ) -> Result<State, RoutingError> {
         let details = EstablishingNodeDetails {
             ack_mgr: self.ack_mgr,
             cache: self.cache,
@@ -165,10 +165,7 @@ impl ProvingNode {
             timer: self.timer,
         };
 
-        match EstablishingNode::from_proving_node(details, outbox) {
-            Ok(node) => State::EstablishingNode(node),
-            Err(_) => State::Terminated,
-        }
+        EstablishingNode::from_proving_node(details, outbox).map(State::EstablishingNode)
     }
 
     fn dispatch_routing_message(

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -8,7 +8,7 @@
 
 use super::{
     common::{proxied, Base, Bootstrapped, NotEstablished, Relocated, RelocatedNotEstablished},
-    node::Node,
+    establishing_node::EstablishingNode,
 };
 use crate::{
     ack_manager::AckManager,
@@ -140,22 +140,20 @@ impl ProvingNode {
         }
     }
 
-    pub fn into_node(self, gen_pfx_info: GenesisPfxInfo) -> State {
-        let node = Node::from_proving_node(
+    pub fn into_establishing_node(self, gen_pfx_info: GenesisPfxInfo) -> State {
+        State::EstablishingNode(EstablishingNode::from_proving_node(
             self.ack_mgr,
             self.cache,
             self.crust_service,
             self.full_id,
             gen_pfx_info,
             self.min_section_size,
-            self.msg_backlog.into_iter().collect(),
+            self.msg_backlog,
             self.notified_nodes,
             self.peer_mgr,
             self.routing_msg_filter,
             self.timer,
-        );
-
-        State::Node(node)
+        ))
     }
 
     fn dispatch_routing_message(
@@ -184,7 +182,7 @@ impl ProvingNode {
             self
         );
 
-        Transition::IntoNode { gen_pfx_info }
+        Transition::IntoEstablishingNode { gen_pfx_info }
     }
 
     fn dropped_peer(&mut self, pub_id: &PublicId) -> bool {

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -311,6 +311,7 @@ impl Base for ProvingNode {
                     self.send_direct_message(pub_id, msg);
                 }
             }
+            BootstrapRequest(_) => self.handle_bootstrap_request(pub_id),
             _ => {
                 debug!("{} Unhandled direct message: {:?}", self, msg);
             }

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -342,6 +342,11 @@ impl ProvingNode {
             true
         }
     }
+
+    #[cfg(feature = "mock")]
+    pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
+        self.timer.get_timed_out_tokens()
+    }
 }
 
 impl Base for ProvingNode {

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    common::{unrelocated, Base, Bootstrapped, Unapproved},
+    common::{proxied, Base, Bootstrapped, NotEstablished},
     Bootstrapping, BootstrappingTargetState,
 };
 use crate::{
@@ -336,11 +336,11 @@ impl Bootstrapped for RelocatingNode {
     }
 }
 
-impl Unapproved for RelocatingNode {
+impl NotEstablished for RelocatingNode {
     const SEND_ACK: bool = true;
 
     fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId> {
-        unrelocated::get_proxy_public_id(self, &self.proxy_pub_id, proxy_name)
+        proxied::get_proxy_public_id(self, &self.proxy_pub_id, proxy_name)
     }
 }
 

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -8,7 +8,7 @@
 
 use super::{
     common::{proxied, Base, Bootstrapped, BootstrappedNotEstablished},
-    Bootstrapping, BootstrappingTargetState,
+    BootstrappingPeer, TargetState,
 };
 use crate::{
     ack_manager::{Ack, AckManager},
@@ -104,11 +104,11 @@ impl RelocatingNode {
             crust_rx,
             crust_sender,
         );
-        let target_state = BootstrappingTargetState::ProvingNode {
+        let target_state = TargetState::ProvingNode {
             old_full_id: self.full_id,
             our_section: our_section,
         };
-        if let Some(bootstrapping) = Bootstrapping::new(
+        if let Some(peer) = BootstrappingPeer::new(
             self.action_sender,
             self.cache,
             target_state,
@@ -117,7 +117,7 @@ impl RelocatingNode {
             self.min_section_size,
             self.timer,
         ) {
-            State::Bootstrapping(bootstrapping)
+            State::BootstrappingPeer(peer)
         } else {
             outbox.send_event(Event::RestartRequired);
             State::Terminated

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -56,28 +56,19 @@ pub struct RelocatingNode {
 }
 
 impl RelocatingNode {
-    #[allow(clippy::too_many_arguments)]
-    pub fn from_bootstrapping(
-        action_sender: RoutingActionSender,
-        cache: Box<Cache>,
-        crust_service: Service,
-        full_id: FullId,
-        min_section_size: usize,
-        proxy_pub_id: PublicId,
-        timer: Timer,
-    ) -> Option<Self> {
-        let relocation_timer_token = timer.schedule(RELOCATE_TIMEOUT);
+    pub fn from_bootstrapping(source: Bootstrapping, proxy_pub_id: PublicId) -> Option<Self> {
+        let relocation_timer_token = source.timer.schedule(RELOCATE_TIMEOUT);
         let mut node = Self {
-            action_sender: action_sender,
+            action_sender: source.action_sender,
             ack_mgr: AckManager::new(),
-            crust_service: crust_service,
-            full_id: full_id,
-            cache: cache,
-            min_section_size: min_section_size,
-            proxy_pub_id: proxy_pub_id,
+            crust_service: source.crust_service,
+            full_id: source.full_id,
+            cache: source.cache,
+            min_section_size: source.min_section_size,
+            proxy_pub_id,
             routing_msg_filter: RoutingMessageFilter::new(),
-            relocation_timer_token: relocation_timer_token,
-            timer: timer,
+            relocation_timer_token,
+            timer: source.timer,
         };
 
         if let Err(error) = node.relocate() {

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -39,6 +39,16 @@ use std::{
 /// Total time to wait for `RelocateResponse`.
 const RELOCATE_TIMEOUT: Duration = Duration::from_secs(60 + RESOURCE_PROOF_DURATION.as_secs());
 
+pub struct RelocatingNodeDetails {
+    pub action_sender: RoutingActionSender,
+    pub cache: Box<Cache>,
+    pub crust_service: Service,
+    pub full_id: FullId,
+    pub min_section_size: usize,
+    pub proxy_pub_id: PublicId,
+    pub timer: Timer,
+}
+
 pub struct RelocatingNode {
     action_sender: RoutingActionSender,
     ack_mgr: AckManager,
@@ -56,19 +66,19 @@ pub struct RelocatingNode {
 }
 
 impl RelocatingNode {
-    pub fn from_bootstrapping(source: Bootstrapping, proxy_pub_id: PublicId) -> Option<Self> {
-        let relocation_timer_token = source.timer.schedule(RELOCATE_TIMEOUT);
+    pub fn from_bootstrapping(details: RelocatingNodeDetails) -> Option<Self> {
+        let relocation_timer_token = details.timer.schedule(RELOCATE_TIMEOUT);
         let mut node = Self {
-            action_sender: source.action_sender,
+            action_sender: details.action_sender,
             ack_mgr: AckManager::new(),
-            crust_service: source.crust_service,
-            full_id: source.full_id,
-            cache: source.cache,
-            min_section_size: source.min_section_size,
-            proxy_pub_id,
+            crust_service: details.crust_service,
+            full_id: details.full_id,
+            cache: details.cache,
+            min_section_size: details.min_section_size,
+            proxy_pub_id: details.proxy_pub_id,
             routing_msg_filter: RoutingMessageFilter::new(),
             relocation_timer_token,
-            timer: source.timer,
+            timer: details.timer,
         };
 
         if let Err(error) = node.relocate() {

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    common::{proxied, Base, Bootstrapped, NotEstablished},
+    common::{proxied, Base, Bootstrapped, BootstrappedNotEstablished},
     Bootstrapping, BootstrappingTargetState,
 };
 use crate::{
@@ -337,7 +337,7 @@ impl Bootstrapped for RelocatingNode {
     }
 }
 
-impl NotEstablished for RelocatingNode {
+impl BootstrappedNotEstablished for RelocatingNode {
     const SEND_ACK: bool = true;
 
     fn get_proxy_public_id(&self, proxy_name: &XorName) -> Result<&PublicId> {

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -367,9 +367,7 @@ pub fn poll_and_resend(nodes: &mut [TestNode], clients: &mut [TestClient]) {
             // after MAX_POLL_CALLS / 2 only filter for opaque events
             // to avoid stalling the test due to lack of parsec voters.
             node.inner.has_unacked_msg()
-                || node
-                    .inner
-                    .has_unconsensused_observations(i > MAX_POLL_CALLS / 2)
+                || node.inner.has_unpolled_observations(i > MAX_POLL_CALLS / 2)
         };
         let client_busy = |client: &TestClient| client.inner.has_unacked_msg();
         if poll_all(nodes, clients)


### PR DESCRIPTION
This is a refactoring PR with almost no functional changes. Exceptions are some minor changes for the sake of simplicity, clarity or performance. They are listed below:

1. When `EstablishingNode` receives `NodeApproval`, it backlogs it and once it becomes `Node` it logs and ignores it. Previously it would immediately log and ignore it.
2. In `EstablishingNode`, `handle_hop_message` and `send_routing_message_via_route` now work the same way as in `ProvingNode` as opposed to the way they work in `Node`. This makes it more explicit what the responsibilities of each of the states are. 