### PR TITLE
use opaque Offline/Online event

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -708,7 +708,7 @@ impl Chain {
 
             NetworkEvent::AddElder(_, _)
             | NetworkEvent::RemoveElder(_)
-            | NetworkEvent::Online(_, _)
+            | NetworkEvent::Online(_)
             | NetworkEvent::Offline(_)
             | NetworkEvent::ExpectCandidate(_)
             | NetworkEvent::PurgeCandidate(_) => {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -122,7 +122,7 @@ impl Chain {
         proof_set: ProofSet,
     ) -> Result<(), RoutingError> {
         match event {
-            NetworkEvent::Online(_, _) | NetworkEvent::Offline(_) => (),
+            NetworkEvent::AddElder(_, _) | NetworkEvent::RemoveElder(_) => (),
             _ => {
                 log_or_panic!(
                     LogLevel::Error,
@@ -705,7 +705,10 @@ impl Chain {
 
                 self.our_info().is_quorum(proofs)
             }
-            NetworkEvent::Online(_, _)
+
+            NetworkEvent::AddElder(_, _)
+            | NetworkEvent::RemoveElder(_)
+            | NetworkEvent::Online(_, _)
             | NetworkEvent::Offline(_)
             | NetworkEvent::ExpectCandidate(_)
             | NetworkEvent::PurgeCandidate(_) => {

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -30,6 +30,8 @@ pub struct ExpectCandidatePayload {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct OnlinePayload {
+    /// The joining node's new public ID.
+    pub new_public_id: PublicId,
     /// The joining node's previous public ID.
     pub old_public_id: PublicId,
     /// The joining node's current authority.
@@ -47,7 +49,7 @@ pub enum NetworkEvent {
     RemoveElder(PublicId),
 
     /// Voted for candidate that pass resource proof
-    Online(PublicId, OnlinePayload),
+    Online(OnlinePayload),
     /// Voted for candidate we no longer consider online.
     Offline(PublicId),
 
@@ -105,7 +107,11 @@ impl Debug for NetworkEvent {
         match self {
             NetworkEvent::AddElder(ref id, _) => write!(formatter, "AddElder({}, _)", id),
             NetworkEvent::RemoveElder(ref id) => write!(formatter, "RemoveElder({})", id),
-            NetworkEvent::Online(ref id, _) => write!(formatter, "Online({}, _)", id),
+            NetworkEvent::Online(ref payload) => write!(
+                formatter,
+                "Online(new:{}, old:{})",
+                payload.new_public_id, payload.old_public_id
+            ),
             NetworkEvent::Offline(ref id) => write!(formatter, "Offline({})", id),
             NetworkEvent::OurMerge => write!(formatter, "OurMerge"),
             NetworkEvent::NeighbourMerge(ref digest) => {

--- a/src/mock_crust/support.rs
+++ b/src/mock_crust/support.rs
@@ -235,7 +235,16 @@ impl<UID: Uid> Network<UID> {
     // Drops any pending messages on a specific route (does not automatically
     // drop packets going the other way).
     fn drop_pending(&self, sender: Endpoint, receiver: Endpoint) {
-        let _ = self.0.borrow_mut().queue.remove(&(sender, receiver));
+        if let Some(dropped) = self.0.borrow_mut().queue.remove(&(sender, receiver)) {
+            for packet in dropped {
+                trace!(
+                    "drop_pending {:?} ->  {:?} : {:?}",
+                    sender,
+                    receiver,
+                    &packet
+                );
+            }
+        }
     }
 
     fn pop_packet(&self) -> Option<(Endpoint, Endpoint, Packet<UID>)> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -622,10 +622,8 @@ impl Node {
     }
 
     /// Indicates if there are any pending observations in the parsec object
-    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
-        self.machine
-            .current()
-            .has_unpolled_observations(filter_opaque)
+    pub fn has_unpolled_observations(&self) -> bool {
+        self.machine.current().has_unpolled_observations()
     }
 
     /// Indicates if a given `PublicId` is in the peer manager as a Node

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -161,20 +161,14 @@ impl ParsecMap {
     }
 
     #[cfg(feature = "mock_base")]
-    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
+    pub fn has_unpolled_observations(&self) -> bool {
         let parsec = if let Some(parsec) = self.map.values().last() {
             parsec
         } else {
             return false;
         };
 
-        if filter_opaque {
-            parsec
-                .our_unpolled_observations()
-                .any(Observation::is_opaque)
-        } else {
-            parsec.has_unpolled_observations()
-        }
+        parsec.has_unpolled_observations()
     }
 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -221,15 +221,15 @@ impl State {
         }
     }
 
-    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
+    pub fn has_unpolled_observations(&self) -> bool {
         match *self {
             State::Terminated
             | State::BootstrappingPeer(_)
             | State::Client(_)
             | State::RelocatingNode(_)
             | State::ProvingNode(_) => false,
-            State::EstablishingNode(ref state) => state.has_unpolled_observations(filter_opaque),
-            State::Node(ref state) => state.has_unpolled_observations(filter_opaque),
+            State::EstablishingNode(ref state) => state.has_unpolled_observations(),
+            State::Node(ref state) => state.has_unpolled_observations(),
         }
     }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -19,6 +19,7 @@ use crate::{
     routing_table::Prefix,
     state_machine::Transition,
     xor_name::XorName,
+    Authority,
 };
 use maidsafe_utilities::serialisation;
 
@@ -27,20 +28,30 @@ pub trait Approved: Relocated {
     fn parsec_map_mut(&mut self) -> &mut ParsecMap;
     fn chain_mut(&mut self) -> &mut Chain;
 
+    /// Handles an accumulated `AddElder` event.
+    fn handle_add_elder_event(
+        &mut self,
+        new_pub_id: PublicId,
+        client_auth: Authority<XorName>,
+        outbox: &mut EventBox,
+    ) -> Result<(), RoutingError>;
+
+    /// Handles an accumulated `RemoveElder` event.
+    fn handle_remove_elder_event(
+        &mut self,
+        pub_id: PublicId,
+        outbox: &mut EventBox,
+    ) -> Result<(), RoutingError>;
+
     /// Handles an accumulated `Online` event.
     fn handle_online_event(
         &mut self,
         new_pub_id: PublicId,
         online_payload: OnlinePayload,
-        outbox: &mut EventBox,
     ) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `Offline` event.
-    fn handle_offline_event(
-        &mut self,
-        pub_id: PublicId,
-        outbox: &mut EventBox,
-    ) -> Result<(), RoutingError>;
+    fn handle_offline_event(&mut self, pub_id: PublicId) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `OurMerge` event.
     fn handle_our_merge_event(&mut self) -> Result<(), RoutingError>;
@@ -145,14 +156,16 @@ pub trait Approved: Relocated {
                     peer_id,
                     related_info,
                 } => {
-                    let event =
-                        NetworkEvent::Online(*peer_id, serialisation::deserialise(&related_info)?);
+                    let event = NetworkEvent::AddElder(
+                        *peer_id,
+                        serialisation::deserialise(&related_info)?,
+                    );
                     let proof_set = to_proof_set(&block);
                     trace!("{} Parsec Add: - {}", self, peer_id);
                     self.chain_mut().handle_churn_event(&event, proof_set)?;
                 }
                 Observation::Remove { peer_id, .. } => {
-                    let event = NetworkEvent::Offline(*peer_id);
+                    let event = NetworkEvent::RemoveElder(*peer_id);
                     let proof_set = to_proof_set(&block);
                     trace!("{} Parsec Remove: - {}", self, peer_id);
                     self.chain_mut().handle_churn_event(&event, proof_set)?;
@@ -174,11 +187,17 @@ pub trait Approved: Relocated {
             trace!("{} Handle accumulated event: {:?}", self, event);
 
             match event {
+                NetworkEvent::AddElder(pub_id, client_auth) => {
+                    self.handle_add_elder_event(pub_id, client_auth, outbox)?;
+                }
+                NetworkEvent::RemoveElder(pub_id) => {
+                    self.handle_remove_elder_event(pub_id, outbox)?;
+                }
                 NetworkEvent::Online(pub_id, info) => {
-                    self.handle_online_event(pub_id, info, outbox)?;
+                    self.handle_online_event(pub_id, info)?;
                 }
                 NetworkEvent::Offline(pub_id) => {
-                    self.handle_offline_event(pub_id, outbox)?;
+                    self.handle_offline_event(pub_id)?;
                 }
                 NetworkEvent::OurMerge => self.handle_our_merge_event()?,
                 NetworkEvent::NeighbourMerge(_) => self.handle_neighbour_merge_event()?,

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -44,11 +44,7 @@ pub trait Approved: Relocated {
     ) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `Online` event.
-    fn handle_online_event(
-        &mut self,
-        new_pub_id: PublicId,
-        online_payload: OnlinePayload,
-    ) -> Result<(), RoutingError>;
+    fn handle_online_event(&mut self, online_payload: OnlinePayload) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `Offline` event.
     fn handle_offline_event(&mut self, pub_id: PublicId) -> Result<(), RoutingError>;
@@ -193,8 +189,8 @@ pub trait Approved: Relocated {
                 NetworkEvent::RemoveElder(pub_id) => {
                     self.handle_remove_elder_event(pub_id, outbox)?;
                 }
-                NetworkEvent::Online(pub_id, info) => {
-                    self.handle_online_event(pub_id, info)?;
+                NetworkEvent::Online(info) => {
+                    self.handle_online_event(info)?;
                 }
                 NetworkEvent::Offline(pub_id) => {
                     self.handle_offline_event(pub_id)?;

--- a/src/states/common/relocated.rs
+++ b/src/states/common/relocated.rs
@@ -307,7 +307,7 @@ pub trait Relocated: Bootstrapped {
         }
 
         if self.peer_mgr().is_client(&their_public_id)
-            || self.peer_mgr().is_joining_node(&their_public_id)
+            || self.peer_mgr().is_or_was_joining_node(&their_public_id)
             || self.peer_mgr().is_proxy(&their_public_id)
         {
             // we use peer_name here instead of their_name since the peer can be
@@ -410,7 +410,7 @@ pub trait Relocated: Bootstrapped {
             debug!("{} Not disconnecting node {}.", self, pub_id);
         } else if self.peer_mgr().is_proxy(pub_id) {
             debug!("{} Not disconnecting proxy node {}.", self, pub_id);
-        } else if self.peer_mgr().is_joining_node(pub_id) {
+        } else if self.peer_mgr().is_or_was_joining_node(pub_id) {
             debug!("{} Not disconnecting joining node {:?}.", self, pub_id);
         } else {
             debug!(

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -183,8 +183,8 @@ impl EstablishingNode {
         self.timer.get_timed_out_tokens()
     }
 
-    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
-        self.parsec_map.has_unpolled_observations(filter_opaque)
+    pub fn has_unpolled_observations(&self) -> bool {
+        self.parsec_map.has_unpolled_observations()
     }
 }
 

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -376,7 +376,7 @@ impl Approved for EstablishingNode {
         Ok(())
     }
 
-    fn handle_online_event(&mut self, _: PublicId, _: OnlinePayload) -> Result<(), RoutingError> {
+    fn handle_online_event(&mut self, _: OnlinePayload) -> Result<(), RoutingError> {
         Ok(())
     }
 

--- a/src/states/establishing_node.rs
+++ b/src/states/establishing_node.rs
@@ -357,22 +357,30 @@ impl Approved for EstablishingNode {
         &mut self.chain
     }
 
-    fn handle_online_event(
+    fn handle_add_elder_event(
         &mut self,
         new_pub_id: PublicId,
-        _: OnlinePayload,
+        _: Authority<XorName>,
         _: &mut EventBox,
     ) -> Result<(), RoutingError> {
         let _ = self.chain.add_member(new_pub_id)?;
         Ok(())
     }
 
-    fn handle_offline_event(
+    fn handle_remove_elder_event(
         &mut self,
         pub_id: PublicId,
         _: &mut EventBox,
     ) -> Result<(), RoutingError> {
         let _ = self.chain.remove_member(pub_id)?;
+        Ok(())
+    }
+
+    fn handle_online_event(&mut self, _: PublicId, _: OnlinePayload) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
+    fn handle_offline_event(&mut self, _: PublicId) -> Result<(), RoutingError> {
         Ok(())
     }
 

--- a/src/states/node/mod.rs
+++ b/src/states/node/mod.rs
@@ -1729,7 +1729,10 @@ impl Node {
         outbox: &mut EventBox,
         try_reconnect: bool,
     ) -> bool {
-        if self.peer_mgr.remove_peer(&pub_id) {
+        // Calling remove twice to remove a potential JoiningNode we have as a Node than purely
+        // demoting it
+        // TODO: Avoid calling this twice.
+        if self.peer_mgr.remove_peer(&pub_id) || self.peer_mgr.remove_peer(&pub_id) {
             info!("{} Dropped {} from the routing table.", self, pub_id.name());
             outbox.send_event(Event::NodeLost(*pub_id.name()));
 

--- a/src/states/node/mod.rs
+++ b/src/states/node/mod.rs
@@ -2186,8 +2186,8 @@ impl Node {
         self.next_relocation_interval = interval;
     }
 
-    pub fn has_unpolled_observations(&self, filter_opaque: bool) -> bool {
-        self.parsec_map.has_unpolled_observations(filter_opaque)
+    pub fn has_unpolled_observations(&self) -> bool {
+        self.parsec_map.has_unpolled_observations()
     }
 
     pub fn is_node_peer(&self, pub_id: &PublicId) -> bool {

--- a/src/states/node/mod.rs
+++ b/src/states/node/mod.rs
@@ -2091,7 +2091,7 @@ impl Base for Node {
                 Ok(*self.name())
             }
             Some(&PeerState::JoiningNode) => Ok(*self.name()),
-            Some(&PeerState::Candidate) | Some(&PeerState::Proxy) | Some(&PeerState::Node) => {
+            Some(&PeerState::Candidate) | Some(&PeerState::Proxy) | Some(&PeerState::Node(_)) => {
                 Ok(*pub_id.name())
             }
             Some(&PeerState::ConnectionInfoPreparing { .. })

--- a/src/states/node/tests.rs
+++ b/src/states/node/tests.rs
@@ -23,9 +23,10 @@ use crate::state_machine::{State, StateMachine};
 use crate::xor_name::XOR_NAME_LEN;
 use utils::LogIdent;
 
-const NO_SINGLE_VETO_VOTE_COUNT: usize = 4;
-const ACCUMULATE_VOTE_COUNT: usize = 3;
-const NOT_ACCUMULATE_ALONE_VOTE_COUNT: usize = 2;
+// Accumulate even if 1 old node and an additional new node do not vote.
+const NO_SINGLE_VETO_VOTE_COUNT: usize = 7;
+const ACCUMULATE_VOTE_COUNT: usize = 6;
+const NOT_ACCUMULATE_ALONE_VOTE_COUNT: usize = 5;
 
 struct CandidateInfo {
     old_full_id: FullId,
@@ -79,13 +80,13 @@ impl NoteUnderTest {
         let full_id = full_ids[0].clone();
         let machine = make_state_machine(&full_id, &gen_pfx_info, &mut ev_buffer);
 
-        let other_full_ids = full_ids[1..4].iter().cloned().collect_vec();
+        let other_full_ids = full_ids[1..].iter().cloned().collect_vec();
         let other_parsec_map = other_full_ids
             .iter()
             .map(|full_id| ParsecMap::new(full_id.clone(), &gen_pfx_info))
             .collect_vec();
 
-        Self {
+        let mut node_test = Self {
             machine,
             full_id,
             other_full_ids,
@@ -93,7 +94,11 @@ impl NoteUnderTest {
             ev_buffer,
             section_info,
             candidate_info: CandidateInfo::new(),
-        }
+        };
+
+        // Process initial unpolled event
+        let _ = node_test.create_gossip();
+        node_test
     }
 
     fn node_state(&self) -> &Node {
@@ -173,6 +178,16 @@ impl NoteUnderTest {
         );
     }
 
+    fn accumulate_add_elder_if_vote(&mut self, online_payload: (PublicId, OnlinePayload)) {
+        let _ = self.n_vote_for_gossipped(
+            ACCUMULATE_VOTE_COUNT,
+            &[&NetworkEvent::AddElder(
+                online_payload.0,
+                online_payload.1.client_auth,
+            )],
+        );
+    }
+
     fn accumulate_section_info_if_vote(&mut self, section_info_payload: SectionInfo) {
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
@@ -180,10 +195,17 @@ impl NoteUnderTest {
         );
     }
 
-    fn accumulate_offline_if_vote(&mut self, offline_payload: PublicId) {
+    fn accumulate_offline(&mut self, offline_payload: PublicId) {
+        let _ = self.n_vote_for_gossipped(
+            ACCUMULATE_VOTE_COUNT,
+            &[&NetworkEvent::Offline(offline_payload)],
+        );
+    }
+
+    fn accumulate_remove_elder_if_vote(&mut self, offline_payload: PublicId) {
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
-            &[&NetworkEvent::Offline(offline_payload)],
+            &[&NetworkEvent::RemoveElder(offline_payload)],
         );
     }
 
@@ -197,6 +219,15 @@ impl NoteUnderTest {
                 .collect(),
             *self.section_info.prefix(),
             Some(&self.section_info)
+        ))
+    }
+
+    fn new_section_info_without_candidate(&self) -> SectionInfo {
+        let old_info = self.new_section_info_with_candidate();
+        unwrap!(SectionInfo::new(
+            self.section_info.members().clone(),
+            *old_info.prefix(),
+            Some(&old_info)
         ))
     }
 
@@ -435,6 +466,7 @@ fn make_state_machine(
 fn construct() {
     let node_test = NoteUnderTest::new();
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.has_resource_proof_candidate());
     assert!(!node_test.is_candidate_a_valid_peer());
 }
@@ -446,6 +478,7 @@ fn accumulate_expect_candidate() {
 
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(node_test.has_resource_proof_candidate());
     assert!(!node_test.is_candidate_a_valid_peer());
 }
@@ -456,7 +489,9 @@ fn not_accumulate_expect_candidate_with_message() {
     let mut node_test = NoteUnderTest::new();
 
     let _ = node_test.dispatch_routing_message(node_test.expect_candidate_message());
+    let _ = node_test.create_gossip();
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.has_resource_proof_candidate());
     assert!(!node_test.is_candidate_a_valid_peer());
 }
@@ -466,9 +501,11 @@ fn not_accumulate_expect_candidate_with_message() {
 fn accumulate_expect_candidate_with_message() {
     let mut node_test = NoteUnderTest::new();
     let _ = node_test.dispatch_routing_message(node_test.expect_candidate_message());
+    let _ = node_test.create_gossip();
 
     node_test.accumulate_expect_candidate_if_vote(node_test.expect_candidate_payload());
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(node_test.has_resource_proof_candidate());
     assert!(!node_test.is_candidate_a_valid_peer());
 }
@@ -479,8 +516,10 @@ fn accumulate_purge_candidate() {
     let mut node_test = NoteUnderTest::new();
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
 
+    // Should probably add a test that the vote occured on timeout
     node_test.accumulate_purge_candidate(node_test.purge_payload());
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.has_resource_proof_candidate());
     assert!(!node_test.is_candidate_a_valid_peer());
 }
@@ -493,54 +532,77 @@ fn accumulate_online_candidate_only_do_not_remove_candidate() {
 
     node_test.accumulate_online(node_test.online_payload());
 
+    assert!(node_test.has_unpolled_observations());
+    assert!(node_test.has_resource_proof_candidate());
+    assert!(!node_test.is_candidate_a_valid_peer());
+}
+
+#[test]
+// Candidate is only removed as candidate when its SectionInfo is consensused
+// Vote for `Online` trigger immediate vote for AddElder
+fn accumulate_online_candidate_then_add_elder_only_do_not_remove_candidate() {
+    let mut node_test = NoteUnderTest::new();
+    node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+    node_test.accumulate_online(node_test.online_payload());
+
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
+
+    assert!(!node_test.has_unpolled_observations());
     assert!(node_test.has_resource_proof_candidate());
     assert!(node_test.is_candidate_a_valid_peer());
 }
 
 #[test]
 // Candidate is only removed as candidate when its SectionInfo is consensused
-fn accumulate_online_candidate_then_section_info_remove_candidate() {
+fn accumulate_online_candidate_then_add_elder_then_section_info_remove_candidate() {
     let mut node_test = NoteUnderTest::new();
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
     node_test.accumulate_online(node_test.online_payload());
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
 
     let new_section_info = node_test.new_section_info_with_candidate();
     node_test.accumulate_section_info_if_vote(new_section_info);
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.has_resource_proof_candidate());
     assert!(node_test.is_candidate_a_valid_peer());
 }
 
 #[test]
 // When Online consensused first, PurgeCandidate has no effect
-fn accumulate_online_then_purge_candidate() {
+fn accumulate_online_then_purge_then_add_elder_for_candidate() {
     let mut node_test = NoteUnderTest::new();
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
     node_test.accumulate_online(node_test.online_payload());
 
     node_test.accumulate_purge_candidate(node_test.purge_payload());
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(node_test.has_resource_proof_candidate());
     assert!(node_test.is_candidate_a_valid_peer());
 }
 
 #[test]
 // When Online consensused first, PurgeCandidate has no effect
-fn accumulate_online_then_purge_then_section_info_for_candidate() {
+fn accumulate_online_then_purge_then_add_elder_then_section_info_for_candidate() {
     let mut node_test = NoteUnderTest::new();
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
     node_test.accumulate_online(node_test.online_payload());
     node_test.accumulate_purge_candidate(node_test.purge_payload());
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
 
     let new_section_info = node_test.new_section_info_with_candidate();
     node_test.accumulate_section_info_if_vote(new_section_info);
 
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.has_resource_proof_candidate());
     assert!(node_test.is_candidate_a_valid_peer());
 }
 
 #[test]
-// When PurgeCandidate consensused first, When Online consensused peer not added.
+// When PurgeCandidate consensused first, When Online consensused AddElder is not voted
+// and the peer is not added.
 fn accumulate_purge_then_online_for_candidate() {
     let mut node_test = NoteUnderTest::new();
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
@@ -548,23 +610,58 @@ fn accumulate_purge_then_online_for_candidate() {
 
     node_test.accumulate_online(node_test.online_payload());
 
-    assert!(node_test.has_unpolled_observations());
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.has_resource_proof_candidate());
+    assert!(!node_test.is_candidate_a_valid_peer());
+}
+
+#[test]
+// When Offline consensused, RemoveElder is voted.
+fn accumulate_offline_for_node() {
+    let mut node_test = NoteUnderTest::new();
+    node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+    node_test.accumulate_online(node_test.online_payload());
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
+    node_test.accumulate_section_info_if_vote(node_test.new_section_info_with_candidate());
+
+    node_test.accumulate_offline(node_test.offline_payload());
+
+    assert!(node_test.has_unpolled_observations());
     assert!(node_test.is_candidate_a_valid_peer());
 }
 
 #[test]
-// When PurgeCandidate consensused first, When Online consensused, Offline is voted.
-fn accumulate_purge_then_online_then_offline_for_candidate() {
+// When Offline consensused, RemoveElder is voted. The peer only become invalid once
+// SectionInfo is consensused
+fn accumulate_offline_then_remove_elder_for_node() {
     let mut node_test = NoteUnderTest::new();
     node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
-    node_test.accumulate_purge_candidate(node_test.purge_payload());
     node_test.accumulate_online(node_test.online_payload());
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
+    node_test.accumulate_section_info_if_vote(node_test.new_section_info_with_candidate());
+    node_test.accumulate_offline(node_test.offline_payload());
 
-    node_test.accumulate_offline_if_vote(node_test.offline_payload());
+    node_test.accumulate_remove_elder_if_vote(node_test.offline_payload());
 
     assert!(!node_test.has_unpolled_observations());
-    assert!(!node_test.has_resource_proof_candidate());
+    assert!(node_test.is_candidate_a_valid_peer());
+}
+
+#[test]
+// When Offline consensused, RemoveElder is voted. The peer only become invalid once
+// SectionInfo is consensused
+fn accumulate_offline_then_remove_elder_then_section_info_for_node() {
+    let mut node_test = NoteUnderTest::new();
+    node_test.accumulate_expect_candidate(node_test.expect_candidate_payload());
+    node_test.accumulate_online(node_test.online_payload());
+    node_test.accumulate_add_elder_if_vote(node_test.online_payload());
+    node_test.accumulate_section_info_if_vote(node_test.new_section_info_with_candidate());
+    node_test.accumulate_offline(node_test.offline_payload());
+    node_test.accumulate_remove_elder_if_vote(node_test.offline_payload());
+
+    node_test.accumulate_section_info_if_vote(node_test.new_section_info_without_candidate());
+
+    assert!(!node_test.has_unpolled_observations());
     assert!(!node_test.is_candidate_a_valid_peer());
 }
 

--- a/src/states/node/tests.rs
+++ b/src/states/node/tests.rs
@@ -171,19 +171,19 @@ impl NoteUnderTest {
         );
     }
 
-    fn accumulate_online(&mut self, online_payload: (PublicId, OnlinePayload)) {
+    fn accumulate_online(&mut self, online_payload: OnlinePayload) {
         let _ = self.n_vote_for_gossipped(
             ACCUMULATE_VOTE_COUNT,
-            &[&NetworkEvent::Online(online_payload.0, online_payload.1)],
+            &[&NetworkEvent::Online(online_payload)],
         );
     }
 
-    fn accumulate_add_elder_if_vote(&mut self, online_payload: (PublicId, OnlinePayload)) {
+    fn accumulate_add_elder_if_vote(&mut self, online_payload: OnlinePayload) {
         let _ = self.n_vote_for_gossipped(
             ACCUMULATE_VOTE_COUNT,
             &[&NetworkEvent::AddElder(
-                online_payload.0,
-                online_payload.1.client_auth,
+                online_payload.new_public_id,
+                online_payload.client_auth,
             )],
         );
     }
@@ -281,18 +281,16 @@ impl NoteUnderTest {
         }
     }
 
-    fn online_payload(&self) -> (PublicId, OnlinePayload) {
+    fn online_payload(&self) -> OnlinePayload {
         let client_auth = Authority::Client {
             client_id: *self.candidate_info.new_full_id.public_id(),
             proxy_node_name: *self.candidate_info.new_proxy_id.public_id().name(),
         };
-        (
-            *self.candidate_info.new_full_id.public_id(),
-            OnlinePayload {
-                client_auth,
-                old_public_id: *self.candidate_info.old_full_id.public_id(),
-            },
-        )
+        OnlinePayload {
+            new_public_id: *self.candidate_info.new_full_id.public_id(),
+            client_auth,
+            old_public_id: *self.candidate_info.old_full_id.public_id(),
+        }
     }
 
     fn offline_payload(&self) -> PublicId {

--- a/src/states/node/tests.rs
+++ b/src/states/node/tests.rs
@@ -232,7 +232,7 @@ impl NoteUnderTest {
     }
 
     fn has_unpolled_observations(&self) -> bool {
-        self.node_state().has_unpolled_observations(false)
+        self.node_state().has_unpolled_observations()
     }
 
     fn has_resource_proof_candidate(&self) -> bool {

--- a/tests/mock_crust/utils.rs
+++ b/tests/mock_crust/utils.rs
@@ -388,16 +388,13 @@ pub fn poll_and_resend_until(
     should_stop: &Fn(&[TestNode]) -> bool,
 ) {
     let mut fired_connecting_peer_timeout = false;
-    for i in 0..MAX_POLL_CALLS {
+    for _ in 0..MAX_POLL_CALLS {
         if should_stop(nodes) {
             return;
         }
 
         let node_busy = |node: &TestNode| {
-            // after MAX_POLL_CALLS / 2 only filter for opaque events
-            // to avoid stalling the test due to lack of parsec voters.
-            node.inner.has_unacked_msg()
-                || node.inner.has_unpolled_observations(i > MAX_POLL_CALLS / 2)
+            node.inner.has_unacked_msg() || node.inner.has_unpolled_observations()
         };
         let client_busy = |client: &TestClient| client.inner.has_unacked_msg();
         if poll_all_until(nodes, clients, should_stop)


### PR DESCRIPTION
Avoid temporarily adding candidate that fail resource proof.
Open door for Node Ageing Adults that do not become Elder. 

Some additional test uncover more issues that will not be addressed here:
https://github.com/maidsafe/routing/pull/1636
