### PR TITLE
Remove all verification logic from hops

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -30,7 +30,7 @@ use itertools::Itertools;
 use lru_time_cache::LruCache;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use safe_crypto;
-use safe_crypto::{PublicSignKey, SecretSignKey, Signature};
+use safe_crypto::{SecretSignKey, Signature};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::result::Result as StdResult;
@@ -186,19 +186,6 @@ impl HopMessage {
             sent_to: sent_to,
             signature: signing_key.sign_detached(&bytes_to_sign),
         })
-    }
-
-    /// Validate that the message is signed by `verification_key` contained in message.
-    ///
-    /// This does not imply that the message came from a known node. That requires a check against
-    /// the routing table to identify the name associated with the `verification_key`.
-    pub fn verify(&self, verification_key: &PublicSignKey) -> Result<()> {
-        let signed_bytes = serialise(HopMessage::content_to_serialise(&self.content))?;
-        if verification_key.verify_detached(&self.signature, &signed_bytes) {
-            Ok(())
-        } else {
-            Err(RoutingError::FailedSignature)
-        }
     }
 
     #[cfg(not(feature = "mock_serialise"))]
@@ -942,8 +929,7 @@ mod tests {
     use maidsafe_utilities::serialisation::serialise;
     use rand;
     use safe_crypto;
-    use safe_crypto::{gen_sign_keypair, SIGNATURE_BYTES};
-    use std::collections::BTreeSet;
+    use safe_crypto::SIGNATURE_BYTES;
     use std::iter;
 
     #[test]
@@ -1071,38 +1057,6 @@ mod tests {
         assert!(!signed_msg
             .signatures
             .contains_id(irrelevant_full_id.public_id(),));
-    }
-
-    #[test]
-    fn hop_message_verify() {
-        let name: XorName = rand::random();
-        let routing_message = RoutingMessage {
-            src: Authority::ClientManager(name),
-            dst: Authority::ClientManager(name),
-            content: MessageContent::Relocate {
-                message_id: MessageId::new(),
-            },
-        };
-        let full_id = FullId::new();
-        let signed_message_result = SignedMessage::new(routing_message.clone(), &full_id, None);
-        let signed_message = unwrap!(signed_message_result);
-
-        let (public_signing_key, secret_signing_key) = gen_sign_keypair();
-        let hop_message_result = HopMessage::new(
-            signed_message.clone(),
-            0,
-            BTreeSet::new(),
-            &secret_signing_key,
-        );
-
-        let hop_message = unwrap!(hop_message_result);
-
-        assert_eq!(signed_message, hop_message.content);
-
-        assert!(hop_message.verify(&public_signing_key).is_ok());
-
-        let (public_signing_key, _) = gen_sign_keypair();
-        assert!(hop_message.verify(&public_signing_key).is_err());
     }
 
     #[test]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -166,8 +166,6 @@ pub struct HopMessage {
     pub route: u8,
     /// Every node this has already been sent to.
     pub sent_to: BTreeSet<XorName>,
-    /// Signature to be validated against the neighbouring sender's public key.
-    signature: Signature,
 }
 
 impl HopMessage {
@@ -177,20 +175,12 @@ impl HopMessage {
         content: SignedMessage,
         route: u8,
         sent_to: BTreeSet<XorName>,
-        signing_key: &SecretSignKey,
     ) -> Result<HopMessage> {
-        let bytes_to_sign = serialise(HopMessage::content_to_serialise(&content))?;
         Ok(HopMessage {
             content: content,
             route: route,
             sent_to: sent_to,
-            signature: signing_key.sign_detached(&bytes_to_sign),
         })
-    }
-
-    #[cfg(not(feature = "mock_serialise"))]
-    fn content_to_serialise(content: &SignedMessage) -> &SignedMessage {
-        content
     }
 
     #[cfg(feature = "mock_serialise")]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -182,11 +182,6 @@ impl HopMessage {
             sent_to: sent_to,
         })
     }
-
-    #[cfg(feature = "mock_serialise")]
-    fn content_to_serialise(_content: &SignedMessage) -> &[u8; 18] {
-        b"HopMessage.content"
-    }
 }
 
 /// Wrapper around a routing message, signed by the originator of the message.

--- a/src/mock/crust/support.rs
+++ b/src/mock/crust/support.rs
@@ -849,9 +849,8 @@ fn test_is_parsec_req_resp() {
     };
     let sig_msg =
         SignedMessage::new(rt_msg, &full_id, None).expect("failed to create signed message");
-    let key = full_id.signing_private_key();
     let hop_msg =
-        HopMessage::new(sig_msg, 1, Default::default(), key).expect("failed to create hop message");
+        HopMessage::new(sig_msg, 1, Default::default()).expect("failed to create hop message");
     let msg = Message::Hop(hop_msg);
     assert!(!Packet::<PublicId>::Message(ser(&msg)).is_parsec_req_resp());
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -266,7 +266,7 @@ impl Base for Adult {
             _ => return Err(RoutingError::UnknownConnection(pub_id)),
         }
 
-        if let Some(routing_msg) = self.filter_hop_message(hop_msg, pub_id)? {
+        if let Some(routing_msg) = self.filter_hop_message(hop_msg)? {
             self.dispatch_routing_message(routing_msg, outbox)
         } else {
             Ok(Transition::Stay)

--- a/src/states/client.rs
+++ b/src/states/client.rs
@@ -267,7 +267,7 @@ impl Base for Client {
             return Err(RoutingError::UnknownConnection(pub_id));
         }
 
-        if let Some(routing_msg) = self.filter_hop_message(hop_msg, pub_id)? {
+        if let Some(routing_msg) = self.filter_hop_message(hop_msg)? {
             Ok(self.dispatch_routing_message(routing_msg, outbox))
         } else {
             Ok(Transition::Stay)

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -310,12 +310,7 @@ pub trait Base: Display {
         route: u8,
         sent_to: BTreeSet<XorName>,
     ) -> Result<CrustBytes, RoutingError> {
-        let hop_msg = HopMessage::new(
-            signed_msg,
-            route,
-            sent_to,
-            self.full_id().signing_private_key(),
-        )?;
+        let hop_msg = HopMessage::new(signed_msg, route, sent_to)?;
         let message = Message::Hop(hop_msg);
         Ok(to_crust_bytes(message).map_err(|(err, _)| err)?)
     }

--- a/src/states/common/bootstrapped_not_established.rs
+++ b/src/states/common/bootstrapped_not_established.rs
@@ -28,13 +28,8 @@ pub trait BootstrappedNotEstablished: Bootstrapped {
     fn filter_hop_message(
         &mut self,
         hop_msg: HopMessage,
-        pub_id: PublicId,
     ) -> Result<Option<RoutingMessage>, RoutingError> {
-        hop_msg.verify(pub_id.signing_public_key())?;
-
         let signed_msg = hop_msg.content;
-        signed_msg.check_integrity(self.min_section_size())?;
-
         let routing_msg = signed_msg.into_routing_message();
         let in_authority = self.in_authority(&routing_msg.dst);
         if in_authority && Self::SEND_ACK {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -561,20 +561,7 @@ impl Elder {
                 return Err(RoutingError::InvalidProvingSection);
             }
         } else {
-            // Remove any untrusted trailing section infos.
-            // TODO: remove wasted clone. Only useful when msg isnt trusted for log msg.
-            let msg_clone = signed_msg.clone();
-            while match signed_msg.previous_hop() {
-                None => true,
-                Some(hop) => !self.is_trusted(hop)?,
-            } {
-                // We don't know the last hop! Try the one before that.
-                if !signed_msg.pop_previous_hop() {
-                    debug!("{} Untrusted message: {:?}", self, msg_clone);
-                    return Err(RoutingError::NotEnoughSignatures);
-                }
-            }
-            // Now that we validated the sections, inform our peers about any new ones.
+            // Inform our peers about any new sections.
             if signed_msg
                 .section_infos()
                 .any(|si| self.chain.is_new_neighbour(si))

--- a/src/states/proving_node.rs
+++ b/src/states/proving_node.rs
@@ -406,7 +406,7 @@ impl Base for ProvingNode {
             _ => return Err(RoutingError::UnknownConnection(pub_id)),
         }
 
-        if let Some(routing_msg) = self.filter_hop_message(hop_msg, pub_id)? {
+        if let Some(routing_msg) = self.filter_hop_message(hop_msg)? {
             self.dispatch_routing_message(routing_msg, outbox)
         } else {
             Ok(Transition::Stay)

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -304,7 +304,7 @@ impl Base for RelocatingNode {
             return Err(RoutingError::UnknownConnection(pub_id));
         }
 
-        if let Some(routing_msg) = self.filter_hop_message(hop_msg, pub_id)? {
+        if let Some(routing_msg) = self.filter_hop_message(hop_msg)? {
             Ok(self.dispatch_routing_message(routing_msg))
         } else {
             Ok(Transition::Stay)


### PR DESCRIPTION
With secure message relay, we used to verify each hop message to avoid
transmitting spammy messages to the rest of the network.
This pattern is going away with the introduction of Reliable Message
Delivery where we ensure that any message passed to us will be
transmitted.
The logic to ensure message validity will only happen at destination
once Secure Message Delivery is introduced.

Fixes #1661