### PR TITLE
chore: remove unnecessary clone

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -287,6 +287,11 @@ impl SignedMessage {
         self.proving_sections.pop().is_some()
     }
 
+    /// Keeps the first `len` hops, dropping the rest.
+    pub fn truncate_hops(&mut self, len: usize) {
+        self.proving_sections.truncate(len)
+    }
+
     /// Appends the proving sections to this message.
     pub fn extend_proving_sections<I>(&mut self, proving_sections: I)
     where

--- a/src/states/node/mod.rs
+++ b/src/states/node/mod.rs
@@ -551,7 +551,8 @@ impl Node {
         } else {
             let mut num_trusted_hops = signed_msg.proving_sections().len();
             let mut trusted_hop_found = false;
-            for (index, hop) in signed_msg.proving_sections()
+            for (index, hop) in signed_msg
+                .proving_sections()
                 .iter()
                 .map(|ps| &ps.sec_info)
                 .enumerate()
@@ -565,10 +566,11 @@ impl Node {
             }
 
             // If none of the intermediate hops are trusted try the source.
-            if !trusted_hop_found && signed_msg.source_section().is_some() &&
-             self.is_trusted(signed_msg.source_section().unwrap())? {
-                 trusted_hop_found = true;
-                 num_trusted_hops = 0;
+            if let Some(src_section) = signed_msg.source_section() {
+                if !trusted_hop_found && self.is_trusted(src_section)? {
+                    trusted_hop_found = true;
+                    num_trusted_hops = 0;
+                }
             }
 
             if !trusted_hop_found {

--- a/src/states/node/mod.rs
+++ b/src/states/node/mod.rs
@@ -550,15 +550,13 @@ impl Node {
             }
         } else {
             // Remove any untrusted trailing section infos.
-            // TODO: remove wasted clone. Only useful when msg isnt trusted for log msg.
-            let msg_clone = signed_msg.clone();
             while match signed_msg.previous_hop() {
                 None => true,
                 Some(hop) => !self.is_trusted(hop)?,
             } {
                 // We don't know the last hop! Try the one before that.
                 if !signed_msg.pop_previous_hop() {
-                    debug!("{} Untrusted message: {:?}", self, msg_clone);
+                    debug!("{} Untrusted message: {:?}", self, signed_msg);
                     return Err(RoutingError::NotEnoughSignatures);
                 }
             }


### PR DESCRIPTION
Addresses a minor TODO to remove an unnecessary clone() operation.