### PR TITLE
test candidate fail resource proof

### DIFF
--- a/src/ack_manager.rs
+++ b/src/ack_manager.rs
@@ -106,6 +106,12 @@ impl AckManager {
     }
 }
 
+impl Default for AckManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Ack {
     /// Compute an `Ack` from a message.
     pub fn compute(routing_msg: &RoutingMessage) -> Result<Ack, RoutingError> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -572,7 +572,7 @@ impl Client {
 
     /// Returns the name of this client.
     pub fn id(&self) -> Result<PublicId, RoutingError> {
-        self.machine.id().ok_or(RoutingError::Terminated)
+        self.machine.current().id().ok_or(RoutingError::Terminated)
     }
 
     /// FIXME: Review the usage poll here

--- a/src/node.rs
+++ b/src/node.rs
@@ -34,8 +34,6 @@ use safe_crypto::PublicSignKey;
 use std::collections::{BTreeMap, BTreeSet};
 #[cfg(feature = "mock_base")]
 use std::fmt::{self, Display, Formatter};
-#[cfg(feature = "mock_base")]
-use std::net::IpAddr;
 use std::sync::mpsc::{channel, Receiver, RecvError, Sender, TryRecvError};
 
 // Helper macro to implement request sending methods.
@@ -595,11 +593,6 @@ impl Node {
     /// Returns this node state unwraped: assume state is Node.
     pub fn node_state_unchecked(&self) -> &crate::states::Node {
         unwrap!(self.node_state(), "Should be State::Node")
-    }
-
-    /// Returns the list of banned clients' IPs held by this node.
-    pub fn get_banned_client_ips(&self) -> BTreeSet<IpAddr> {
-        self.node_state_unchecked().get_banned_client_ips()
     }
 
     /// Returns whether the current state is `Node`.

--- a/src/node.rs
+++ b/src/node.rs
@@ -520,12 +520,6 @@ impl Node {
         self.machine.id().ok_or(RoutingError::Terminated)
     }
 
-    /// Returns the chain for this node.
-    #[cfg(feature = "mock_base")]
-    pub fn chain(&self) -> Result<&Chain, RoutingError> {
-        self.machine.chain().ok_or(RoutingError::Terminated)
-    }
-
     /// Returns the minimum section size this vault is using.
     pub fn min_section_size(&self) -> usize {
         self.machine.min_section_size()
@@ -577,6 +571,11 @@ impl EventStepper for Node {
 
 #[cfg(feature = "mock_base")]
 impl Node {
+    /// Returns the chain for this node.
+    pub fn chain(&self) -> Option<&Chain> {
+        self.machine.chain()
+    }
+
     /// Returns the list of banned clients' IPs held by this node.
     pub fn get_banned_client_ips(&self) -> BTreeSet<IpAddr> {
         self.machine.current().get_banned_client_ips()
@@ -601,11 +600,6 @@ impl Node {
         self.machine
             .current_mut()
             .set_next_relocation_interval(interval)
-    }
-
-    /// Get the rate limiter's bandwidth usage map.
-    pub fn get_clients_usage(&self) -> BTreeMap<IpAddr, u64> {
-        unwrap!(self.machine.current().get_clients_usage())
     }
 
     /// Indicates if there are any pending observations in the parsec object

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -342,7 +342,7 @@ impl PeerManager {
     }
 
     /// Return true if already has a candidate
-    pub fn has_candidate(&self) -> bool {
+    pub fn has_resource_proof_candidate(&self) -> bool {
         self.candidate != Candidate::None
     }
 

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -273,11 +273,6 @@ impl RateLimiter {
             }
         }
     }
-
-    #[cfg(feature = "mock_base")]
-    pub fn usage_map(&self) -> &BTreeMap<IpAddr, u64> {
-        &self.used
-    }
 }
 
 #[cfg(all(test, feature = "mock_base"))]

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -90,6 +90,12 @@ impl RoutingMessageFilter {
     }
 }
 
+impl Default for RoutingMessageFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn hash<T: Serialize + Debug>(msg: &T) -> Option<Digest> {
     if let Ok(msg_bytes) = serialise(msg) {
         Some(safe_crypto::hash(&msg_bytes))

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -24,7 +24,7 @@ use crate::{mock_crust, routing_table::Authority, states::common::Bootstrapped, 
 use log::LogLevel;
 use maidsafe_utilities::event_sender::MaidSafeEventCategory;
 #[cfg(feature = "mock_base")]
-use std::{collections::BTreeMap, net::IpAddr};
+use std::net::IpAddr;
 use std::{
     collections::BTreeSet,
     fmt::{self, Debug, Display, Formatter},
@@ -224,14 +224,6 @@ impl State {
             State::ProvingNode(ref mut state) => state.get_timed_out_tokens(),
             State::EstablishingNode(ref mut state) => state.get_timed_out_tokens(),
             State::Node(ref mut state) => state.get_timed_out_tokens(),
-        }
-    }
-
-    pub fn get_clients_usage(&self) -> Option<BTreeMap<IpAddr, u64>> {
-        if let State::Node(ref state) = *self {
-            Some(state.get_clients_usage())
-        } else {
-            None
         }
     }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -23,8 +23,6 @@ use crate::{
 use crate::{mock_crust, routing_table::Authority, states::common::Bootstrapped, Chain};
 use log::LogLevel;
 use maidsafe_utilities::event_sender::MaidSafeEventCategory;
-#[cfg(feature = "mock_base")]
-use std::net::IpAddr;
 use std::{
     collections::BTreeSet,
     fmt::{self, Debug, Display, Formatter},
@@ -114,7 +112,7 @@ impl State {
         )
     }
 
-    fn id(&self) -> Option<PublicId> {
+    pub fn id(&self) -> Option<PublicId> {
         state_dispatch!(
             *self,
             ref state => Some(*state.id()),
@@ -122,20 +120,7 @@ impl State {
         )
     }
 
-    #[cfg(feature = "mock_base")]
-    fn chain(&self) -> Option<&Chain> {
-        match *self {
-            State::EstablishingNode(ref state) => Some(state.chain()),
-            State::Node(ref state) => Some(state.chain()),
-            State::BootstrappingPeer(_)
-            | State::Client(_)
-            | State::RelocatingNode(_)
-            | State::ProvingNode(_)
-            | State::Terminated => None,
-        }
-    }
-
-    fn close_group(&self, name: XorName, count: usize) -> Option<Vec<XorName>> {
+    pub fn close_group(&self, name: XorName, count: usize) -> Option<Vec<XorName>> {
         state_dispatch!(
             *self,
             ref state => state.close_group(name, count),
@@ -143,7 +128,7 @@ impl State {
         )
     }
 
-    fn min_section_size(&self) -> usize {
+    pub fn min_section_size(&self) -> usize {
         state_dispatch!(
             *self,
             ref state => state.min_section_size(),
@@ -197,22 +182,15 @@ impl Debug for State {
 
 #[cfg(feature = "mock_base")]
 impl State {
-    pub fn get_banned_client_ips(&self) -> BTreeSet<IpAddr> {
+    pub fn chain(&self) -> Option<&Chain> {
         match *self {
-            State::Node(ref state) => state.get_banned_client_ips(),
-            _ => panic!("Should be State::Node"),
-        }
-    }
-
-    pub fn set_next_relocation_dst(&mut self, dst: Option<XorName>) {
-        if let State::Node(ref mut node) = *self {
-            node.set_next_relocation_dst(dst);
-        }
-    }
-
-    pub fn set_next_relocation_interval(&mut self, interval: Option<(XorName, XorName)>) {
-        if let State::Node(ref mut node) = *self {
-            node.set_next_relocation_interval(interval);
+            State::EstablishingNode(ref state) => Some(state.chain()),
+            State::Node(ref state) => Some(state.chain()),
+            State::BootstrappingPeer(_)
+            | State::Client(_)
+            | State::RelocatingNode(_)
+            | State::ProvingNode(_)
+            | State::Terminated => None,
         }
     }
 
@@ -239,23 +217,12 @@ impl State {
         }
     }
 
-    pub fn is_routing_peer(&self, pub_id: &PublicId) -> bool {
-        if let State::Node(ref state) = *self {
-            state.is_routing_peer(pub_id)
-        } else {
-            false
-        }
-    }
-
     pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
-        match *self {
-            State::Terminated | State::BootstrappingPeer(_) => false,
-            State::Client(ref state) => state.in_authority(auth),
-            State::RelocatingNode(ref state) => state.in_authority(auth),
-            State::ProvingNode(ref state) => state.in_authority(auth),
-            State::EstablishingNode(ref state) => state.in_authority(auth),
-            State::Node(ref state) => state.in_authority(auth),
-        }
+        state_dispatch!(
+            *self,
+            ref state => state.in_authority(auth),
+            Terminated => false
+        )
     }
 
     pub fn has_unacked_msg(&self) -> bool {
@@ -554,24 +521,6 @@ impl StateMachine {
         Err(TryRecvError::Empty)
     }
 
-    pub fn id(&self) -> Option<PublicId> {
-        self.state.id()
-    }
-
-    #[cfg(feature = "mock_base")]
-    pub fn chain(&self) -> Option<&Chain> {
-        self.state.chain()
-    }
-
-    pub fn close_group(&self, name: XorName, count: usize) -> Option<Vec<XorName>> {
-        self.state.close_group(name, count)
-    }
-
-    pub fn min_section_size(&self) -> usize {
-        self.state.min_section_size()
-    }
-
-    #[cfg(feature = "mock_base")]
     /// Get reference to the current state.
     pub fn current(&self) -> &State {
         &self.state

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1274,7 +1274,7 @@ impl Node {
         &mut self,
         vote: &ExpectCandidatePayload,
     ) -> Option<(XorName, XorName)> {
-        if self.peer_mgr.has_candidate() {
+        if self.peer_mgr.has_resource_proof_candidate() {
             return None;
         }
 
@@ -2161,6 +2161,10 @@ impl Node {
         self.peer_mgr
             .get_peer(pub_id)
             .map_or(false, Peer::is_routing)
+    }
+
+    pub fn has_resource_proof_candidate(&self) -> bool {
+        self.peer_mgr.has_resource_proof_candidate()
     }
 }
 

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -47,8 +47,6 @@ use lru_time_cache::LruCache;
 use maidsafe_utilities::serialisation;
 use rand::{self, Rng};
 use safe_crypto::Signature;
-#[cfg(feature = "mock_base")]
-use std::collections::BTreeMap;
 use std::{
     cmp,
     collections::{BTreeSet, VecDeque},
@@ -305,11 +303,6 @@ impl Node {
         self.crust_service.set_service_discovery_listen(true);
 
         Ok(())
-    }
-
-    #[cfg(feature = "mock_base")]
-    pub fn chain(&self) -> &Chain {
-        &self.chain
     }
 
     fn handle_routing_messages(&mut self, outbox: &mut EventBox) {
@@ -2137,6 +2130,10 @@ impl Base for Node {
 
 #[cfg(feature = "mock_base")]
 impl Node {
+    pub fn chain(&self) -> &Chain {
+        &self.chain
+    }
+
     pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
         self.timer.get_timed_out_tokens()
     }
@@ -2154,10 +2151,6 @@ impl Node {
 
     pub fn set_next_relocation_interval(&mut self, interval: Option<(XorName, XorName)>) {
         self.next_relocation_interval = interval;
-    }
-
-    pub fn get_clients_usage(&self) -> BTreeMap<IpAddr, u64> {
-        self.clients_rate_limiter.usage_map().clone()
     }
 
     pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {

--- a/tests/mock_crust/client_restrictions.rs
+++ b/tests/mock_crust/client_restrictions.rs
@@ -38,7 +38,10 @@ fn ban_malicious_client() {
     );
     let _ = poll_all(&mut nodes, &mut clients);
     expect_next_event!(unwrap!(clients.last_mut()), Event::Terminated);
-    let banned_client_ips = nodes[0].inner.get_banned_client_ips();
+    let banned_client_ips = nodes[0]
+        .inner
+        .node_state_unchecked()
+        .get_banned_client_ips();
     assert_eq!(banned_client_ips.len(), 1);
     let ip_addr = clients[0].ip();
     assert_eq!(unwrap!(banned_client_ips.into_iter().next()), ip_addr);

--- a/tests/mock_crust/mod.rs
+++ b/tests/mock_crust/mod.rs
@@ -19,15 +19,36 @@ pub use self::utils::{
     add_connected_nodes_until_split, count_sections, create_connected_clients,
     create_connected_nodes, create_connected_nodes_until_split, current_sections, gen_bytes,
     gen_immutable_data, gen_range, gen_range_except, poll_all, poll_and_resend,
-    remove_nodes_which_failed_to_connect, sort_nodes_by_distance_to,
+    poll_and_resend_until, remove_nodes_which_failed_to_connect, sort_nodes_by_distance_to,
     verify_invariant_for_all_nodes, Nodes, TestClient, TestNode,
 };
+use fake_clock::FakeClock;
 use routing::mock_crust::{Endpoint, Network};
-use routing::{BootstrapConfig, Event, EventStream, Prefix, XorName, XOR_NAME_LEN};
+use routing::{Authority, BootstrapConfig, Event, EventStream, Prefix, XorName, XOR_NAME_LEN};
 
 pub const MIN_SECTION_SIZE: usize = 3;
 
 // -----  Miscellaneous tests below  -----
+
+fn nodes_in_authority(nodes: &[TestNode], name: &XorName) -> Vec<XorName> {
+    nodes
+        .iter()
+        .filter(|node| node.inner.in_authority(&Authority::Section(*name)))
+        .map(TestNode::name)
+        .collect()
+}
+
+fn nodes_with_candidate(nodes: &[TestNode]) -> Vec<XorName> {
+    nodes
+        .iter()
+        .filter(|node| {
+            node.inner
+                .node_state_unchecked()
+                .has_resource_proof_candidate()
+        })
+        .map(TestNode::name)
+        .collect()
+}
 
 fn test_nodes(percentage_size: usize) {
     let size = MIN_SECTION_SIZE * percentage_size / 100;
@@ -52,6 +73,51 @@ fn disconnect_on_rebootstrap() {
     // When retrying to bootstrap, we should have disconnected from the bootstrap node.
     assert!(!unwrap!(nodes.last()).handle.is_connected(&nodes[1].handle));
     expect_next_event!(unwrap!(nodes.last_mut()), Event::Terminated);
+}
+
+#[test]
+fn candidate_timeout_resource_proof() {
+    let network = Network::new(MIN_SECTION_SIZE, None);
+    let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1], false);
+    let bootstrap_config = BootstrapConfig::with_contacts(&[nodes[0].handle.endpoint()]);
+    nodes.insert(
+        0,
+        TestNode::builder(&network)
+            .bootstrap_config(bootstrap_config)
+            .create(),
+    );
+
+    // Initiate connection until the candidate switch to ProvingNode:
+    info!("Candidate joining name: {}", nodes[0].name());
+    poll_and_resend_until(&mut nodes, &mut [], &|nodes| {
+        nodes[0].inner.is_proving_node()
+    });
+    let proving_node = nodes.remove(0);
+
+    assert!(
+        proving_node.inner.is_proving_node(),
+        "Accepted as candidate"
+    );
+
+    // Continue without the joining node until all nodes idle:
+    info!("Candidate new name: {}", proving_node.name());
+    poll_and_resend(&mut nodes, &mut []);
+
+    assert_eq!(
+        nodes_in_authority(&nodes, &proving_node.name()),
+        nodes_with_candidate(&nodes),
+        "All members of destination section accepted node as candidate"
+    );
+
+    // Continue after candidate time out:
+    FakeClock::advance_time(60 * 60 * 1000);
+    poll_and_resend(&mut nodes, &mut []);
+
+    assert_eq!(
+        Vec::<XorName>::new(),
+        nodes_with_candidate(&nodes),
+        "All members have rejected the candidate"
+    );
 }
 
 #[test]

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -168,7 +168,7 @@ impl TestNode {
 pub fn count_sections(nodes: &[TestNode]) -> usize {
     nodes
         .iter()
-        .filter_map(|n| n.inner.chain().ok())
+        .filter_map(|n| n.inner.chain())
         .flat_map(Chain::prefixes)
         .unique()
         .count()
@@ -177,7 +177,7 @@ pub fn count_sections(nodes: &[TestNode]) -> usize {
 pub fn current_sections(nodes: &[TestNode]) -> BTreeSet<Prefix<XorName>> {
     nodes
         .iter()
-        .filter_map(|n| n.inner.chain().ok())
+        .filter_map(|n| n.inner.chain())
         .flat_map(Chain::prefixes)
         .collect()
 }


### PR DESCRIPTION
Refactor in multiple commits to ease access to node state in test avoiding much boiler plate code.
Add new test verifying behaviour when a candidate does not go through with resource proof.
Extend poll_and_resend with pool_and_resend_until to stop progression when condition reached.