### PR TITLE
fix/routing: only remove_expired_peers on timeout.

### DIFF
--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1207,8 +1207,6 @@ impl Node {
         new_client_auth: Authority<XorName>,
         outbox: &mut EventBox,
     ) -> Result<(), RoutingError> {
-        self.remove_expired_peers();
-
         // Once the joining node joined, it may receive the vote regarding itself.
         // Or a node may receive CandidateApproval before connection established.
         // If we are not connected to the candidate, we do not want to add them
@@ -1469,8 +1467,6 @@ impl Node {
         pub_id: PublicId,
         signature: Signature,
     ) -> Result<(), RoutingError> {
-        self.remove_expired_peers();
-
         let peer_kind = if let Some(peer) = self.peer_mgr.get_peer(&pub_id) {
             match *peer.state() {
                 PeerState::Bootstrapper { peer_kind, .. } => peer_kind,
@@ -1756,8 +1752,6 @@ impl Node {
         if !self.chain.is_member() {
             return Ok(());
         }
-
-        self.remove_expired_peers();
 
         if let Some(prefix) = self.need_to_forward_expect_candidate_to_prefix() {
             return self.forward_expect_candidate_to_prefix(vote, prefix);


### PR DESCRIPTION
remove_expired_peers update peer_manager.candidate that we want to move
to the chain eventually: Simplify behaviour so it only happen in
this time out. Remove implied constraint that remove_expired_peers was
needed.

Test:
Soak test churn 22 others 250.