### PR TITLE
fix/parsec: Update to Parsec with temp common coin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "~0.3.8"
 lru_time_cache = "~0.8.1"
 maidsafe_utilities = "~0.16.0"
 num-bigint = "~0.1.40"
-parsec = { git = "https://github.com/maidsafe/parsec", rev = "f2860553c" }
+parsec = { git = "https://github.com/maidsafe/parsec", rev = "8c0d9d00e" }
 quick-error = "~1.2.0"
 rand = "~0.3.16"
 resource_proof = "~0.6.0"


### PR DESCRIPTION
We had some soak testing issues with the previous PARSEC head that used
a concrete coin.

The problem came from different nodes sometimes having a different
perception of the concrete coin, which was to be expected by definition
of a concrete coin. It was an issue due to an implicit assumption that
existed in the PARSEC code that if a node learnt about consensus, any
node hearing from them should immediately reach the same conclusion.

Rather than changing the erroneous assumption, we replaced the concrete
coin with a common coin that is predictable.
It suffers from a lack of asynchrony as an adversary which controls the
scheduler could use this property to affect Liveness; but should be good
enough as a place-holder until we implement DKG, BLS and a proper common
coin.

Having routing point at that latest PARSEC will allow us to continue
soak testing routing with real PARSEC which is good to truly push PARSEC
to its limits and test its interaction with routing.