### PR TITLE
Replace AcceptAsCandidate RPC

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -18,7 +18,7 @@ mod test_utils;
 
 pub use self::chain::{Chain, PrefixChangeOutcome};
 pub use self::neighbour_sigs::NeighbourSigs;
-pub use self::network_event::NetworkEvent;
+pub use self::network_event::{ExpectCandidatePayload, NetworkEvent};
 pub use self::proof::{Proof, ProofSet, ProvingSection};
 pub use self::section_info::SectionInfo;
 #[cfg(any(test, feature = "mock_base"))]

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -10,10 +10,23 @@ use super::{ProofSet, ProvingSection, SectionInfo};
 use crate::id::PublicId;
 use crate::parsec;
 use crate::sha3::Digest256;
+use crate::types::MessageId;
 use crate::{Authority, RoutingError, XorName};
 use hex_fmt::HexFmt;
 use maidsafe_utilities::serialisation::serialise;
 use std::fmt::{self, Debug, Formatter};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ExpectCandidatePayload {
+    /// The joining node's current public ID.
+    pub old_public_id: PublicId,
+    /// The joining node's current authority.
+    pub old_client_auth: Authority<XorName>,
+    /// The message's unique identifier.
+    pub message_id: MessageId,
+    // The routing_msg.dst
+    pub dst_name: XorName,
+}
 
 /// Routing Network events
 // TODO: Box `SectionInfo`?
@@ -25,6 +38,10 @@ pub enum NetworkEvent {
     OurMerge,
     NeighbourMerge(Digest256),
     SectionInfo(SectionInfo),
+
+    /// Voted for received ExpectCandidate RPC.
+    ExpectCandidate(ExpectCandidatePayload),
+
     /// A list of proofs for a neighbour section, starting from the current section.
     ProvingSections(Vec<ProvingSection>, SectionInfo),
 }
@@ -76,6 +93,7 @@ impl Debug for NetworkEvent {
             NetworkEvent::SectionInfo(ref sec_info) => {
                 write!(formatter, "SectionInfo({:?})", sec_info)
             }
+            NetworkEvent::ExpectCandidate(ref vote) => write!(formatter, "SectionInfo({:?})", vote),
             NetworkEvent::ProvingSections(_, ref sec_info) => {
                 write!(formatter, "ProvingSections(_, {:?})", sec_info)
             }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -535,8 +535,8 @@ impl RoutingMessage {
 /// Once in `JoiningNode` state, A sends a `Relocate` request to the `NaeManager` section authority
 /// X of A's current name. X computes a target destination Y to which A should relocate and sends
 /// that section's `NaeManager`s an `ExpectCandidate` containing A's current public ID. Each member
-/// of Y caches A's public ID, and sends `AcceptAsCandidate` to self section. Once Y receives
-/// `AcceptAsCandidate`, sends a `RelocateResponse` back to A, which includes an address space range
+/// of Y votes for `ExpectCandidate`. Once Y accumulates votes for `ExpectCandidate`, send a
+/// `RelocateResponse` back to A, which includes an address space range
 /// into which A should relocate and also the public IDs of the members of Y. A then disconnects
 /// from the network and reconnects with a new ID which falls within the specified address range.
 /// After connecting to the members of Y, it begins the resource proof process. Upon successful
@@ -639,19 +639,6 @@ pub enum MessageContent {
         cacheable: bool,
         /// The `part_index`-th part of the serialised user message.
         payload: Vec<u8>,
-    },
-    /// Confirm with section that the candidate is about to resource prove.
-    ///
-    /// Sent from the `NaeManager` to the `NaeManager`.
-    AcceptAsCandidate {
-        /// The joining node's current public ID.
-        old_public_id: PublicId,
-        /// The joining node's current authority.
-        old_client_auth: Authority<XorName>,
-        /// The interval into which the joining node should join.
-        target_interval: (XorName, XorName),
-        /// The message's unique identifier.
-        message_id: MessageId,
     },
     /// Approves the joining node as a routing node.
     ///
@@ -807,16 +794,6 @@ impl Debug for MessageContent {
                 hash[0],
                 hash[1],
                 hash[2]
-            ),
-            AcceptAsCandidate {
-                ref old_public_id,
-                ref old_client_auth,
-                ref target_interval,
-                ref message_id,
-            } => write!(
-                formatter,
-                "AcceptAsCandidate {{ {:?}, {:?}, {:?}, {:?} }}",
-                old_public_id, old_client_auth, target_interval, message_id
             ),
             NodeApproval(ref gen_info) => write!(formatter, "NodeApproval {{ {:?} }}", gen_info),
         }

--- a/src/resource_prover.rs
+++ b/src/resource_prover.rs
@@ -26,7 +26,7 @@ use std::iter::Iterator;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-/// Time (in seconds) between accepting a new candidate (i.e. receiving an `AcceptAsCandidate` from
+/// Time (in seconds) between accepting a new candidate (i.e. accumulating an `ExpectCandidate` in
 /// our section) and sending a `CandidateApproval` for this candidate. If the candidate cannot
 /// satisfy the proof of resource challenge within this time, no `CandidateApproval` is sent.
 pub const RESOURCE_PROOF_DURATION: Duration = Duration::from_secs(300);

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -176,7 +176,6 @@ impl RelocatingNode {
             | NeighbourConfirm(..)
             | Merge(..)
             | UserMessagePart { .. }
-            | AcceptAsCandidate { .. }
             | NodeApproval { .. } => {
                 warn!(
                     "{} Not joined yet. Not handling {:?} from {:?} to {:?}",

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -130,6 +130,10 @@ fn multiple_joining_nodes() {
             .collect();
         info!("Added Nodes: {:?}", nodes_added);
         verify_invariant_for_all_nodes(&mut nodes);
+        assert!(
+            !nodes_added.is_empty(),
+            "Should always handle at least one node"
+        );
     }
 }
 


### PR DESCRIPTION
Add:
-ExpectCandidate struct from MessageContent::ExpectCandidate.
-NetworkEvent::ExpectCandidate to consensus the RPC and the
 RPC destination used as the source of the response.

Remove:
-MessageContent::AcceptAsCandidate replacing its function with consensus
 through Parsec of NetworkEvent::ExpectCandidate.
-Candidate::Expecting that was used when waiting AcceptAsCandidate.
-CANDIDATE_ACCEPT_TIMEOUT_SECS

Replace:
-expect_candidate with has_candidate: Do not raise an error in handling
 the parsec event because we already have a candidate.

Update handling ExpectCandidate:
-handle_expect_candidate only vote for the received RPC.
-new handle_expect_candidate_event take on combined responsabilities
 of handle_expect_candidate and handle_expect_candidate_event.
-only processed events if member of chain or established to be allowed
 to vote.
