### PR TITLE
Check for Fixup Commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ before_script:
   - rustup component add rustfmt clippy
 jobs:
   include:
+    - script: scripts/fixup_check
+      name: 'check for fixup/wip commits'
+      os: linux
+      if: type = pull_request
     - script: scripts/clippy --verbose
       os: linux
       env: CACHE_NAME=clippy_linux

--- a/scripts/fixup_check
+++ b/scripts/fixup_check
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+output=$(git log --oneline | grep -iE 'fixup|wip')
+if [[ $? != 1 ]]; then
+    echo "Found fixup or WIP commit(s):"
+    echo "$output"
+    exit 1
+fi


### PR DESCRIPTION
Hi Pierre/Fraser,

This is a bit trivial, but Stephen wanted me to come back to this issue of some protection against fixup commits.

This isn't completely perfect because I don't know how to get the commits just for a particular PR. There is a mechanism for doing that with `git log fleming..branch_name`, but on Travis it only seems to have the current branch in the clone, so if you try to do it that way it errors.

It's also possibly a bit excessive to have this in its own job because that spins up a machine, but I wasn't sure how to specify the 'if PR' conditional without doing that.

[Here](https://travis-ci.com/jacderida/routing/builds/114561421) is an example of the job not triggering on a PR. [Here](https://travis-ci.com/maidsafe/routing/builds/114561425) is an example of it failing a build, ironically because my commit message contained the text 'fixup' (I've now squashed and changed the commit message).

Cheers,

Chris