### PR TITLE
rename EstablishingNode to Adult and Node to Elder

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -139,9 +139,15 @@ impl NodeBuilder {
         StateMachine::new(
             move |action_sender, crust_service, timer, outbox2| {
                 if self.first {
-                    states::Node::first(self.cache, crust_service, full_id, min_section_size, timer)
-                        .map(State::Node)
-                        .unwrap_or(State::Terminated)
+                    states::Elder::first(
+                        self.cache,
+                        crust_service,
+                        full_id,
+                        min_section_size,
+                        timer,
+                    )
+                    .map(State::Elder)
+                    .unwrap_or(State::Terminated)
                 } else if !dev_config.allow_multiple_lan_nodes && crust_service.has_peers_on_lan() {
                     error!(
                         "More than one routing node found on LAN. Currently this is not supported."
@@ -575,18 +581,18 @@ impl Node {
     }
 
     /// Returns this node state.
-    pub fn node_state(&self) -> Option<&crate::states::Node> {
-        self.machine.current().node_state()
+    pub fn node_state(&self) -> Option<&crate::states::Elder> {
+        self.machine.current().elder_state()
     }
 
     /// Returns this node mut state.
-    pub fn node_state_mut(&mut self) -> Option<&mut crate::states::Node> {
-        self.machine.current_mut().node_state_mut()
+    pub fn node_state_mut(&mut self) -> Option<&mut crate::states::Elder> {
+        self.machine.current_mut().elder_state_mut()
     }
 
-    /// Returns this node state unwraped: assume state is Node.
-    pub fn node_state_unchecked(&self) -> &crate::states::Node {
-        unwrap!(self.node_state(), "Should be State::Node")
+    /// Returns this node state unwraped: assume state is Elder.
+    pub fn node_state_unchecked(&self) -> &crate::states::Elder {
+        unwrap!(self.node_state(), "Should be State::Elder")
     }
 
     /// Returns whether the current state is `ProvingNode`.

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -74,7 +74,7 @@ const CLIENT_BAN_DURATION: Duration = Duration::from_secs(2 * 60 * 60);
 /// Duration for which clients' IDs we disconnected from are retained.
 const DROPPED_CLIENT_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
 
-pub struct NodeDetails {
+pub struct ElderDetails {
     pub ack_mgr: AckManager,
     pub cache: Box<Cache>,
     pub chain: Chain,
@@ -89,7 +89,7 @@ pub struct NodeDetails {
     pub timer: Timer,
 }
 
-pub struct Node {
+pub struct Elder {
     ack_mgr: AckManager,
     cacheable_user_msg_cache: UserMessageCache,
     crust_service: Service,
@@ -134,7 +134,7 @@ pub struct Node {
     chain: Chain,
 }
 
-impl Node {
+impl Elder {
     pub fn first(
         cache: Box<Cache>,
         crust_service: Service,
@@ -153,7 +153,7 @@ impl Node {
         let chain = Chain::new(min_section_size, public_id, gen_pfx_info.clone());
         let peer_mgr = PeerManager::new(public_id, dev_config.disable_client_rate_limiter);
 
-        let details = NodeDetails {
+        let details = ElderDetails {
             ack_mgr: AckManager::new(),
             cache,
             chain,
@@ -183,19 +183,19 @@ impl Node {
         }
     }
 
-    pub fn from_establishing_node(
-        mut details: NodeDetails,
+    pub fn from_adult(
+        mut details: ElderDetails,
         sec_info: SectionInfo,
         old_pfx: Prefix<XorName>,
         outbox: &mut EventBox,
     ) -> Result<Self, RoutingError> {
         let event_backlog = mem::replace(&mut details.event_backlog, Vec::new());
-        let mut node = Self::new(details, false);
-        node.init(sec_info, old_pfx, event_backlog, outbox)?;
-        Ok(node)
+        let mut elder = Self::new(details, false);
+        elder.init(sec_info, old_pfx, event_backlog, outbox)?;
+        Ok(elder)
     }
 
-    fn new(details: NodeDetails, is_first_node: bool) -> Self {
+    fn new(details: ElderDetails, is_first_node: bool) -> Self {
         let dev_config = config_handler::get_config().dev.unwrap_or_default();
 
         let timer = details.timer;
@@ -1812,7 +1812,7 @@ impl Node {
     }
 }
 
-impl Base for Node {
+impl Base for Elder {
     fn crust_service(&self) -> &Service {
         &self.crust_service
     }
@@ -2160,7 +2160,7 @@ impl Base for Node {
 }
 
 #[cfg(feature = "mock_base")]
-impl Node {
+impl Elder {
     pub fn chain(&self) -> &Chain {
         &self.chain
     }
@@ -2197,7 +2197,7 @@ impl Node {
     }
 }
 
-impl Bootstrapped for Node {
+impl Bootstrapped for Elder {
     fn ack_mgr(&self) -> &AckManager {
         &self.ack_mgr
     }
@@ -2298,7 +2298,7 @@ impl Bootstrapped for Node {
     }
 }
 
-impl Relocated for Node {
+impl Relocated for Elder {
     fn peer_mgr(&self) -> &PeerManager {
         &self.peer_mgr
     }
@@ -2332,7 +2332,7 @@ impl Relocated for Node {
     }
 }
 
-impl Approved for Node {
+impl Approved for Elder {
     fn parsec_map_mut(&mut self) -> &mut ParsecMap {
         &mut self.parsec_map
     }
@@ -2498,9 +2498,9 @@ impl Approved for Node {
     }
 }
 
-impl Display for Node {
+impl Display for Elder {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "Node({}({:b}))", self.name(), self.our_prefix())
+        write!(formatter, "Elder({}({:b}))", self.name(), self.our_prefix())
     }
 }
 

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -6,19 +6,19 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+mod adult;
 mod bootstrapping_peer;
 mod client;
 pub mod common;
-mod establishing_node;
-mod node;
+mod elder;
 mod proving_node;
 mod relocating_node;
 
 pub use self::{
+    adult::Adult,
     bootstrapping_peer::{BootstrappingPeer, TargetState},
     client::{Client, RATE_EXCEED_RETRY},
-    establishing_node::EstablishingNode,
-    node::Node,
+    elder::Elder,
     proving_node::ProvingNode,
     relocating_node::RelocatingNode,
 };
@@ -41,15 +41,15 @@ pub use self::{
 //        │                        │
 //        │                        │
 //        │                        ▼
-//        │                      ┌──────────────────┐
-//        │                      │ EstablishingNode │
-//        │                      └──────────────────┘
+//        │                      ┌───────┐
+//        │                      │ Adult │
+//        │                      └───────┘
 //        │                        │
 //        │                        │
 //        ▼                        ▼
-// ┌────────┐                    ┌──────┐
-// │ Client │                    │ Node │
-// └────────┘                    └──────┘
+// ┌────────┐                    ┌───────┐
+// │ Client │                    │ Elder │
+// └────────┘                    └───────┘
 //
 //
 // # Common traits
@@ -57,8 +57,8 @@ pub use self::{
 //                              │   Client
 //                              │   │   RelocatingNode
 //                              │   │   │   ProvingNode
-//                              │   │   │   │   EstablishingNode
-//                              │   │   │   │   │   Node
+//                              │   │   │   │   Adult
+//                              │   │   │   │   │   Elder
 //                              │   │   │   │   │   │
 // Base                         *   *   *   *   *   *
 // Bootstrapped                     *   *   *   *   *

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -7,10 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
+    adult::{Adult, AdultDetails},
     common::{
         proxied, Base, Bootstrapped, BootstrappedNotEstablished, Relocated, RelocatedNotEstablished,
     },
-    establishing_node::{EstablishingNode, EstablishingNodeDetails},
 };
 use crate::{
     ack_manager::AckManager,
@@ -150,7 +150,7 @@ impl ProvingNode {
         gen_pfx_info: GenesisPfxInfo,
         outbox: &mut EventBox,
     ) -> Result<State, RoutingError> {
-        let details = EstablishingNodeDetails {
+        let details = AdultDetails {
             ack_mgr: self.ack_mgr,
             cache: self.cache,
             crust_service: self.crust_service,
@@ -164,7 +164,7 @@ impl ProvingNode {
             timer: self.timer,
         };
 
-        EstablishingNode::from_proving_node(details, outbox).map(State::EstablishingNode)
+        Adult::from_proving_node(details, outbox).map(State::Adult)
     }
 
     fn dispatch_routing_message(
@@ -193,7 +193,7 @@ impl ProvingNode {
             self
         );
 
-        Transition::IntoEstablishingNode { gen_pfx_info }
+        Transition::IntoAdult { gen_pfx_info }
     }
 
     #[cfg(feature = "mock_base")]


### PR DESCRIPTION
This PR is purely a rename to facilitate upcoming changes regarding node-ageing impl spec.