### PR TITLE
Resource proofing with lagging elders

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -650,6 +650,13 @@ impl Node {
     pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
         self.machine.current().in_authority(auth)
     }
+
+    /// Sets a counter to be used ignoring certain number of `CandidateInfo`.
+    pub fn set_ignore_candidate_info_counter(&mut self, counter: u8) {
+        let _ = self
+            .node_state_mut()
+            .map(|state| state.set_ignore_candidate_info_counter(counter));
+    }
 }
 
 #[cfg(feature = "mock_base")]

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -129,6 +129,8 @@ pub struct Elder {
     gen_pfx_info: GenesisPfxInfo,
     gossip_timer_token: u64,
     chain: Chain,
+    #[cfg(feature = "mock_base")]
+    ignore_candidate_info_counter: u8,
 }
 
 impl Elder {
@@ -228,6 +230,8 @@ impl Elder {
             gen_pfx_info: details.gen_pfx_info,
             gossip_timer_token,
             chain: details.chain,
+            #[cfg(feature = "mock_base")]
+            ignore_candidate_info_counter: 0,
         }
     }
 
@@ -1057,6 +1061,13 @@ impl Elder {
         new_client_auth: &Authority<XorName>,
         outbox: &mut EventBox,
     ) {
+        #[cfg(feature = "mock_base")]
+        {
+            if self.ignore_candidate_info_counter > 0 {
+                self.ignore_candidate_info_counter -= 1;
+                return;
+            }
+        }
         debug!(
             "{} Handling CandidateInfo from {}->{}.",
             self, old_pub_id, new_pub_id
@@ -2192,6 +2203,10 @@ impl Elder {
 
     pub fn has_resource_proof_candidate(&self) -> bool {
         self.chain.has_resource_proof_candidate()
+    }
+
+    pub fn set_ignore_candidate_info_counter(&mut self, counter: u8) {
+        self.ignore_candidate_info_counter = counter;
     }
 }
 


### PR DESCRIPTION
This PR contains the work of making a joining_node resend ConnectionInfoReq and CandidateInfo to an elder in case of not having connection to it or hasn't started resource proofing with it. Which allows resource proofing to be carried out with lagging elders.
A test is also create to confirm that the update will work as expected.