### PR TITLE
consistent failed candidate when timing out

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -705,11 +705,16 @@ impl Chain {
 
                 self.our_info().is_quorum(proofs)
             }
-            NetworkEvent::Online(_, _) | NetworkEvent::Offline(_) => {
+            NetworkEvent::Online(_, _)
+            | NetworkEvent::Offline(_)
+            | NetworkEvent::ExpectCandidate(_) => {
                 self.state() == &ChainState::Normal && self.our_info().is_quorum(proofs)
             }
             NetworkEvent::ProvingSections(_, _) => true,
-            _ => self.our_info().is_quorum(proofs),
+
+            NetworkEvent::OurMerge | NetworkEvent::NeighbourMerge(_) => {
+                self.our_info().is_quorum(proofs)
+            }
         }
     }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -707,7 +707,8 @@ impl Chain {
             }
             NetworkEvent::Online(_, _)
             | NetworkEvent::Offline(_)
-            | NetworkEvent::ExpectCandidate(_) => {
+            | NetworkEvent::ExpectCandidate(_)
+            | NetworkEvent::PurgeCandidate(_) => {
                 self.state() == &ChainState::Normal && self.our_info().is_quorum(proofs)
             }
             NetworkEvent::ProvingSections(_, _) => true,

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -42,6 +42,9 @@ pub enum NetworkEvent {
     /// Voted for received ExpectCandidate RPC.
     ExpectCandidate(ExpectCandidatePayload),
 
+    // Voted for timeout expired for this candidate old_public_id.
+    PurgeCandidate(PublicId),
+
     /// A list of proofs for a neighbour section, starting from the current section.
     ProvingSections(Vec<ProvingSection>, SectionInfo),
 }
@@ -93,7 +96,10 @@ impl Debug for NetworkEvent {
             NetworkEvent::SectionInfo(ref sec_info) => {
                 write!(formatter, "SectionInfo({:?})", sec_info)
             }
-            NetworkEvent::ExpectCandidate(ref vote) => write!(formatter, "SectionInfo({:?})", vote),
+            NetworkEvent::ExpectCandidate(ref vote) => {
+                write!(formatter, "ExpectCandidate({:?})", vote)
+            }
+            NetworkEvent::PurgeCandidate(ref id) => write!(formatter, "PurgeCandidate({})", id),
             NetworkEvent::ProvingSections(_, ref sec_info) => {
                 write!(formatter, "ProvingSections(_, {:?})", sec_info)
             }

--- a/src/node.rs
+++ b/src/node.rs
@@ -576,18 +576,12 @@ impl Node {
 
     /// Returns this node state.
     pub fn node_state(&self) -> Option<&crate::states::Node> {
-        match *self.machine.current() {
-            State::Node(ref state) => Some(state),
-            _ => None,
-        }
+        self.machine.current().node_state()
     }
 
     /// Returns this node mut state.
     pub fn node_state_mut(&mut self) -> Option<&mut crate::states::Node> {
-        match *self.machine.current_mut() {
-            State::Node(ref mut state) => Some(state),
-            _ => None,
-        }
+        self.machine.current_mut().node_state_mut()
     }
 
     /// Returns this node state unwraped: assume state is Node.

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -971,6 +971,11 @@ impl PeerManager {
         let _ = self.peers.insert(peer.pub_id, peer);
     }
 
+    // Forget about the current candidate
+    pub fn remove_candidate(&mut self) {
+        self.candidate = Candidate::None;
+    }
+
     /// Removes the given peer. Returns whether the peer was actually present.
     pub fn remove_peer(&mut self, pub_id: &PublicId) -> bool {
         let remove_candidate = match self.candidate {

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -194,6 +194,22 @@ impl State {
         }
     }
 
+    /// Returns this node state.
+    pub fn node_state(&self) -> Option<&Node> {
+        match *self {
+            State::Node(ref state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Returns this node mut state.
+    pub fn node_state_mut(&mut self) -> Option<&mut Node> {
+        match *self {
+            State::Node(ref mut state) => Some(state),
+            _ => None,
+        }
+    }
+
     pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
         match *self {
             State::BootstrappingPeer(_) | State::Terminated => vec![],

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -63,6 +63,10 @@ pub trait Approved: Relocated {
         vote: ExpectCandidatePayload,
     ) -> Result<(), RoutingError>;
 
+    /// Handles an accumulated `PurgeCandidate` event.
+    fn handle_purge_candidate_event(&mut self, old_public_id: PublicId)
+        -> Result<(), RoutingError>;
+
     /// Handles an accumulated `ProvingSections` event.
     fn handle_proving_sections_event(
         &mut self,
@@ -184,6 +188,10 @@ pub trait Approved: Relocated {
                     }
                 }
                 NetworkEvent::ExpectCandidate(vote) => self.handle_expect_candidate_event(vote)?,
+                NetworkEvent::PurgeCandidate(old_public_id) => {
+                    self.handle_purge_candidate_event(old_public_id)?
+                }
+
                 NetworkEvent::ProvingSections(proving_secs, sec_info) => {
                     self.handle_proving_sections_event(proving_secs, sec_info)?;
                 }

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -228,7 +228,7 @@ pub trait Base: Display {
         outbox: &mut EventBox,
     ) -> Transition {
         let result = from_crust_bytes(bytes)
-            .and_then(|message| self.handle_new_deserialized_message(pub_id, message, outbox));
+            .and_then(|message| self.handle_new_deserialised_message(pub_id, message, outbox));
 
         match result {
             Ok(transition) => transition,
@@ -240,7 +240,7 @@ pub trait Base: Display {
         }
     }
 
-    fn handle_new_deserialized_message(
+    fn handle_new_deserialised_message(
         &mut self,
         pub_id: PublicId,
         message: Message,

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -381,6 +381,10 @@ impl Approved for EstablishingNode {
         Ok(())
     }
 
+    fn handle_purge_candidate_event(&mut self, _: PublicId) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn handle_section_info_event(
         &mut self,
         sec_info: SectionInfo,

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -402,7 +402,7 @@ impl Node {
             completed_events,
         } = self.chain.finalise_prefix_change()?;
         self.gen_pfx_info = gen_pfx_info;
-        self.peer_mgr.remove_candidate();
+        self.peer_mgr.reset_candidate();
         self.init_parsec(); // We don't reset the chain on prefix change.
 
         let neighbour_infos: Vec<_> = self.chain.neighbour_infos().cloned().collect();
@@ -2380,6 +2380,8 @@ impl Approved for Node {
         } else if old_pfx.is_extension_of(sec_info.prefix()) {
             self.finalise_prefix_change()?;
             self.send_event(Event::SectionMerged(*sec_info.prefix()), outbox);
+        } else {
+            self.peer_mgr.reset_candidate_if_member(sec_info.members());
         }
 
         let self_sec_update = sec_info.prefix().matches(self.name());


### PR DESCRIPTION
We want to ensure eventually that the candidate is a state shared by
all peers in the section. To do that all modification must be the
result of reaching consensus on an event.

We use a new consensused event PurgeCandidate to decide together
whether a candidate failed or succeeded.