### PR TITLE
mock serialise: 4x speed up aggressive churn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "~1.0.8"
 [features]
 mock = ["lru_time_cache/fake_clock", "safe_crypto/mock", "parsec/mock", "parsec/malice-detection"]
 mock_parsec = ["mock"]
+mock_serialise = ["mock"]
 
 [[example]]
 bench = false

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -7,3 +7,4 @@ cargo fmt -- --check
 cargo clippy $@ --all-targets
 cargo clippy $@ --all-targets --features=mock
 cargo clippy $@ --all-targets --features=mock_parsec
+cargo clippy $@ --all-targets --features=mock_serialise

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ type CrustBytes = Vec<u8>;
 #[cfg(feature = "mock_serialise")]
 use crate::messages::Message;
 #[cfg(feature = "mock_serialise")]
-type CrustBytes = Message;
+type CrustBytes = Box<Message>;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,15 @@ type CrustEventSender = crust::CrustEventSender<PublicId>;
 type PrivConnectionInfo = crust::PrivConnectionInfo<PublicId>;
 type PubConnectionInfo = crust::PubConnectionInfo<PublicId>;
 
+// Format that can be sent between peers
+#[cfg(not(feature = "mock_serialise"))]
+type CrustBytes = Vec<u8>;
+
+#[cfg(feature = "mock_serialise")]
+use crate::messages::Message;
+#[cfg(feature = "mock_serialise")]
+type CrustBytes = Message;
+
 #[cfg(test)]
 mod tests {
     use super::{QUORUM_DENOMINATOR, QUORUM_NUMERATOR};

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -51,6 +51,7 @@ pub const CLIENT_GET_PRIORITY: u8 = 3;
 /// Wrapper of all messages.
 ///
 /// This is the only type allowed to be sent / received on the network.
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Debug, Serialize, Deserialize)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
@@ -73,6 +74,7 @@ impl Message {
 /// Messages sent via a direct connection.
 ///
 /// Allows routing to directly send specific messages between nodes.
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Serialize, Deserialize)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
@@ -153,6 +155,7 @@ impl DirectMessage {
 /// To relay a `SignedMessage` via another node, the `SignedMessage` is wrapped in a `HopMessage`.
 /// The `signature` is from the node that sends this directly to a node in its routing table. To
 /// prevent Man-in-the-middle attacks, the `content` is signed by the original sender.
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Serialize, Deserialize)]
 pub struct HopMessage {
     /// Wrapped signed message.

--- a/src/mock_crust/crust.rs
+++ b/src/mock_crust/crust.rs
@@ -8,6 +8,7 @@
 
 pub use super::support::Config;
 use super::support::{Endpoint, Network, ServiceHandle, ServiceImpl};
+use crate::CrustBytes;
 use maidsafe_utilities::event_sender;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -149,7 +150,7 @@ impl<UID: Uid> Service<UID> {
 
     /// Send message to the given peer.
     // TODO: Implement tests that drop low-priority messages.
-    pub fn send(&self, uid: &UID, data: Vec<u8>, _priority: u8) -> Result<(), CrustError> {
+    pub fn send(&self, uid: &UID, data: CrustBytes, _priority: u8) -> Result<(), CrustError> {
         if self.lock().send_message(uid, data) {
             Ok(())
         } else {
@@ -212,7 +213,7 @@ pub enum Event<UID: Uid> {
     /// Invoked when a peer disconnects or can no longer be contacted.
     LostPeer(UID),
     /// Invoked when a new message is received. Passes the message.
-    NewMessage(UID, CrustUser, Vec<u8>),
+    NewMessage(UID, CrustUser, CrustBytes),
     /// Invoked when trying to sending a too large data.
     WriteMsgSizeProhibitive(UID, Vec<u8>),
 }

--- a/src/mock_crust/mod.rs
+++ b/src/mock_crust/mod.rs
@@ -12,6 +12,7 @@ pub mod crust;
 mod support;
 
 #[cfg(test)]
+#[cfg(not(feature = "mock_serialise"))]
 mod tests;
 
 pub use self::support::{

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -732,8 +732,11 @@ impl<UID: Uid> Packet<UID> {
     #[cfg(feature = "mock_serialise")]
     fn is_parsec_req_resp(&self) -> bool {
         match self {
-            Packet::Message(Message::Direct(DirectMessage::ParsecRequest(_, _)))
-            | Packet::Message(Message::Direct(DirectMessage::ParsecResponse(_, _))) => true,
+            Packet::Message(msg) => match **msg {
+                Message::Direct(DirectMessage::ParsecRequest(_, _))
+                | Message::Direct(DirectMessage::ParsecResponse(_, _)) => true,
+                _ => false,
+            },
             _ => false,
         }
     }

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -14,9 +14,14 @@ use super::crust::{
     PubConnectionInfo, Uid,
 };
 use crate::id::PublicId;
+#[cfg(feature = "mock_serialise")]
+use crate::messages::DirectMessage;
 #[cfg(feature = "mock_parsec")]
 use crate::parsec;
+use crate::CrustBytes;
 use crate::CrustEvent;
+#[cfg(feature = "mock_serialise")]
+use crate::Message;
 use maidsafe_utilities::SeededRng;
 use rand::Rng;
 use safe_crypto;
@@ -401,7 +406,7 @@ impl<UID: Uid> ServiceImpl<UID> {
         }
     }
 
-    pub fn send_message(&self, uid: &UID, data: Vec<u8>) -> bool {
+    pub fn send_message(&self, uid: &UID, data: CrustBytes) -> bool {
         if let Some(endpoint) = self.find_endpoint_by_uid(uid) {
             self.send_packet(endpoint, Packet::Message(data));
             true
@@ -507,7 +512,7 @@ impl<UID: Uid> ServiceImpl<UID> {
         self.send_event(CrustEvent::ConnectFailure(their_id));
     }
 
-    fn handle_message(&self, peer_endpoint: Endpoint, data: Vec<u8>) {
+    fn handle_message(&self, peer_endpoint: Endpoint, data: CrustBytes) {
         if let Some((uid, kind)) = self.find_uid_and_kind_by_endpoint(&peer_endpoint) {
             self.send_event(CrustEvent::NewMessage(uid, kind, data));
         } else {
@@ -688,15 +693,17 @@ enum Packet<UID: Uid> {
     ConnectSuccess(UID, UID),
     ConnectFailure(UID, UID),
 
-    Message(Vec<u8>),
+    Message(CrustBytes),
     Disconnect,
 }
 
 /// The 4-byte tags of `Message::Direct` and `DirectMessage::ParsecRequest`.
 /// A serialised Parsec request message starts with these bytes.
+#[cfg(not(feature = "mock_serialise"))]
 static PARSEC_REQ_MSG_TAGS: &[u8] = &[0, 0, 0, 0, 9, 0, 0, 0];
 /// The 4-byte tags of `Message::Direct` and `DirectMessage::ParsecResponse`.
 /// A serialised Parsec response message starts with these bytes.
+#[cfg(not(feature = "mock_serialise"))]
 static PARSEC_RSP_MSG_TAGS: &[u8] = &[0, 0, 0, 0, 10, 0, 0, 0];
 
 impl<UID: Uid> Packet<UID> {
@@ -712,11 +719,21 @@ impl<UID: Uid> Packet<UID> {
     }
 
     /// Returns `true` if this packet contains a Parsec request or response.
+    #[cfg(not(feature = "mock_serialise"))]
     fn is_parsec_req_resp(&self) -> bool {
         match self {
             Packet::Message(bytes) if bytes.len() >= 8 => {
                 &bytes[..8] == PARSEC_REQ_MSG_TAGS || &bytes[..8] == PARSEC_RSP_MSG_TAGS
             }
+            _ => false,
+        }
+    }
+
+    #[cfg(feature = "mock_serialise")]
+    fn is_parsec_req_resp(&self) -> bool {
+        match self {
+            Packet::Message(Message::Direct(DirectMessage::ParsecRequest(_, _)))
+            | Packet::Message(Message::Direct(DirectMessage::ParsecResponse(_, _))) => true,
             _ => false,
         }
     }
@@ -766,6 +783,7 @@ where
 }
 
 #[test]
+#[cfg(not(feature = "mock_serialise"))]
 #[allow(clippy::let_unit_value)]
 fn test_is_parsec_req_resp() {
     use crate::chain::NetworkEvent;

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -21,11 +21,12 @@ use crate::outbox::EventBox;
 use crate::routing_message_filter::RoutingMessageFilter;
 use crate::routing_table::Authority;
 use crate::state_machine::Transition;
+use crate::states::common::from_crust_bytes;
 use crate::time::{Duration, Instant};
 use crate::timer::Timer;
 use crate::xor_name::XorName;
+use crate::CrustBytes;
 use crate::{CrustEvent, Service};
-use maidsafe_utilities::serialisation;
 use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 
@@ -171,13 +172,13 @@ impl Client {
     fn handle_new_message(
         &mut self,
         pub_id: PublicId,
-        bytes: Vec<u8>,
+        bytes: CrustBytes,
         outbox: &mut EventBox,
     ) -> Transition {
-        let transition = match serialisation::deserialise(&bytes) {
+        let transition = match from_crust_bytes(bytes) {
             Ok(Message::Hop(hop_msg)) => self.handle_hop_message(hop_msg, pub_id, outbox),
             Ok(Message::Direct(direct_msg)) => self.handle_direct_message(direct_msg),
-            Err(error) => Err(RoutingError::SerialisationError(error)),
+            Err(error) => Err(error),
         };
 
         match transition {

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -102,7 +102,7 @@ fn to_crust_bytes(
     let result = serialisation::serialise(&message).map_err(|err| (err, message));
 
     #[cfg(feature = "mock_serialise")]
-    let result = Ok(message);
+    let result = Ok(Box::new(message));
 
     result
 }
@@ -112,7 +112,7 @@ pub fn from_crust_bytes(data: CrustBytes) -> Result<Message, RoutingError> {
     let result = serialisation::deserialise(&data).map_err(RoutingError::SerialisationError);
 
     #[cfg(feature = "mock_serialise")]
-    let result = Ok(data);
+    let result = Ok(*data);
 
     result
 }

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -6,14 +6,17 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::error::RoutingError;
 use crate::id::{FullId, PublicId};
-use crate::messages::{DirectMessage, Message};
+use crate::messages::{DirectMessage, HopMessage, Message, SignedMessage};
 use crate::outbox::EventBox;
 use crate::routing_table::Authority;
 use crate::state_machine::Transition;
 use crate::xor_name::XorName;
+use crate::CrustBytes;
 use crate::Service;
 use maidsafe_utilities::serialisation;
+use std::collections::BTreeSet;
 use std::fmt::Display;
 
 // Trait for all states.
@@ -46,11 +49,11 @@ pub trait Base: Display {
     fn send_message(&mut self, dst_id: &PublicId, message: Message) {
         let priority = message.priority();
 
-        match serialisation::serialise(&message) {
+        match to_crust_bytes(message) {
             Ok(bytes) => {
                 self.send_or_drop(dst_id, bytes, priority);
             }
-            Err(error) => {
+            Err((error, message)) => {
                 error!(
                     "{} Failed to serialise message {:?}: {:?}",
                     self, message, error
@@ -62,10 +65,10 @@ pub trait Base: Display {
         };
     }
 
-    // Sends the given `bytes` to the peer with the given `dst_id`. If that results in an
+    // Sends the given `data` to the peer with the given `dst_id`. If that results in an
     // error, it disconnects from the peer.
-    fn send_or_drop(&mut self, dst_id: &PublicId, bytes: Vec<u8>, priority: u8) {
-        if let Err(err) = self.crust_service().send(dst_id, bytes, priority) {
+    fn send_or_drop(&mut self, dst_id: &PublicId, data: CrustBytes, priority: u8) {
+        if let Err(err) = self.crust_service().send(dst_id, data, priority) {
             info!("{} Connection to {} failed: {:?}", self, dst_id, err);
             // TODO: Handle lost peer, but avoid a cascade of sending messages and handling more
             //       lost peers: https://maidsafe.atlassian.net/browse/MAID-1924
@@ -73,4 +76,43 @@ pub trait Base: Display {
             // return self.handle_lost_peer(*pub_id).map(|_| Err(err.into()));
         }
     }
+
+    // Serialise HopMessage containing the given signed message.
+    fn to_hop_bytes(
+        &self,
+        signed_msg: SignedMessage,
+        route: u8,
+        sent_to: BTreeSet<XorName>,
+    ) -> Result<CrustBytes, RoutingError> {
+        let hop_msg = HopMessage::new(
+            signed_msg,
+            route,
+            sent_to,
+            self.full_id().signing_private_key(),
+        )?;
+        let message = Message::Hop(hop_msg);
+        Ok(to_crust_bytes(message).map_err(|(err, _)| err)?)
+    }
+}
+
+fn to_crust_bytes(
+    message: Message,
+) -> Result<CrustBytes, (serialisation::SerialisationError, Message)> {
+    #[cfg(not(feature = "mock_serialise"))]
+    let result = serialisation::serialise(&message).map_err(|err| (err, message));
+
+    #[cfg(feature = "mock_serialise")]
+    let result = Ok(message);
+
+    result
+}
+
+pub fn from_crust_bytes(data: CrustBytes) -> Result<Message, RoutingError> {
+    #[cfg(not(feature = "mock_serialise"))]
+    let result = serialisation::deserialise(&data).map_err(RoutingError::SerialisationError);
+
+    #[cfg(feature = "mock_serialise")]
+    let result = Ok(data);
+
+    result
 }

--- a/src/states/common/bootstrapped.rs
+++ b/src/states/common/bootstrapped.rs
@@ -11,14 +11,12 @@ use crate::ack_manager::{Ack, AckManager, UnacknowledgedMessage, ACK_TIMEOUT};
 use crate::chain::SectionInfo;
 use crate::error::Result;
 use crate::id::PublicId;
-use crate::messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedMessage};
+use crate::messages::{MessageContent, RoutingMessage};
 use crate::routing_message_filter::RoutingMessageFilter;
 use crate::routing_table::Authority;
 use crate::time::Instant;
 use crate::timer::Timer;
 use crate::xor_name::XorName;
-use maidsafe_utilities::serialisation;
-use std::collections::BTreeSet;
 
 // Common functionality for states that are bootstrapped (have established a crust
 // connection to at least one peer).
@@ -157,22 +155,5 @@ pub trait Bootstrapped: Base {
         if let Err(error) = self.send_routing_message_via_route(response, None, route, None) {
             debug!("{} Failed to send ack: {:?}", self, error);
         }
-    }
-
-    // Serialise HopMessage containing the given signed message.
-    fn to_hop_bytes(
-        &self,
-        signed_msg: SignedMessage,
-        route: u8,
-        sent_to: BTreeSet<XorName>,
-    ) -> Result<Vec<u8>> {
-        let hop_msg = HopMessage::new(
-            signed_msg,
-            route,
-            sent_to,
-            self.full_id().signing_private_key(),
-        )?;
-        let message = Message::Hop(hop_msg);
-        Ok(serialisation::serialise(&message)?)
     }
 }

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -13,7 +13,8 @@ mod unapproved;
 pub mod unrelocated;
 
 pub use self::{
-    base::Base, bootstrapped::Bootstrapped, relocated::Relocated, unapproved::Unapproved,
+    base::from_crust_bytes, base::Base, bootstrapped::Bootstrapped, relocated::Relocated,
+    unapproved::Unapproved,
 };
 use crate::time::Duration;
 

--- a/src/states/joining_node.rs
+++ b/src/states/joining_node.rs
@@ -21,13 +21,14 @@ use crate::resource_prover::RESOURCE_PROOF_DURATION;
 use crate::routing_message_filter::RoutingMessageFilter;
 use crate::routing_table::{Authority, Prefix};
 use crate::state_machine::{State, Transition};
+use crate::states::common::from_crust_bytes;
 use crate::time::{Duration, Instant};
 use crate::timer::Timer;
 use crate::types::{MessageId, RoutingActionSender};
 use crate::xor_name::XorName;
+use crate::CrustBytes;
 use crate::{CrustEvent, CrustEventSender, Service};
 use log::LogLevel;
-use maidsafe_utilities::serialisation;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -190,14 +191,14 @@ impl JoiningNode {
         old_crust_service
     }
 
-    fn handle_new_message(&mut self, pub_id: PublicId, bytes: Vec<u8>) -> Transition {
-        let transition = match serialisation::deserialise(&bytes) {
+    fn handle_new_message(&mut self, pub_id: PublicId, bytes: CrustBytes) -> Transition {
+        let transition = match from_crust_bytes(bytes) {
             Ok(Message::Hop(hop_msg)) => self.handle_hop_message(hop_msg, pub_id),
             Ok(message) => {
                 debug!("{} - Unhandled new message: {:?}", self, message);
                 Ok(Transition::Stay)
             }
-            Err(error) => Err(RoutingError::SerialisationError(error)),
+            Err(error) => Err(error),
         };
 
         match transition {

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -10,6 +10,7 @@ use super::{
     common::{Base, Bootstrapped, Relocated, Unapproved},
     node::Node,
 };
+use crate::states::common::from_crust_bytes;
 use crate::{
     ack_manager::{Ack, AckManager},
     action::Action,
@@ -32,7 +33,7 @@ use crate::{
     timer::Timer,
     types::RoutingActionSender,
     xor_name::XorName,
-    CrustEvent, Service,
+    CrustBytes, CrustEvent, Service,
 };
 use maidsafe_utilities::serialisation;
 use std::{
@@ -225,16 +226,15 @@ impl ProvingNode {
     fn handle_new_message(
         &mut self,
         pub_id: PublicId,
-        bytes: Vec<u8>,
+        bytes: CrustBytes,
         outbox: &mut EventBox,
     ) -> Result<Transition, RoutingError> {
-        match serialisation::deserialise(&bytes) {
-            Ok(Message::Direct(msg)) => {
+        match from_crust_bytes(bytes)? {
+            Message::Direct(msg) => {
                 self.handle_direct_message(msg, pub_id, outbox)?;
                 Ok(Transition::Stay)
             }
-            Ok(Message::Hop(msg)) => self.handle_hop_message(msg, pub_id, outbox),
-            Err(error) => Err(RoutingError::SerialisationError(error)),
+            Message::Hop(msg) => self.handle_hop_message(msg, pub_id, outbox),
         }
     }
 


### PR DESCRIPTION
Not serialize when sending messages.
Not serialising full content when verifying HopMessage

mock_crust::churn::aggressive_churn
seed: Some([0,1,2,4]):
Before: 100 seconds  (features=mock_parsec)
After:   23 seconds  (features=mock_serialise_send)

Note:
- The big remaining serialisation item is SignedMessage::check_integrity, we may remove it as part of N/3 message passing. Removing it aggressive_churn is 13.5 seconds.
- After that, what remains is in mock parsec, and the Message clone used to mock serialization.  