### PR TITLE
chore/routing: change 'mock' to mock all, and rename to `mock_base`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,10 @@ libc = "~0.2.29"
 serde_json = "~1.0.8"
 
 [features]
-mock = ["lru_time_cache/fake_clock", "safe_crypto/mock", "parsec/mock", "parsec/malice-detection"]
-mock_parsec = ["mock"]
-mock_serialise = ["mock"]
+mock_base = ["lru_time_cache/fake_clock", "safe_crypto/mock", "parsec/mock", "parsec/malice-detection"]
+mock_parsec = ["mock_base"]
+mock_serialise = ["mock_base"]
+mock = ["mock_parsec", "mock_serialise"]
 
 [[example]]
 bench = false

--- a/examples/ci_test.rs
+++ b/examples/ci_test.rs
@@ -52,7 +52,7 @@
     variant_size_differences,
     non_camel_case_types
 )]
-#![cfg_attr(feature = "mock", allow(unused_extern_crates, unused_imports))]
+#![cfg_attr(feature = "mock_base", allow(unused_extern_crates, unused_imports))]
 
 #[macro_use]
 extern crate log;
@@ -63,14 +63,14 @@ extern crate serde_derive;
 
 mod utils;
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 fn main() {
     println!("This example should be built without `--features=mock`.");
     // Return Linux sysexit code for "configuration error"
     ::std::process::exit(78);
 }
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 mod unnamed {
     use crate::utils::{ExampleClient, ExampleNode};
     use docopt::Docopt;
@@ -430,7 +430,7 @@ Options:
     }
 }
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 fn main() {
     unnamed::run_main()
 }

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -55,7 +55,7 @@
     variant_size_differences,
     non_camel_case_types
 )]
-#![cfg_attr(feature = "mock", allow(unused_extern_crates, unused_imports))]
+#![cfg_attr(feature = "mock_base", allow(unused_extern_crates, unused_imports))]
 
 #[macro_use]
 extern crate log;
@@ -63,19 +63,19 @@ extern crate log;
 extern crate unwrap;
 #[macro_use]
 extern crate serde_derive;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 extern crate safe_crypto;
 
 mod utils;
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 fn main() {
     println!("This example should be built without `--features=mock`.");
     // Return Linux sysexit code for "configuration error"
     ::std::process::exit(78);
 }
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 mod unnamed {
     use crate::utils::{ExampleClient, ExampleNode};
     use docopt::Docopt;
@@ -274,7 +274,7 @@ Options:
     }
 }
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 fn main() {
     unnamed::run_main()
 }

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#![cfg(not(feature = "mock"))]
+#![cfg(not(feature = "mock_base"))]
 
 mod example_client;
 mod example_node;

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -5,6 +5,7 @@ export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
 
 cargo fmt -- --check
 cargo clippy $@ --all-targets
-cargo clippy $@ --all-targets --features=mock
+cargo clippy $@ --all-targets --features=mock_base
 cargo clippy $@ --all-targets --features=mock_parsec
 cargo clippy $@ --all-targets --features=mock_serialise
+cargo clippy $@ --all-targets --features=mock

--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -100,7 +100,7 @@ impl AckManager {
         self.pending.remove(ack)
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     pub fn has_unacked_msg(&self) -> bool {
         !self.pending.is_empty()
     }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1354,7 +1354,7 @@ impl Display for Chain {
     }
 }
 
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 impl Chain {
     /// Returns the members of the section with the given prefix (if it exists)
     pub fn get_section(&self, pfx: &Prefix<XorName>) -> Option<&SectionInfo> {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -13,7 +13,7 @@ mod neighbour_sigs;
 mod network_event;
 mod proof;
 mod section_info;
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 mod test_utils;
 
 pub use self::chain::{Chain, PrefixChangeOutcome};
@@ -21,7 +21,7 @@ pub use self::neighbour_sigs::NeighbourSigs;
 pub use self::network_event::NetworkEvent;
 pub use self::proof::{Proof, ProofSet, ProvingSection};
 pub use self::section_info::SectionInfo;
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 pub use self::test_utils::verify_chain_invariant;
 use std::fmt::{self, Debug, Formatter};
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use crate::config_handler::{self, Config};
 use crate::data::{EntryAction, ImmutableData, MutableData, PermissionSet, User};
 use crate::error::{InterfaceError, RoutingError};
 use crate::event::Event;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use crate::event_stream::{EventStepper, EventStream};
 use crate::id::{FullId, PublicId};
 use crate::messages::{Request, CLIENT_GET_PRIORITY, DEFAULT_PRIORITY};
@@ -23,16 +23,16 @@ use crate::states::{Bootstrapping, BootstrappingTargetState};
 use crate::types::{MessageId, RoutingActionSender};
 use crate::xor_name::XorName;
 use crate::{BootstrapConfig, MIN_SECTION_SIZE};
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 use crust::read_config_file as read_bootstrap_config_file;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 use maidsafe_utilities::thread::{self, Joiner};
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 use safe_crypto;
 use safe_crypto::PublicSignKey;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::mpsc::{channel, Receiver, Sender};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use std::sync::mpsc::{RecvError, TryRecvError};
 use std::time::Duration;
 
@@ -45,14 +45,14 @@ pub struct Client {
     interface_result_tx: Sender<Result<(), InterfaceError>>,
     interface_result_rx: Receiver<Result<(), InterfaceError>>,
 
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     action_sender: RoutingActionSender,
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     _joiner: Joiner,
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     machine: StateMachine,
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     event_buffer: EventBuf,
 }
 
@@ -443,7 +443,7 @@ impl Client {
     }
 }
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 impl Client {
     /// Create a new `Client`.
     ///
@@ -540,7 +540,7 @@ impl Client {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl Client {
     /// Create a new `Client` for testing with mock crust.
     #[allow(clippy::new_ret_no_self)]
@@ -606,7 +606,7 @@ impl Client {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl EventStepper for Client {
     type Item = Event;
 
@@ -623,7 +623,7 @@ impl EventStepper for Client {
     }
 }
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 impl Drop for Client {
     fn drop(&mut self) {
         if let Err(err) = self.action_sender.send(Action::Terminate) {
@@ -632,7 +632,7 @@ impl Drop for Client {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl Drop for Client {
     fn drop(&mut self) {
         let _ = self.poll();

--- a/src/data/immutable_data.rs
+++ b/src/data/immutable_data.rs
@@ -82,12 +82,12 @@ impl Debug for ImmutableData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     use hex::ToHex;
     use maidsafe_utilities::{serialisation, SeededRng};
     use rand::Rng;
 
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     #[test]
     fn deterministic_test() {
         let value = "immutable data value".to_owned().into_bytes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! let (sender, receiver) = mpsc::channel::<Event>();
 //! let full_id = FullId::new(); // Generate new keys.
-//! # #[cfg(not(feature = "mock"))]
+//! # #[cfg(not(feature = "mock_base"))]
 //! let client = Client::new(sender, Some(full_id), None).unwrap();
 //! ```
 //!
@@ -153,7 +153,7 @@ extern crate log;
 extern crate quick_error;
 #[macro_use]
 extern crate unwrap;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 extern crate crust;
 #[macro_use]
 extern crate lazy_static;
@@ -203,7 +203,7 @@ mod xor_name;
 pub type BootstrapConfig = crust::Config;
 
 /// Mock crust
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 pub mod mock_crust;
 
 /// SHA-3 type alias.
@@ -229,7 +229,7 @@ pub const MIN_SECTION_SIZE: usize = 3;
 pub const ACC_LOGIN_ENTRY_KEY: &[u8] = b"Login";
 
 pub use crate::cache::{Cache, NullCache};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 pub use crate::chain::verify_chain_invariant;
 pub use crate::chain::Chain;
 pub use crate::client::Client;
@@ -246,16 +246,16 @@ pub use crate::event::Event;
 pub use crate::event_stream::EventStream;
 pub use crate::id::{FullId, PublicId};
 pub use crate::messages::{AccountInfo, Request, Response};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 pub use crate::mock_crust::crust;
 #[cfg(feature = "mock_parsec")]
 pub(crate) use crate::mock_parsec as parsec;
 pub use crate::node::{Node, NodeBuilder};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 pub use crate::peer_manager::test_consts;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 pub use crate::rate_limiter::rate_limiter_consts;
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 pub use crate::routing_table::verify_network_invariant;
 pub use crate::routing_table::Error as RoutingTableError;
 pub use crate::routing_table::{Authority, Prefix, RoutingTable, VersionedPrefix, Xorable};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-/// This macro will panic with the given message if compiled with "mock", otherwise it
+/// This macro will panic with the given message if compiled with "mock_base", otherwise it
 /// will simply log the message at the requested level.
 ///
 /// Example usage:
@@ -14,7 +14,7 @@
 #[macro_export]
 macro_rules! log_or_panic {
     ($log_level:expr, $($arg:tt)*) => {
-        if cfg!(feature = "mock") && !::std::thread::panicking() {
+        if cfg!(feature = "mock_base") && !::std::thread::panicking() {
             panic!($($arg)*);
         } else {
             log!($log_level, $($arg)*);

--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -102,13 +102,13 @@ mod tests {
     use rand::{self, Rng};
     use std::time::Duration;
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     fn sleep(time: u64) {
         use fake_clock::FakeClock;
         FakeClock::advance_time(time);
     }
 
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     fn sleep(time: u64) {
         use std::thread;
         thread::sleep(Duration::from_millis(time));

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,16 +25,16 @@ use crate::state_machine::{State, StateMachine};
 use crate::states::{self, Bootstrapping, BootstrappingTargetState};
 use crate::types::{MessageId, RoutingActionSender};
 use crate::xor_name::XorName;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use crate::Chain;
 use crate::MIN_SECTION_SIZE;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 use safe_crypto;
 use safe_crypto::PublicSignKey;
 use std::collections::{BTreeMap, BTreeSet};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use std::fmt::{self, Display, Formatter};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use std::net::IpAddr;
 use std::sync::mpsc::{channel, Receiver, RecvError, Sender, TryRecvError};
 
@@ -114,7 +114,7 @@ impl NodeBuilder {
     pub fn create(self) -> Result<Node, RoutingError> {
         // If we're not in a test environment where we might want to manually seed the crypto RNG
         // then seed randomly.
-        #[cfg(not(feature = "mock"))]
+        #[cfg(not(feature = "mock_base"))]
         safe_crypto::init()?;
 
         let mut ev_buffer = EventBuf::new();
@@ -528,7 +528,7 @@ impl Node {
     }
 
     /// Returns the chain for this node.
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     pub fn chain(&self) -> Result<&Chain, RoutingError> {
         self.machine.chain().ok_or(RoutingError::Terminated)
     }
@@ -582,7 +582,7 @@ impl EventStepper for Node {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl Node {
     /// Returns the list of banned clients' IPs held by this node.
     pub fn get_banned_client_ips(&self) -> BTreeSet<IpAddr> {
@@ -638,7 +638,7 @@ impl Node {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl Display for Node {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         self.machine.fmt(formatter)

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -34,7 +34,7 @@ const CONNECTED_PEER_TIMEOUT_SECS: u64 = 120;
 /// Time (in seconds) after which a `VotedFor` candidate will be removed.
 const CANDIDATE_ACCEPT_TIMEOUT_SECS: u64 = 120;
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 #[doc(hidden)]
 pub mod test_consts {
     pub const ACCUMULATION_TIMEOUT_SECS: u64 = super::ACCUMULATION_TIMEOUT.as_secs();
@@ -1021,7 +1021,7 @@ impl fmt::Display for PeerManager {
     }
 }
 
-#[cfg(all(test, feature = "mock"))]
+#[cfg(all(test, feature = "mock_base"))]
 mod tests {
     use super::*;
     use crate::id::FullId;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -32,16 +32,16 @@ const MIN_CLIENT_CAPACITY: u64 = MAX_IMMUTABLE_DATA_SIZE_IN_BYTES + 10_240;
 /// it can be exceeded if there are enough client entries: each client will be allowed a
 /// hard-minimum of `MIN_CLIENT_CAPACITY` even if this means the `RateLimiter`'s total capacity
 /// exceeds the `SOFT_CAPACITY`.
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 const SOFT_CAPACITY: u64 = 8 * 1024 * 1024;
 /// For the mock-crust tests, we want a small `SOFT_CAPACITY` in order to trigger more rate-limited
 /// rejections. This must be at least `2 * MIN_CLIENT_CAPACITY` for the multi-client tests to work.
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 const SOFT_CAPACITY: u64 = 2 * MIN_CLIENT_CAPACITY;
 /// Duration for which entries are kept in the `overcharged` cache, in seconds.
 const OVERCHARGED_TIMEOUT_SECS: u64 = 300;
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 #[doc(hidden)]
 pub mod rate_limiter_consts {
     pub const SOFT_CAPACITY: u64 = super::SOFT_CAPACITY;
@@ -274,13 +274,13 @@ impl RateLimiter {
         }
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     pub fn usage_map(&self) -> &BTreeMap<IpAddr, u64> {
         &self.used
     }
 }
 
-#[cfg(all(test, feature = "mock"))]
+#[cfg(all(test, feature = "mock_base"))]
 mod tests {
     use super::*;
     use crate::data::ImmutableData;

--- a/src/resource_prover.rs
+++ b/src/resource_prover.rs
@@ -174,7 +174,7 @@ impl ResourceProver {
             }
         });
         // If using mock_crust we want the joiner to drop and join immediately
-        if cfg!(feature = "mock") {
+        if cfg!(feature = "mock_base") {
             let _ = joiner;
         } else {
             let old = self.workers.insert(pub_id, (atomic_cancel, joiner));

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -105,7 +105,7 @@ mod xorable;
 
 pub use self::authority::Authority;
 pub use self::error::Error;
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 pub use self::network_tests::verify_network_invariant;
 pub use self::prefix::{Prefix, VersionedPrefix, DEFAULT_PREFIX};
 pub use self::xorable::Xorable;
@@ -1176,7 +1176,7 @@ impl<T: Binary + Clone + Copy + Debug + Default + Hash + Xorable> RoutingTable<T
     }
 
     /// Runs the built-in invariant checker
-    #[cfg(any(test, feature = "mock"))]
+    #[cfg(any(test, feature = "mock_base"))]
     pub fn verify_invariant(&self) {
         unwrap!(
             self.check_invariant(false, true),

--- a/src/routing_table/network_tests.rs
+++ b/src/routing_table/network_tests.rs
@@ -8,7 +8,7 @@
 
 // This is used two ways: inline tests, and integration tests (with mock).
 // There's no point configuring each item which is only used in one of these.
-#![cfg(any(test, feature = "mock"))]
+#![cfg(any(test, feature = "mock_base"))]
 #![allow(dead_code, missing_docs)]
 
 use super::authority::Authority;

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -9,31 +9,31 @@
 use crate::action::Action;
 use crate::chain::GenesisPfxInfo;
 use crate::id::{FullId, PublicId};
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use crate::mock_crust;
 use crate::outbox::EventBox;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use crate::routing_table::Authority;
 use crate::routing_table::Prefix;
 use crate::states::common::Base;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use crate::states::common::Bootstrapped;
 use crate::states::{Bootstrapping, Client, JoiningNode, Node, ProvingNode};
 use crate::timer::Timer;
 use crate::types::RoutingActionSender;
 use crate::xor_name::XorName;
 use crate::BootstrapConfig;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use crate::Chain;
 use crate::{CrustEvent, CrustEventSender, Service, MIN_SECTION_SIZE};
 use log::LogLevel;
 use maidsafe_utilities::event_sender::MaidSafeEventCategory;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::mem;
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 use std::net::IpAddr;
 use std::sync::mpsc::{self, Receiver, RecvError, Sender, TryRecvError};
 
@@ -46,7 +46,7 @@ pub struct StateMachine {
     crust_tx: Sender<CrustEvent<PublicId>>,
     action_rx: Receiver<Action>,
     is_running: bool,
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     events: Vec<EventType>,
 }
 
@@ -61,13 +61,13 @@ pub enum State {
     Terminated,
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 enum EventType {
     CrustEvent(CrustEvent<PublicId>),
     Action(Box<Action>),
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 // TODO: remove this
 #[allow(unused)]
 impl EventType {
@@ -114,7 +114,7 @@ impl State {
         self.base_state().map(|state| *state.id())
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     fn chain(&self) -> Option<&Chain> {
         match *self {
             State::Node(ref state) => Some(state.chain()),
@@ -165,7 +165,7 @@ impl Debug for State {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl State {
     pub fn get_banned_client_ips(&self) -> BTreeSet<IpAddr> {
         match *self {
@@ -285,13 +285,13 @@ impl StateMachine {
         );
 
         let res = match bootstrap_config {
-            #[cfg(feature = "mock")]
+            #[cfg(feature = "mock_base")]
             Some(c) => Service::with_config(mock_crust::take_current(), crust_sender, c, pub_id),
-            #[cfg(not(feature = "mock"))]
+            #[cfg(not(feature = "mock_base"))]
             Some(c) => Service::with_config(crust_sender, c, pub_id),
-            #[cfg(feature = "mock")]
+            #[cfg(feature = "mock_base")]
             None => Service::new(mock_crust::take_current(), crust_sender, pub_id),
-            #[cfg(not(feature = "mock"))]
+            #[cfg(not(feature = "mock_base"))]
             None => Service::new(crust_sender, pub_id),
         };
 
@@ -306,7 +306,7 @@ impl StateMachine {
             State::Terminated => false,
             _ => true,
         };
-        #[cfg(feature = "mock")]
+        #[cfg(feature = "mock_base")]
         let machine = StateMachine {
             category_rx: category_rx,
             category_tx: category_tx,
@@ -317,7 +317,7 @@ impl StateMachine {
             is_running: is_running,
             events: Vec::new(),
         };
-        #[cfg(not(feature = "mock"))]
+        #[cfg(not(feature = "mock_base"))]
         let machine = StateMachine {
             category_rx: category_rx,
             category_tx: category_tx,
@@ -360,7 +360,7 @@ impl StateMachine {
     }
 
     // Handle an event from the list and send any events produced for higher layers.
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     fn handle_event_from_list(&mut self, outbox: &mut EventBox) {
         assert!(!self.events.is_empty());
         let event = self.events.remove(0);
@@ -441,7 +441,7 @@ impl StateMachine {
     }
 
     /// Query for a result, or yield: Err(NothingAvailable), Err(Disconnected) or Err(Terminated).
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     pub fn try_step(&mut self, outbox: &mut EventBox) -> Result<(), TryRecvError> {
         if self.is_running {
             let category = self.category_rx.try_recv()?;
@@ -453,7 +453,7 @@ impl StateMachine {
     }
 
     /// Query for a result, or yield: Err(NothingAvailable), Err(Disconnected).
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     pub fn try_step(&mut self, outbox: &mut EventBox) -> Result<(), TryRecvError> {
         use itertools::Itertools;
         use maidsafe_utilities::SeededRng;
@@ -525,7 +525,7 @@ impl StateMachine {
         self.state.id()
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     pub fn chain(&self) -> Option<&Chain> {
         self.state.chain()
     }
@@ -538,7 +538,7 @@ impl StateMachine {
         self.state.min_section_size()
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     /// Get reference to the current state.
     pub fn current(&self) -> &State {
         &self.state

--- a/src/states/bootstrapping.rs
+++ b/src/states/bootstrapping.rs
@@ -371,7 +371,7 @@ impl Display for Bootstrapping {
     }
 }
 
-#[cfg(all(test, feature = "mock"))]
+#[cfg(all(test, feature = "mock_base"))]
 mod tests {
     use super::*;
     use crate::cache::NullCache;

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -387,7 +387,7 @@ impl Unapproved for Client {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl Client {
     pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
         self.timer.get_timed_out_tokens()

--- a/src/states/joining_node.rs
+++ b/src/states/joining_node.rs
@@ -161,7 +161,7 @@ impl JoiningNode {
         }
     }
 
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(feature = "mock_base"))]
     fn start_new_crust_service(
         old_crust_service: Service,
         pub_id: PublicId,
@@ -180,7 +180,7 @@ impl JoiningNode {
         crust_service
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     fn start_new_crust_service(
         old_crust_service: Service,
         pub_id: PublicId,
@@ -309,7 +309,7 @@ impl JoiningNode {
         Transition::Stay
     }
 
-    #[cfg(feature = "mock")]
+    #[cfg(feature = "mock_base")]
     pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
         self.timer.get_timed_out_tokens()
     }

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1766,7 +1766,7 @@ impl Node {
                 RESOURCE_PROOF_TARGET_SIZE / (self.chain().our_section().len() + 1),
             )
         };
-        let seed: Vec<u8> = if cfg!(feature = "mock") {
+        let seed: Vec<u8> = if cfg!(feature = "mock_base") {
             vec![5u8; 4]
         } else {
             rand::thread_rng().gen_iter().take(10).collect()
@@ -1913,7 +1913,7 @@ impl Node {
 
         // If we're running in mock-crust mode, and we have relocation interval, don't try to do
         // section balancing, as it will break things.
-        let forbid_join_balancing = if cfg!(feature = "mock") {
+        let forbid_join_balancing = if cfg!(feature = "mock_base") {
             self.next_relocation_interval.is_some()
         } else {
             false
@@ -2605,7 +2605,7 @@ impl Base for Node {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 impl Node {
     pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
         self.timer.get_timed_out_tokens()

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 pub use fake_clock::FakeClock as Instant;
 pub use std::time::Duration;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 pub use std::time::Instant;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -8,7 +8,7 @@
 
 pub use self::implementation::Timer;
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(feature = "mock_base"))]
 mod implementation {
     use crate::{
         action::Action,
@@ -229,7 +229,7 @@ mod implementation {
     }
 }
 
-#[cfg(feature = "mock")]
+#[cfg(feature = "mock_base")]
 mod implementation {
     use crate::{
         time::{Duration, Instant},

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,11 +8,11 @@
 
 use crate::xor_name::XorName;
 use maidsafe_utilities::event_sender::MaidSafeObserver;
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 use maidsafe_utilities::SeededRng;
-#[cfg(all(not(test), not(feature = "mock")))]
+#[cfg(all(not(test), not(feature = "mock_base")))]
 use rand;
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 use rand::Rng;
 
 pub type RoutingActionSender = MaidSafeObserver<crate::action::Action>;
@@ -27,14 +27,14 @@ pub struct MessageId(XorName);
 
 impl MessageId {
     /// Generate a new `MessageId` with random content.
-    #[cfg(any(test, feature = "mock"))]
+    #[cfg(any(test, feature = "mock_base"))]
     pub fn new() -> MessageId {
         let mut rng = SeededRng::thread_rng();
         MessageId(rng.gen())
     }
 
     /// Generate a new `MessageId` with random content.
-    #[cfg(all(not(test), not(feature = "mock")))]
+    #[cfg(all(not(test), not(feature = "mock_base")))]
     pub fn new() -> MessageId {
         MessageId(rand::random())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -91,7 +91,7 @@ pub fn calculate_relocation_interval(
     (new_end - third_of_distance, new_end)
 }
 
-#[cfg(any(test, feature = "mock"))]
+#[cfg(any(test, feature = "mock_base"))]
 pub fn rand_index(exclusive_max: usize) -> usize {
     use maidsafe_utilities::SeededRng;
     use rand::Rng;
@@ -100,7 +100,7 @@ pub fn rand_index(exclusive_max: usize) -> usize {
     rng.gen::<usize>() % exclusive_max
 }
 
-#[cfg(all(not(test), not(feature = "mock")))]
+#[cfg(all(not(test), not(feature = "mock_base")))]
 pub fn rand_index(exclusive_max: usize) -> usize {
     ::rand::random::<usize>() % exclusive_max
 }

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -52,7 +52,7 @@
     missing_copy_implementations,
     missing_debug_implementations
 )]
-#![cfg(not(feature = "mock"))]
+#![cfg(not(feature = "mock_base"))]
 
 #[cfg(target_os = "macos")]
 extern crate libc;

--- a/tests/mock_crust_tests.rs
+++ b/tests/mock_crust_tests.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#![cfg(feature = "mock")]
+#![cfg(feature = "mock_base")]
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(


### PR DESCRIPTION
Rename `mock` to `mock_base`.
Re-add `mock` feature to mean mock all: mock_parsec,mock_serialise.
For fastest soak testing use features=mock.

Test:
time RUSTFLAGS=-g cargo test --release --features=mock
 => 1 min

time RUSTFLAGS=-g cargo test --release --features=mock_serialise --
--skip aggres --skip messages_during_churn
 => 22 min

mock_crust::churn::aggressive_churn seed: Some([0,1,2,4])
 => Killed after 2 hours as it was still running.