### PR TITLE
chore/clippy: resolve clippy errors

### DIFF
--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -25,6 +25,6 @@ pub use self::mpid_message_wrapper::MpidMessageWrapper;
 
 #[cfg(test)]
 fn generate_random_bytes(size: usize) -> Vec<u8> {
-    use rand::{self, Rng};
+    use rand::Rng;
     rand::thread_rng().gen_iter().take(size).collect()
 }

--- a/src/routing_table/mod.rs
+++ b/src/routing_table/mod.rs
@@ -1276,7 +1276,7 @@ mod tests {
     // `need_to_add()` while also implicitly testing `add()` and `split()`.
     #[test]
     #[ignore]
-    #[allow(clippy::cyclomatic_complexity, clippy::assertions_on_constants)]
+    #[allow(clippy::cognitive_complexity, clippy::assertions_on_constants)]
     fn test_routing_sections() {
         assert!(
             SPLIT_BUFFER < 3818,

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -474,7 +474,7 @@ impl StateMachine {
         use itertools::Itertools;
         use maidsafe_utilities::SeededRng;
         use rand::Rng;
-        use std::iter::{self, Iterator};
+        use std::iter;
 
         if !self.is_running {
             return Err(TryRecvError::Disconnected);

--- a/src/states/node/mod.rs
+++ b/src/states/node/mod.rs
@@ -1480,6 +1480,7 @@ impl Node {
         user_msg: UserMessage,
         priority: u8,
     ) -> Result<(), RoutingError> {
+        #[allow(clippy::identity_conversion)]
         for part in user_msg.to_parts(priority)? {
             self.send_routing_message(src, dst, part)?;
         }

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -327,7 +327,7 @@ fn closest_nodes(node_names: &[XorName], target: &XorName) -> Vec<XorName> {
 }
 
 // TODO: Extract the individual tests into their own functions.
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn core() {
     let (event_sender, event_receiver) = mpsc::channel();
     let mut nodes = create_connected_nodes(MIN_SECTION_SIZE + 1, &event_sender, &event_receiver);


### PR DESCRIPTION
I silenced the error below as the suggested fix didn't make sense and was unsure how to resolve:
```
error: identical conversion
    --> src/states/node.rs:3099:21
     |
3099 |         for part in user_msg.to_parts(priority)? {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `user_msg.to_parts(priority)?()`: `user_msg.to_parts(priority)?`
     |
note: lint level defined here
    --> src/lib.rs:105:5
     |
105  |     warnings
     |     ^^^^^^^^
     = note: #[forbid(clippy::identity_conversion)] implied by #[forbid(warnings)]
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
```

All other errors are fixed