### PR TITLE
Misc code cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "~0.3.8"
 lru_time_cache = "~0.8.1"
 maidsafe_utilities = "~0.16.0"
 num-bigint = "~0.1.40"
-parsec = { git = "https://github.com/maidsafe/parsec", rev = "a8c157c13" }
+parsec = { git = "https://github.com/maidsafe/parsec", rev = "f2860553c" }
 quick-error = "~1.2.0"
 rand = "~0.3.16"
 resource_proof = "~0.6.0"

--- a/src/mock_parsec/mod.rs
+++ b/src/mock_parsec/mod.rs
@@ -184,8 +184,7 @@ where
         unimplemented!()
     }
 
-    // TODO: rename this to `has_unpolled_observations`
-    pub fn has_unconsensused_observations(&self) -> bool {
+    pub fn has_unpolled_observations(&self) -> bool {
         state::with::<T, S::PublicId, _, _>(self.section_hash, |state| {
             state
                 .observations

--- a/src/node.rs
+++ b/src/node.rs
@@ -595,17 +595,17 @@ impl Node {
         unwrap!(self.node_state(), "Should be State::Node")
     }
 
-    /// Returns whether the current state is `Node`.
-    pub fn is_node(&self) -> bool {
-        self.node_state().is_some()
-    }
-
     /// Returns whether the current state is `ProvingNode`.
     pub fn proving_node_state(&self) -> Option<&crate::states::ProvingNode> {
         match *self.machine.current() {
             State::ProvingNode(ref state) => Some(state),
             _ => None,
         }
+    }
+
+    /// Returns whether the current state is `Node`.
+    pub fn is_node(&self) -> bool {
+        self.node_state().is_some()
     }
 
     /// Returns whether the current state is `ProvingNode`.
@@ -634,10 +634,10 @@ impl Node {
             .has_unpolled_observations(filter_opaque)
     }
 
-    /// Indicates if a given `PublicId` is in the peer manager as a routing peer
-    pub fn is_routing_peer(&self, pub_id: &PublicId) -> bool {
+    /// Indicates if a given `PublicId` is in the peer manager as a Node
+    pub fn is_node_peer(&self, pub_id: &PublicId) -> bool {
         self.node_state()
-            .map(|state| state.is_routing_peer(pub_id))
+            .map(|state| state.is_node_peer(pub_id))
             .unwrap_or(false)
     }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -12,6 +12,7 @@ use crate::{
     chain::{self, GenesisPfxInfo},
     id::{self, FullId},
     messages::{DirectMessage, Message},
+    utils::LogIdent,
 };
 use log::LogLevel;
 #[cfg(not(feature = "mock_parsec"))]
@@ -45,7 +46,7 @@ impl ParsecMap {
         Self { map }
     }
 
-    pub fn init(&mut self, full_id: FullId, gen_pfx_info: &GenesisPfxInfo, log_ident: &str) {
+    pub fn init(&mut self, full_id: FullId, gen_pfx_info: &GenesisPfxInfo, log_ident: &LogIdent) {
         if let Entry::Vacant(entry) = self.map.entry(*gen_pfx_info.first_info.version()) {
             let _ = entry.insert(create(full_id, gen_pfx_info));
             info!(
@@ -60,7 +61,7 @@ impl ParsecMap {
         msg_version: u64,
         request: Request,
         pub_id: id::PublicId,
-        log_ident: &str,
+        log_ident: &LogIdent,
     ) -> (Option<Message>, bool) {
         let parsec = if let Some(parsec) = self.map.get_mut(&msg_version) {
             parsec
@@ -86,7 +87,7 @@ impl ParsecMap {
         msg_version: u64,
         response: Response,
         pub_id: id::PublicId,
-        log_ident: &str,
+        log_ident: &LogIdent,
     ) -> bool {
         let parsec = if let Some(parsec) = self.map.get_mut(&msg_version) {
             parsec
@@ -108,7 +109,7 @@ impl ParsecMap {
         )))
     }
 
-    pub fn vote_for(&mut self, event: chain::NetworkEvent, log_ident: &str) {
+    pub fn vote_for(&mut self, event: chain::NetworkEvent, log_ident: &LogIdent) {
         if let Some(ref mut parsec) = self.map.values_mut().last() {
             let obs = match event.into_obs() {
                 Err(_) => {

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -172,7 +172,7 @@ impl ParsecMap {
                 .our_unpolled_observations()
                 .any(Observation::is_opaque)
         } else {
-            parsec.has_unconsensused_observations()
+            parsec.has_unpolled_observations()
         }
     }
 }

--- a/src/resource_prover.rs
+++ b/src/resource_prover.rs
@@ -6,25 +6,29 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::ack_manager::ACK_TIMEOUT;
-use crate::action::Action;
-use crate::event::Event;
-use crate::id::PublicId;
-use crate::messages::{DirectMessage, MAX_PART_LEN};
-use crate::outbox::EventBox;
-use crate::signature_accumulator::ACCUMULATION_TIMEOUT;
-use crate::state_machine::Transition;
-use crate::time::{Duration, Instant};
-use crate::timer::Timer;
-use crate::types::RoutingActionSender;
-use crate::utils::DisplayDuration;
+use crate::{
+    ack_manager::ACK_TIMEOUT,
+    action::Action,
+    event::Event,
+    id::PublicId,
+    messages::{DirectMessage, MAX_PART_LEN},
+    outbox::EventBox,
+    signature_accumulator::ACCUMULATION_TIMEOUT,
+    state_machine::Transition,
+    time::{Duration, Instant},
+    timer::Timer,
+    types::RoutingActionSender,
+    utils::{DisplayDuration, LogIdent},
+};
 use itertools::Itertools;
 use maidsafe_utilities::thread;
 use resource_proof::ResourceProof;
-use std::collections::HashMap;
-use std::iter::Iterator;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    iter::Iterator,
+    sync::atomic::{AtomicBool, Ordering},
+    sync::Arc,
+};
 
 /// Time (in seconds) between accepting a new candidate (i.e. accumulating an `ExpectCandidate` in
 /// our section) and sending a `CandidateApproval` for this candidate. If the candidate cannot
@@ -93,7 +97,7 @@ impl ResourceProver {
         seed: Vec<u8>,
         target_size: usize,
         difficulty: u8,
-        log_ident: String,
+        log_ident: LogIdent,
     ) {
         if self.response_parts.is_empty() {
             info!(
@@ -218,7 +222,7 @@ impl ResourceProver {
     pub fn handle_timeout(
         &mut self,
         token: u64,
-        log_ident: String,
+        log_ident: LogIdent,
         outbox: &mut EventBox,
     ) -> Option<Transition> {
         if self.get_approval_timer_token == Some(token) {
@@ -248,7 +252,7 @@ impl ResourceProver {
         }
     }
 
-    fn handle_approval_timeout(&mut self, log_ident: String, outbox: &mut EventBox) {
+    fn handle_approval_timeout(&mut self, log_ident: LogIdent, outbox: &mut EventBox) {
         let completed = self
             .response_parts
             .values()

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -77,7 +77,7 @@ pub trait Approved: Relocated {
         pub_id: PublicId,
         outbox: &mut EventBox,
     ) -> Result<Transition, RoutingError> {
-        let log_ident = format!("{}", self);
+        let log_ident = self.log_ident();
         let (response, poll) =
             self.parsec_map_mut()
                 .handle_request(msg_version, par_request, pub_id, &log_ident);
@@ -100,7 +100,7 @@ pub trait Approved: Relocated {
         pub_id: PublicId,
         outbox: &mut EventBox,
     ) -> Result<Transition, RoutingError> {
-        let log_ident = format!("{}", self);
+        let log_ident = self.log_ident();
         if self
             .parsec_map_mut()
             .handle_response(msg_version, par_response, pub_id, &log_ident)

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -15,6 +15,7 @@ use crate::{
     outbox::EventBox,
     routing_table::Authority,
     state_machine::Transition,
+    utils::LogIdent,
     xor_name::XorName,
     CrustBytes, CrustEvent, Service,
 };
@@ -27,6 +28,10 @@ pub trait Base: Display {
     fn full_id(&self) -> &FullId;
     fn in_authority(&self, auth: &Authority<XorName>) -> bool;
     fn min_section_size(&self) -> usize;
+
+    fn log_ident(&self) -> LogIdent {
+        LogIdent::new(self)
+    }
 
     fn handle_direct_message(
         &mut self,

--- a/src/states/common/relocated.rs
+++ b/src/states/common/relocated.rs
@@ -33,6 +33,7 @@ pub trait Relocated: Bootstrapped {
     fn is_peer_valid(&self, pub_id: &PublicId) -> bool;
     fn add_node_success(&mut self, pub_id: &PublicId);
     fn add_node_failure(&mut self, pub_id: &PublicId);
+    fn send_event(&mut self, event: Event, outbox: &mut EventBox);
 
     fn handle_connection_info_prepared(
         &mut self,
@@ -425,7 +426,7 @@ pub trait Relocated: Bootstrapped {
         match self.peer_mgr_mut().set_node(pub_id) {
             Ok(true) => {
                 info!("{} - Added peer {} as node.", self, pub_id);
-                outbox.send_event(Event::NodeAdded(*pub_id.name()));
+                self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
                 self.add_node_success(pub_id);
             }
             Ok(false) => {}

--- a/src/states/common/relocated.rs
+++ b/src/states/common/relocated.rs
@@ -330,7 +330,7 @@ pub trait Relocated: Bootstrapped {
             return Ok(());
         }
 
-        let log_ident = format!("{}", self);
+        let log_ident = self.log_ident();
         let our_pub_info = match self.peer_mgr().get_peer(&their_public_id).map(Peer::state) {
             Some(PeerState::ConnectionInfoReady(our_priv_info)) => {
                 our_priv_info.to_pub_connection_info()
@@ -423,7 +423,8 @@ pub trait Relocated: Bootstrapped {
     }
 
     fn add_node(&mut self, pub_id: &PublicId, outbox: &mut EventBox) {
-        match self.peer_mgr_mut().set_node(pub_id) {
+        let log_ident = self.log_ident();
+        match self.peer_mgr_mut().set_node(pub_id, &log_ident) {
             Ok(true) => {
                 info!("{} - Added peer {} as node.", self, pub_id);
                 self.send_event(Event::NodeAdded(*pub_id.name()), outbox);

--- a/src/states/common/relocated_not_established.rs
+++ b/src/states/common/relocated_not_established.rs
@@ -141,7 +141,6 @@ pub trait RelocatedNotEstablished: Relocated {
     fn dropped_peer(&mut self, pub_id: &PublicId) -> bool {
         let was_proxy = self.peer_mgr().is_proxy(pub_id);
         let _ = self.peer_mgr_mut().remove_peer(pub_id);
-        let _ = self.remove_from_notified_nodes(pub_id);
 
         if was_proxy {
             debug!("{} Lost connection to proxy {}.", self, pub_id);

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -434,6 +434,11 @@ impl RelocatedNotEstablished for ProvingNode {
 
 impl Display for ProvingNode {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "ProvingNode({}())", self.name())
+        write!(
+            formatter,
+            "ProvingNode({}({:b}))",
+            self.name(),
+            self.our_prefix()
+        )
     }
 }

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -224,7 +224,7 @@ impl Base for ProvingNode {
     }
 
     fn handle_timeout(&mut self, token: u64, outbox: &mut EventBox) -> Transition {
-        let log_ident = format!("{}", self);
+        let log_ident = self.log_ident();
         if let Some(transition) = self
             .resource_prover
             .handle_timeout(token, log_ident, outbox)
@@ -285,7 +285,7 @@ impl Base for ProvingNode {
                 target_size,
                 difficulty,
             } => {
-                let log_ident = format!("{}", self);
+                let log_ident = self.log_ident();
                 self.resource_prover.handle_request(
                     pub_id,
                     seed,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,15 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::routing_table::Xorable;
-use crate::xor_name::XorName;
-use crate::Prefix;
+use crate::{routing_table::Xorable, xor_name::XorName, Prefix};
 use itertools::Itertools;
 use safe_crypto;
-use std::collections::BTreeSet;
-use std::fmt::{self, Display};
-use std::iter;
-use std::time::Duration;
+use std::{
+    collections::BTreeSet,
+    fmt::{self, Display, Formatter},
+    iter,
+    time::Duration,
+};
 
 /// Display a "number" to the given number of decimal places
 pub trait DisplayDuration {
@@ -34,12 +34,28 @@ pub struct DisplayDurObj {
 }
 
 impl Display for DisplayDurObj {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut secs = self.dur.as_secs();
         if self.dur.subsec_nanos() >= 500_000_000 {
             secs += 1;
         }
         write!(f, "{} seconds", secs)
+    }
+}
+
+/// Identified or node/client for logging purposes.
+#[derive(Clone)]
+pub struct LogIdent(String);
+
+impl LogIdent {
+    pub fn new<T: Display + ?Sized>(node: &T) -> Self {
+        LogIdent(format!("{}", node))
+    }
+}
+
+impl Display for LogIdent {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", self.0)
     }
 }
 

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -685,7 +685,7 @@ pub fn verify_invariant_for_all_nodes(nodes: &mut [TestNode]) {
         let mut peers = node.chain().valid_peers();
         let _ = peers.remove(&node.chain().our_id());
         for pub_id in peers {
-            assert_eq!(true, node.inner.is_routing_peer(pub_id));
+            assert_eq!(true, node.inner.is_node_peer(pub_id));
         }
     }
 }


### PR DESCRIPTION
- get rid of `notified_nodes` (not needed as `PeerManager` can handle the logic itself now)
- rename `PeerState::Routing` to `PeerState::Node` and `add_to_routing_table` to `add_node`
- change `self.chain.is_valid_peer` to `self.is_valid_peer`
- bump parsec version and rename `has_unconsensused_observations` to `has_unpolled_observations` in mock parsec.
- backlog `Event::NodeAdded`/`Event::NodeLost` until we become `Node` to make sure they are send *after* `Event::Connected`.
- Improve logging by introducing `LogIdent` utility struct which is to be used as prefix for all log messages for log consistency. 