### PR TITLE
fix/states: remove candidate when PurgeCandidate event comes first

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -18,7 +18,7 @@ mod test_utils;
 
 pub use self::chain::{Chain, PrefixChangeOutcome};
 pub use self::neighbour_sigs::NeighbourSigs;
-pub use self::network_event::{ExpectCandidatePayload, NetworkEvent};
+pub use self::network_event::{ExpectCandidatePayload, NetworkEvent, OnlinePayload};
 pub use self::proof::{Proof, ProofSet, ProvingSection};
 pub use self::section_info::SectionInfo;
 #[cfg(any(test, feature = "mock_base"))]

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -28,12 +28,20 @@ pub struct ExpectCandidatePayload {
     pub dst_name: XorName,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct OnlinePayload {
+    /// The joining node's previous public ID.
+    pub old_public_id: PublicId,
+    /// The joining node's current authority.
+    pub client_auth: Authority<XorName>,
+}
+
 /// Routing Network events
 // TODO: Box `SectionInfo`?
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum NetworkEvent {
-    Online(PublicId, Authority<XorName>),
+    Online(PublicId, OnlinePayload),
     Offline(PublicId),
     OurMerge,
     NeighbourMerge(Digest256),

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -409,6 +409,16 @@ impl PeerManager {
         self.candidate != Candidate::None
     }
 
+    /// Return true if received CandidateInfo
+    #[cfg(all(test, feature = "mock_parsec"))]
+    pub fn has_candidate_info(&self) -> bool {
+        if let Candidate::ResourceProof { .. } = self.candidate {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Our section decided that the candidate should be selected next.
     /// replace any ongoing (i.e. unapproved) candidate with the new state
     /// `AcceptedForResourceProof` for the given candidate.

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -554,29 +554,6 @@ impl PeerManager {
         }
     }
 
-    /// Handles approved accumulated candidate. Returns if the candidate is connected or
-    /// `Err` if the peer is not the candidate or we're missing its info.
-    pub fn handle_candidate_approval(
-        &mut self,
-        new_pub_id: &PublicId,
-        log_ident: &LogIdent,
-    ) -> Result<bool, RoutingError> {
-        if let Some(peer) = self.peers.get_mut(new_pub_id) {
-            let is_connected = peer.is_connected();
-            if !is_connected {
-                trace!(
-                    "{} Candidate {} not yet connected to us.",
-                    log_ident,
-                    new_pub_id.name()
-                );
-            }
-            Ok(is_connected)
-        } else {
-            trace!("{} No peer with name {}", log_ident, new_pub_id.name());
-            Err(RoutingError::InvalidStateForOperation)
-        }
-    }
-
     /// Updates peer's state to `Candidate` in the peer map if it is an unapproved candidate and
     /// returns the whether the candidate needs to perform the resource proof.
     ///

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -9,13 +9,14 @@
 use super::Relocated;
 use crate::{
     chain::{
-        Chain, ExpectCandidatePayload, NetworkEvent, Proof, ProofSet, ProvingSection, SectionInfo,
+        Chain, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof, ProofSet,
+        ProvingSection, SectionInfo,
     },
     error::RoutingError,
     id::PublicId,
     outbox::EventBox,
     parsec::{self, Block, Observation, ParsecMap},
-    routing_table::{Authority, Prefix},
+    routing_table::Prefix,
     state_machine::Transition,
     xor_name::XorName,
 };
@@ -30,7 +31,7 @@ pub trait Approved: Relocated {
     fn handle_online_event(
         &mut self,
         new_pub_id: PublicId,
-        new_client_auth: Authority<XorName>,
+        online_payload: OnlinePayload,
         outbox: &mut EventBox,
     ) -> Result<(), RoutingError>;
 
@@ -173,8 +174,8 @@ pub trait Approved: Relocated {
             trace!("{} Handle accumulated event: {:?}", self, event);
 
             match event {
-                NetworkEvent::Online(pub_id, client_auth) => {
-                    self.handle_online_event(pub_id, client_auth, outbox)?;
+                NetworkEvent::Online(pub_id, info) => {
+                    self.handle_online_event(pub_id, info, outbox)?;
                 }
                 NetworkEvent::Offline(pub_id) => {
                     self.handle_offline_event(pub_id, outbox)?;

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -16,7 +16,9 @@ use super::{
 use crate::{
     ack_manager::AckManager,
     cache::Cache,
-    chain::{Chain, ExpectCandidatePayload, GenesisPfxInfo, ProvingSection, SectionInfo},
+    chain::{
+        Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload, ProvingSection, SectionInfo,
+    },
     error::RoutingError,
     event::Event,
     id::{FullId, PublicId},
@@ -358,7 +360,7 @@ impl Approved for EstablishingNode {
     fn handle_online_event(
         &mut self,
         new_pub_id: PublicId,
-        _: Authority<XorName>,
+        _: OnlinePayload,
         _: &mut EventBox,
     ) -> Result<(), RoutingError> {
         let _ = self.chain.add_member(new_pub_id)?;

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1074,6 +1074,7 @@ impl Node {
                 self, new_pub_id
             );
             self.disconnect_peer(new_pub_id);
+            return;
         }
 
         // If this is a valid node in peer_mgr but the Candidate has sent us a CandidateInfo, it
@@ -3067,6 +3068,22 @@ mod tests {
 
         let _ = node_test.dispatch_routing_message(node_test.connection_info_request_rpc());
         let _ = node_test.handle_direct_message(node_test.candidate_info_rpc());
+
+        assert!(!node_test.has_candidate_info());
+        assert!(node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
+    }
+
+    #[test]
+    // Candidate info that is not trustworthy is not trusted.
+    fn candidate_info_rpc_bad_signature() {
+        let mut node_test = NoteUnderTest::new();
+        node_test.set_interval_to_match_candidate(true);
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+
+        let _ = node_test.dispatch_routing_message(node_test.connection_info_request_rpc());
+        let _ = node_test
+            .handle_direct_message(node_test.candidate_info_rpc_use_wrong_old_signature(true));
 
         assert!(!node_test.has_candidate_info());
         assert!(node_test.has_resource_proof_candidate());

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -2490,6 +2490,7 @@ fn create_first_section_info(public_id: PublicId) -> Result<SectionInfo, Routing
 mod tests {
     use super::*;
     use crate::cache::NullCache;
+    use crate::messages::Message;
     use crate::mock_crust::crust::Config;
     use crate::mock_crust::{self, Network};
     use crate::outbox::{EventBox, EventBuf};
@@ -2501,6 +2502,26 @@ mod tests {
     const ACCUMULATE_VOTE_COUNT: usize = 3;
     const NOT_ACCUMULATE_ALONE_VOTE_COUNT: usize = 2;
 
+    struct CandidateInfo {
+        old_full_id: FullId,
+        old_proxy_id: FullId,
+        new_full_id: FullId,
+        new_proxy_id: FullId,
+        message_id: MessageId,
+    }
+
+    impl CandidateInfo {
+        fn new() -> Self {
+            Self {
+                old_full_id: FullId::new(),
+                old_proxy_id: FullId::new(),
+                new_full_id: FullId::new(),
+                new_proxy_id: FullId::new(),
+                message_id: MessageId::new(),
+            }
+        }
+    }
+
     struct NoteUnderTest {
         pub machine: StateMachine,
         pub full_id: FullId,
@@ -2508,6 +2529,7 @@ mod tests {
         pub other_parsec_map: Vec<ParsecMap>,
         pub ev_buffer: EventBuf,
         pub section_info: SectionInfo,
+        pub candidate_info: CandidateInfo,
     }
 
     impl NoteUnderTest {
@@ -2545,6 +2567,7 @@ mod tests {
                 other_parsec_map,
                 ev_buffer,
                 section_info,
+                candidate_info: CandidateInfo::new(),
             }
         }
 
@@ -2561,34 +2584,54 @@ mod tests {
             }
         }
 
-        fn create_gossip(&mut self) -> Result<Transition, RoutingError> {
+        fn create_gossip(&mut self) -> Result<(), RoutingError> {
             let other_pub_id = *self.other_full_ids[0].public_id();
-            let message =
-                unwrap!(self.other_parsec_map[0].create_gossip(0, self.full_id.public_id()));
-
-            unwrap!(self.machine.current_mut().node_state_mut()).handle_new_deserialised_message(
-                other_pub_id,
-                message,
-                &mut self.ev_buffer,
-            )
+            match self.other_parsec_map[0].create_gossip(0, self.full_id.public_id()) {
+                Some(Message::Direct(message)) => {
+                    self.handle_direct_message((message, other_pub_id))?
+                }
+                _ => panic!("create_gossip unexpected message"),
+            };
+            Ok(())
         }
 
         fn n_vote_for_gossipped(
             &mut self,
             count: usize,
             events: &[&NetworkEvent],
-        ) -> Result<Transition, RoutingError> {
+        ) -> Result<(), RoutingError> {
             self.n_vote_for(count, events);
             self.create_gossip()
         }
 
-        fn accumulate_expect_candidate(&mut self) -> ExpectCandidatePayload {
-            let payload_expect = expect_candidate_payload();
+        fn set_interval_to_match_candidate(&mut self, match_candidate: bool) {
+            let name = if match_candidate {
+                *self.candidate_info.new_full_id.public_id().name()
+            } else {
+                *self.full_id.public_id().name()
+            };
+
+            unwrap!(self.machine.current_mut().node_state_mut())
+                .set_next_relocation_interval(Some((name, name)));
+        }
+
+        fn accumulate_expect_candidate(&mut self, payload_expect: ExpectCandidatePayload) {
+            self.n_accumulate_expect_candidate(ACCUMULATE_VOTE_COUNT, payload_expect)
+        }
+
+        fn accumulate_expect_candidate_if_vote(&mut self, payload_expect: ExpectCandidatePayload) {
+            self.n_accumulate_expect_candidate(NOT_ACCUMULATE_ALONE_VOTE_COUNT, payload_expect)
+        }
+
+        fn n_accumulate_expect_candidate(
+            &mut self,
+            count: usize,
+            payload_expect: ExpectCandidatePayload,
+        ) {
             let _ = self.n_vote_for_gossipped(
-                ACCUMULATE_VOTE_COUNT,
+                count,
                 &[&NetworkEvent::ExpectCandidate(payload_expect.clone())],
             );
-            payload_expect
         }
 
         fn accumulate_purge_candidate(&mut self, purge_payload: PublicId) {
@@ -2619,12 +2662,12 @@ mod tests {
             );
         }
 
-        fn new_section_info_with(&self, new_id: &PublicId) -> SectionInfo {
+        fn new_section_info_with_candidate(&self) -> SectionInfo {
             unwrap!(SectionInfo::new(
                 self.section_info
                     .members()
                     .iter()
-                    .chain(Some(new_id))
+                    .chain(Some(self.candidate_info.new_full_id.public_id()))
                     .cloned()
                     .collect(),
                 *self.section_info.prefix(),
@@ -2640,8 +2683,156 @@ mod tests {
             self.node_state().has_resource_proof_candidate()
         }
 
-        fn is_peer_valid(&self, public_id: &PublicId) -> bool {
-            self.node_state().chain().is_peer_valid(public_id)
+        fn has_candidate_info(&self) -> bool {
+            self.node_state().peer_mgr().has_candidate_info()
+        }
+
+        fn is_candidate_a_valid_peer(&self) -> bool {
+            self.node_state()
+                .chain()
+                .is_peer_valid(self.candidate_info.new_full_id.public_id())
+        }
+
+        fn dispatch_routing_message(
+            &mut self,
+            routing_msg: RoutingMessage,
+        ) -> Result<(), RoutingError> {
+            unwrap!(self.machine.current_mut().node_state_mut())
+                .dispatch_routing_message(routing_msg, &mut self.ev_buffer)
+        }
+
+        fn handle_direct_message(
+            &mut self,
+            msg: (DirectMessage, PublicId),
+        ) -> Result<(), RoutingError> {
+            let _ = unwrap!(self.machine.current_mut().node_state_mut()).handle_direct_message(
+                msg.0,
+                msg.1,
+                &mut self.ev_buffer,
+            )?;
+            Ok(())
+        }
+
+        fn expect_candidate_payload(&self) -> ExpectCandidatePayload {
+            ExpectCandidatePayload {
+                old_public_id: *self.candidate_info.old_full_id.public_id(),
+                old_client_auth: Authority::Client {
+                    client_id: *self.candidate_info.old_full_id.public_id(),
+                    proxy_node_name: *self.candidate_info.old_proxy_id.public_id().name(),
+                },
+                message_id: self.candidate_info.message_id,
+                dst_name: XorName([0; XOR_NAME_LEN]),
+            }
+        }
+
+        fn online_payload(&self) -> (PublicId, OnlinePayload) {
+            let client_auth = Authority::Client {
+                client_id: *self.candidate_info.new_full_id.public_id(),
+                proxy_node_name: *self.candidate_info.new_proxy_id.public_id().name(),
+            };
+            (
+                *self.candidate_info.new_full_id.public_id(),
+                OnlinePayload {
+                    client_auth,
+                    old_public_id: *self.candidate_info.old_full_id.public_id(),
+                },
+            )
+        }
+
+        fn offline_payload(&self) -> PublicId {
+            *self.candidate_info.new_full_id.public_id()
+        }
+
+        fn purge_payload(&self) -> PublicId {
+            *self.candidate_info.old_full_id.public_id()
+        }
+
+        fn expect_candidate_rpc(&self) -> RoutingMessage {
+            let payload = self.expect_candidate_payload();
+
+            RoutingMessage {
+                src: Authority::Section(*payload.old_public_id.name()),
+                dst: Authority::Section(payload.dst_name),
+                content: MessageContent::ExpectCandidate {
+                    old_public_id: payload.old_public_id,
+                    old_client_auth: payload.old_client_auth,
+                    message_id: payload.message_id,
+                },
+            }
+        }
+
+        fn connection_info_request_rpc(&self) -> RoutingMessage {
+            use crate::mock_crust::Endpoint;
+            use crate::PubConnectionInfo;
+
+            let new_full_id = &self.candidate_info.new_full_id;
+            let their_pub_id = self.full_id.public_id();
+
+            let src = Authority::Client {
+                client_id: *new_full_id.public_id(),
+                proxy_node_name: *self.candidate_info.new_proxy_id.public_id().name(),
+            };
+            let dst = Authority::ManagedNode(*their_pub_id.name());
+
+            let content = {
+                let shared_secret = new_full_id
+                    .encrypting_private_key()
+                    .shared_secret(their_pub_id.encrypting_public_key());
+
+                let our_pub_info = PubConnectionInfo {
+                    id: *new_full_id.public_id(),
+                    endpoint: Endpoint(333),
+                };
+                let encrypted_conn_info = unwrap!(shared_secret.encrypt(&our_pub_info));
+
+                MessageContent::ConnectionInfoRequest {
+                    encrypted_conn_info,
+                    pub_id: *new_full_id.public_id(),
+                    msg_id: MessageId::new(),
+                }
+            };
+
+            RoutingMessage { src, dst, content }
+        }
+
+        fn candidate_info_rpc(&self) -> (DirectMessage, PublicId) {
+            self.candidate_info_rpc_use_wrong_old_signature(false)
+        }
+
+        fn candidate_info_rpc_use_wrong_old_signature(
+            &self,
+            use_bad_sig: bool,
+        ) -> (DirectMessage, PublicId) {
+            let old_full_id = &self.candidate_info.old_full_id;
+            let new_full_id = &self.candidate_info.new_full_id;
+
+            let old_and_new_pub_ids = (old_full_id.public_id(), new_full_id.public_id());
+
+            let old_signing_id = if use_bad_sig {
+                new_full_id
+            } else {
+                old_full_id
+            };
+
+            let mut to_sign = unwrap!(serialisation::serialise(&old_and_new_pub_ids));
+            let signature_using_old = old_signing_id.signing_private_key().sign_detached(&to_sign);
+
+            to_sign.extend_from_slice(&signature_using_old.into_bytes());
+            let signature_using_new = new_full_id.signing_private_key().sign_detached(&to_sign);
+
+            (
+                DirectMessage::CandidateInfo {
+                    old_public_id: *old_full_id.public_id(),
+                    new_public_id: *new_full_id.public_id(),
+                    signature_using_old,
+                    signature_using_new,
+                    new_client_auth: Authority::Client {
+                        client_id: *new_full_id.public_id(),
+                        proxy_node_name: *self.candidate_info.new_proxy_id.public_id().name(),
+                    },
+                },
+                *new_full_id.public_id(),
+            )
         }
     }
 
@@ -2715,42 +2906,12 @@ mod tests {
         })
     }
 
-    fn expect_candidate_payload() -> ExpectCandidatePayload {
-        let old_full_id = FullId::new();
-        let proxy_id = FullId::new();
-
-        ExpectCandidatePayload {
-            old_public_id: *old_full_id.public_id(),
-            old_client_auth: Authority::Client {
-                client_id: *old_full_id.public_id(),
-                proxy_node_name: *proxy_id.public_id().name(),
-            },
-            message_id: MessageId::new(),
-            dst_name: XorName([0; XOR_NAME_LEN]),
-        }
-    }
-
-    fn online_payload(old_public_id: PublicId) -> (PublicId, OnlinePayload) {
-        let new_full_id = FullId::new();
-        let proxy_id = FullId::new();
-        let client_auth = Authority::Client {
-            client_id: *new_full_id.public_id(),
-            proxy_node_name: *proxy_id.public_id().name(),
-        };
-        (
-            *new_full_id.public_id(),
-            OnlinePayload {
-                client_auth,
-                old_public_id,
-            },
-        )
-    }
-
     #[test]
     fn construct() {
         let node_test = NoteUnderTest::new();
 
         assert!(!node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
@@ -2758,113 +2919,157 @@ mod tests {
     fn accumulate_expect_candidate() {
         let mut node_test = NoteUnderTest::new();
 
-        let _ = node_test.accumulate_expect_candidate();
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
 
         assert!(node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
+    }
+
+    #[test]
+    // ExpectCandidate not consensused but node received RPC: candidate is not added
+    fn not_accumulate_expect_candidate_with_rpc() {
+        let mut node_test = NoteUnderTest::new();
+
+        let _ = node_test.dispatch_routing_message(node_test.expect_candidate_rpc());
+
+        assert!(!node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
+    }
+
+    #[test]
+    // ExpectCandidate is consensused with the vote of node under test: candidate is added
+    fn accumulate_expect_candidate_with_rpc() {
+        let mut node_test = NoteUnderTest::new();
+        let _ = node_test.dispatch_routing_message(node_test.expect_candidate_rpc());
+
+        node_test.accumulate_expect_candidate_if_vote(node_test.expect_candidate_payload());
+
+        assert!(node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // PurgeCandidate is consensused first: candidate is removed
     fn accumulate_purge_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
 
-        let purge_payload = payload_expect.old_public_id;
-        node_test.accumulate_purge_candidate(purge_payload);
+        node_test.accumulate_purge_candidate(node_test.purge_payload());
 
         assert!(!node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // Candidate is only removed as candidate when its SectionInfo is consensused
     fn accumulate_online_candidate_only_do_not_remove_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
 
-        let online_payload = online_payload(payload_expect.old_public_id);
-        node_test.accumulate_online(online_payload.clone());
+        node_test.accumulate_online(node_test.online_payload());
 
         assert!(node_test.has_resource_proof_candidate());
-        assert!(node_test.is_peer_valid(&online_payload.0));
+        assert!(node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // Candidate is only removed as candidate when its SectionInfo is consensused
     fn accumulate_online_candidate_then_section_info_remove_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
-        let online_payload = online_payload(payload_expect.old_public_id);
-        node_test.accumulate_online(online_payload.clone());
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+        node_test.accumulate_online(node_test.online_payload());
 
-        let new_section_info = node_test.new_section_info_with(&online_payload.0);
+        let new_section_info = node_test.new_section_info_with_candidate();
         node_test.accumulate_section_info_if_vote(new_section_info);
 
         assert!(!node_test.has_resource_proof_candidate());
-        assert!(node_test.is_peer_valid(&online_payload.0));
+        assert!(node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // When Online consensused first, PurgeCandidate has no effect
     fn accumulate_online_then_purge_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
-        let online_payload = online_payload(payload_expect.old_public_id);
-        node_test.accumulate_online(online_payload.clone());
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+        node_test.accumulate_online(node_test.online_payload());
 
-        let purge_payload = payload_expect.old_public_id;
-        node_test.accumulate_purge_candidate(purge_payload);
+        node_test.accumulate_purge_candidate(node_test.purge_payload());
 
         assert!(node_test.has_resource_proof_candidate());
-        assert!(node_test.is_peer_valid(&online_payload.0));
+        assert!(node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // When Online consensused first, PurgeCandidate has no effect
     fn accumulate_online_then_purge_then_section_info_for_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
-        let online_payload = online_payload(payload_expect.old_public_id);
-        node_test.accumulate_online(online_payload.clone());
-        let purge_payload = payload_expect.old_public_id;
-        node_test.accumulate_purge_candidate(purge_payload);
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+        node_test.accumulate_online(node_test.online_payload());
+        node_test.accumulate_purge_candidate(node_test.purge_payload());
 
-        let new_section_info = node_test.new_section_info_with(&online_payload.0);
+        let new_section_info = node_test.new_section_info_with_candidate();
         node_test.accumulate_section_info_if_vote(new_section_info);
 
         assert!(!node_test.has_resource_proof_candidate());
-        assert!(node_test.is_peer_valid(&online_payload.0));
+        assert!(node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // When PurgeCandidate consensused first, When Online consensused peer not added.
     fn accumulate_purge_then_online_for_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
-        let purge_payload = payload_expect.old_public_id;
-        node_test.accumulate_purge_candidate(purge_payload);
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+        node_test.accumulate_purge_candidate(node_test.purge_payload());
 
-        let online_payload = online_payload(payload_expect.old_public_id);
-        node_test.accumulate_online(online_payload.clone());
+        node_test.accumulate_online(node_test.online_payload());
 
         assert!(node_test.has_unpolled_observations());
         assert!(!node_test.has_resource_proof_candidate());
-        assert!(node_test.is_peer_valid(&online_payload.0));
+        assert!(node_test.is_candidate_a_valid_peer());
     }
 
     #[test]
     // When PurgeCandidate consensused first, When Online consensused, Offline is voted.
     fn accumulate_purge_then_online_then_offline_for_candidate() {
         let mut node_test = NoteUnderTest::new();
-        let payload_expect = node_test.accumulate_expect_candidate();
-        let purge_payload = payload_expect.old_public_id;
-        node_test.accumulate_purge_candidate(purge_payload);
-        let online_payload = online_payload(payload_expect.old_public_id);
-        node_test.accumulate_online(online_payload.clone());
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+        node_test.accumulate_purge_candidate(node_test.purge_payload());
+        node_test.accumulate_online(node_test.online_payload());
 
-        node_test.accumulate_offline_if_vote(online_payload.0);
+        node_test.accumulate_offline_if_vote(node_test.offline_payload());
 
         assert!(!node_test.has_unpolled_observations());
         assert!(!node_test.has_resource_proof_candidate());
-        assert!(!node_test.is_peer_valid(&online_payload.0));
+        assert!(!node_test.is_candidate_a_valid_peer());
+    }
+
+    #[test]
+    // Candidate now show info
+    fn candidate_info_rpc_in_interval() {
+        let mut node_test = NoteUnderTest::new();
+        node_test.set_interval_to_match_candidate(true);
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+
+        let _ = node_test.dispatch_routing_message(node_test.connection_info_request_rpc());
+        let _ = node_test.handle_direct_message(node_test.candidate_info_rpc());
+
+        assert!(node_test.has_candidate_info());
+        assert!(node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
+    }
+
+    #[test]
+    // Candidate info in wrong interval: Candidate not modifed - require purge event to remove
+    fn candidate_info_rpc_not_in_interval() {
+        let mut node_test = NoteUnderTest::new();
+        node_test.set_interval_to_match_candidate(false);
+        node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+
+        let _ = node_test.dispatch_routing_message(node_test.connection_info_request_rpc());
+        let _ = node_test.handle_direct_message(node_test.candidate_info_rpc());
+
+        assert!(!node_test.has_candidate_info());
+        assert!(node_test.has_resource_proof_candidate());
+        assert!(!node_test.is_candidate_a_valid_peer());
     }
 }

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -389,6 +389,10 @@ impl Node {
     }
 
     fn finalise_prefix_change(&mut self) -> Result<(), RoutingError> {
+        // Clear any relocation overrides
+        self.next_relocation_dst = None;
+        self.next_relocation_interval = None;
+
         let drained_obs: Vec<_> = self
             .parsec_map
             .our_unpolled_observations()

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -696,7 +696,7 @@ pub fn verify_invariant_for_all_nodes(nodes: &mut [TestNode]) {
                 "verify_invariant_for_all_nodes: node {}: missing: {:?}",
                 our_id, &missing_peers
             );
-            all_missing_peers.extend(missing_peers.into_iter());
+            all_missing_peers.extend(missing_peers);
         }
     }
 

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -680,14 +680,31 @@ pub fn verify_invariant_for_all_nodes(nodes: &mut [TestNode]) {
     let min_section_size = nodes[0].handle.0.borrow().network.min_section_size();
     verify_chain_invariant(nodes.iter().map(TestNode::chain), min_section_size);
 
+    let mut all_missing_peers = BTreeSet::<PublicId>::new();
     for node in nodes.iter_mut() {
         // Confirm valid peers from chain are connected according to PeerMgr
         let mut peers = node.chain().valid_peers();
-        let _ = peers.remove(&node.chain().our_id());
-        for pub_id in peers {
-            assert_eq!(true, node.inner.is_node_peer(pub_id));
+        let our_id = node.chain().our_id();
+        let _ = peers.remove(&our_id);
+        let missing_peers = peers
+            .iter()
+            .filter(|pub_id| !node.inner.is_node_peer(pub_id))
+            .cloned()
+            .collect_vec();
+        if !missing_peers.is_empty() {
+            error!(
+                "verify_invariant_for_all_nodes: node {}: missing: {:?}",
+                our_id, &missing_peers
+            );
+            all_missing_peers.extend(missing_peers.into_iter());
         }
     }
+
+    assert!(
+        all_missing_peers.is_empty(),
+        "verify_invariant_for_all_nodes - all_missing_peers: {:?}",
+        all_missing_peers
+    );
 }
 
 // Generate a vector of random bytes of the given length.


### PR DESCRIPTION
Add new tests to cover when PurgeCandidate comes before Online event.
Fix the code to ensure the test pass:
 - Add new field to NetworkEvent::Online with the old_public_id.
 - Use that field to decide whether we should accept the new member
   or vote it offline consistently imediately.

Both auth_client and old_public info are needed because the current
node did not receive the CandidateInfo. Keep them together in a
struct that will be serialized as related_info.

Note:
-This is not ideal because it introduce a new quirk: when candidate is
 rejected, it is added then removed. This did not happen before.
 The benefit is all node behave consistently, and this will be better
 addressed soon when introducing Opaque Online/Offline NetworkEvent.
-Now PeerManager::candidate has an expectation to only change
 from None to not None when reaching consensus on ExpectCandidate and
 from not None to None when reaching Consensus on PrugeCandidate or the
 SectionInfo containing the candidate.
 => We must no longer fall back to reseting it to None on error.


Also improve error message for soak test failure.
Also fix issue when receiving CandidateInfo signed incorrectly.