### PR TITLE
clean up timer to vote node is approved

### DIFF
--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -459,7 +459,9 @@ impl PeerManager {
                 ref mut passed_our_challenge,
                 ref res_proof_start,
                 ..
-            } if new_pub_id == pub_id => (challenge, passed_our_challenge, res_proof_start),
+            } if *passed_our_challenge || new_pub_id == pub_id => {
+                (challenge, passed_our_challenge, res_proof_start)
+            }
             _ => return Err(RoutingError::UnknownCandidate),
         };
 

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -446,90 +446,48 @@ impl PeerManager {
     /// elapsed since the candidate was inserted.
     pub fn verify_candidate(
         &mut self,
-        new_pub_id: &PublicId,
+        new_public_id: &PublicId,
         part_index: usize,
         part_count: usize,
         proof_part: Vec<u8>,
         leading_zero_bytes: u64,
-    ) -> Result<Option<(usize, u8, Duration)>, RoutingError> {
-        let (challenge, passed_our_challenge, res_proof_start) = match self.candidate {
-            Candidate::ResourceProof {
-                new_pub_id: ref pub_id,
-                challenge: Some(ref mut challenge),
-                ref mut passed_our_challenge,
-                ref res_proof_start,
-                ..
-            } if *passed_our_challenge || new_pub_id == pub_id => {
-                (challenge, passed_our_challenge, res_proof_start)
-            }
-            _ => return Err(RoutingError::UnknownCandidate),
-        };
+    ) -> Result<(Option<OnlinePayload>, Duration), RoutingError> {
+        let (challenge, passed_our_challenge, res_proof_start, online_payload) =
+            match self.candidate {
+                Candidate::ResourceProof {
+                    ref old_pub_id,
+                    ref new_pub_id,
+                    ref new_client_auth,
+                    challenge: Some(ref mut challenge),
+                    ref mut passed_our_challenge,
+                    ref res_proof_start,
+                    ..
+                } if !*passed_our_challenge && new_public_id == new_pub_id => (
+                    challenge,
+                    passed_our_challenge,
+                    res_proof_start,
+                    OnlinePayload {
+                        new_public_id: *new_pub_id,
+                        client_auth: *new_client_auth,
+                        old_public_id: *old_pub_id,
+                    },
+                ),
+                _ => return Err(RoutingError::UnknownCandidate),
+            };
 
         challenge.proof.extend(proof_part);
         if part_index + 1 != part_count {
-            return Ok(None);
+            return Ok((None, res_proof_start.elapsed()));
         }
         let rp_object = ResourceProof::new(challenge.target_size, challenge.difficulty);
         if rp_object.validate_all(&challenge.seed, &challenge.proof, leading_zero_bytes) {
+            // Only succeed once:
             *passed_our_challenge = true;
-            Ok(Some((
-                challenge.target_size,
-                challenge.difficulty,
-                res_proof_start.elapsed(),
-            )))
+
+            Ok((Some(online_payload), res_proof_start.elapsed()))
         } else {
             Err(RoutingError::FailedResourceProofValidation)
         }
-    }
-
-    /// Returns a tuple completed using the verified candidate's details.
-    pub fn verified_candidate_info(
-        &self,
-        log_ident: &LogIdent,
-    ) -> Result<OnlinePayload, RoutingError> {
-        let (new_pub_id, new_client_auth, old_pub_id) = match self.candidate {
-            Candidate::ResourceProof {
-                ref new_pub_id,
-                ref new_client_auth,
-                ref old_pub_id,
-                passed_our_challenge: true,
-                ..
-            } => (new_pub_id, new_client_auth, old_pub_id),
-            Candidate::ResourceProof {
-                ref new_pub_id,
-                passed_our_challenge: false,
-                ..
-            } => {
-                info!(
-                    "{} Candidate {} has not passed our resource proof challenge in time. Not \
-                     sending approval vote to our section.",
-                    log_ident,
-                    new_pub_id.name()
-                );
-                return Err(RoutingError::UnknownCandidate);
-            }
-            Candidate::None
-            | Candidate::AcceptedForResourceProof { .. }
-            | Candidate::ApprovedWaitingSectionInfo { .. } => {
-                return Err(RoutingError::UnknownCandidate)
-            }
-        };
-
-        if !self.is_connected(new_pub_id) {
-            log_or_panic!(
-                LogLevel::Error,
-                "{} Not connected to {}.",
-                log_ident,
-                new_pub_id.name()
-            );
-            return Err(RoutingError::UnknownCandidate);
-        }
-
-        Ok(OnlinePayload {
-            new_public_id: *new_pub_id,
-            client_auth: *new_client_auth,
-            old_public_id: *old_pub_id,
-        })
     }
 
     /// Handles accumulated candidate approval. Marks the candidate as `Approved`.

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -30,7 +30,6 @@ use crate::{
     parsec::{self, ParsecMap},
     peer_manager::{Peer, PeerManager, PeerState},
     rate_limiter::RateLimiter,
-    resource_prover::RESOURCE_PROOF_DURATION,
     routing_message_filter::{FilteringResult, RoutingMessageFilter},
     routing_table::Error as RoutingTableError,
     routing_table::{Authority, Prefix, Xorable, DEFAULT_PREFIX},
@@ -110,8 +109,6 @@ pub struct Elder {
     next_relocation_dst: Option<XorName>,
     /// Interval used for relocation in mock crust tests.
     next_relocation_interval: Option<(XorName, XorName)>,
-    /// The timer token for accepting a new candidate.
-    candidate_timer_token: Option<u64>,
     /// The timer token for displaying the current candidate status.
     candidate_status_token: u64,
     /// Limits the rate at which clients can pass messages through this node when it acts as their
@@ -221,7 +218,6 @@ impl Elder {
             user_msg_cache: UserMessageCache::with_expiry_duration(USER_MSG_CACHE_EXPIRY_DURATION),
             next_relocation_dst: None,
             next_relocation_interval: None,
-            candidate_timer_token: None,
             candidate_status_token,
             clients_rate_limiter: RateLimiter::new(dev_config.disable_client_rate_limiter),
             banned_client_ips: LruCache::with_expiry_duration(CLIENT_BAN_DURATION),
@@ -829,14 +825,6 @@ impl Elder {
         proof: Vec<u8>,
         leading_zero_bytes: u64,
     ) {
-        if self.candidate_timer_token.is_none() {
-            debug!(
-                "{} Won't handle resource proof response from {:?} - not currently waiting.",
-                self, pub_id
-            );
-            return;
-        }
-
         match self.peer_mgr.verify_candidate(
             &pub_id,
             part_index,
@@ -853,10 +841,7 @@ impl Elder {
             Ok(None) => {
                 self.send_direct_message(pub_id, DirectMessage::ResourceProofResponseReceipt);
             }
-            Ok(Some((target_size, difficulty, elapsed)))
-                if difficulty == 0 && target_size < 1000 =>
-            {
-                // Small tests don't require waiting for synchronisation. Send approval now.
+            Ok(Some((_, _, elapsed))) => {
                 info!(
                     "{} Candidate {} passed our challenge in {}. Sending approval \
                      to our section with {:?}.",
@@ -865,20 +850,7 @@ impl Elder {
                     elapsed.display_secs(),
                     self.our_prefix()
                 );
-                // We set the timer token to None so we do not send another
-                // CandidateApproval when the token fires
-                self.candidate_timer_token = None;
                 self.send_candidate_approval();
-            }
-            Ok(Some((_, _, elapsed))) => {
-                info!(
-                    "{} Candidate {} passed our challenge in {}. Waiting to send approval to \
-                     our section with {:?}.",
-                    self,
-                    pub_id,
-                    elapsed.display_secs(),
-                    self.our_prefix()
-                );
             }
         }
     }
@@ -1864,9 +1836,6 @@ impl Base for Elder {
             self.proxy_load_amount = 0;
             self.update_peer_states(outbox);
             outbox.send_event(Event::TimerTicked);
-        } else if self.candidate_timer_token == Some(token) {
-            self.candidate_timer_token = None;
-            self.send_candidate_approval();
         } else if self.candidate_status_token == token {
             self.candidate_status_token = self.timer.schedule(CANDIDATE_STATUS_INTERVAL);
             self.peer_mgr.show_candidate_status(&self.log_ident());
@@ -2409,7 +2378,6 @@ impl Approved for Elder {
         }
 
         if let Some(target_interval) = self.accept_candidate_with_interval(&vote) {
-            self.candidate_timer_token = Some(self.timer.schedule(RESOURCE_PROOF_DURATION));
             return self.send_relocate_response(vote, target_interval);
         }
 


### PR DESCRIPTION
candidate_timer_token was used before we moved to Parsec to ensure
the RPC from different elders would be sent at the same time.

This is no longer needed with Parsec: Send it when resource proof is
complete.