### PR TITLE
Remove UserMessage chunking

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::routing_table::Error as RoutingTableError;
-use crate::{action::Action, event::Event, id::PublicId, quic_p2p, sha3::Digest256};
+use crate::{action::Action, event::Event, id::PublicId, quic_p2p, types::MessageId};
 use config_file_handler::Error as ConfigFileHandlerError;
 use crossbeam_channel as mpmc;
 use maidsafe_utilities::serialisation;
@@ -134,9 +134,9 @@ pub enum RoutingError {
     InvalidMessage,
     /// Invalid Peer
     InvalidPeer,
-    /// The client's message indicated by the included hash digest has been rejected by the
+    /// The client's message indicated by the included message id has been rejected by the
     /// rate-limiter.
-    ExceedsRateLimit(Digest256),
+    ExceedsRateLimit(MessageId),
     /// Invalid configuration
     ConfigError(ConfigFileHandlerError),
     /// Invalid chain

--- a/src/resource_prover.rs
+++ b/src/resource_prover.rs
@@ -10,7 +10,7 @@ use crate::{
     action::Action,
     event::Event,
     id::PublicId,
-    messages::{DirectMessage, MAX_PART_LEN},
+    messages::DirectMessage,
     outbox::EventBox,
     signature_accumulator::ACCUMULATION_TIMEOUT,
     state_machine::Transition,
@@ -41,6 +41,9 @@ const APPROVAL_TIMEOUT: Duration =
     Duration::from_secs(RESOURCE_PROOF_DURATION.as_secs() + 2 * ACCUMULATION_TIMEOUT.as_secs());
 /// Interval between displaying info about ongoing approval progress, in seconds.
 const APPROVAL_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
+
+// Maximum size in bytes of the proof data contained in one `ResourceProofResponse` message.
+const MAX_PROOF_DATA_PART_SIZE: usize = 20 * 1024;
 
 /// Handles resource proofs
 pub struct ResourceProver {
@@ -126,7 +129,7 @@ impl ResourceProver {
 
             let parts = proof_data
                 .into_iter()
-                .chunks(MAX_PART_LEN)
+                .chunks(MAX_PROOF_DATA_PART_SIZE)
                 .into_iter()
                 .map(Iterator::collect)
                 .collect_vec();

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -22,6 +22,3 @@ pub use self::{
     relocated::Relocated,
     relocated_not_established::RelocatedNotEstablished,
 };
-use crate::time::Duration;
-
-pub const USER_MSG_CACHE_EXPIRY_DURATION: Duration = Duration::from_secs(120);

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -129,7 +129,7 @@ impl RelocatingNode {
             | NeighbourInfo(..)
             | NeighbourConfirm(..)
             | Merge(..)
-            | UserMessagePart { .. }
+            | UserMessage { .. }
             | NodeApproval { .. } => {
                 warn!(
                     "{} Not joined yet. Not handling {:?} from {:?} to {:?}",


### PR DESCRIPTION
Replace `MessageContent::UserMessagePart` with `MessageContent::UserMessage` which contains the whole message. Remove all the logic around splitting the message into parts and reassembling it back.

This is possible to do because quic-p2p internally re-prioritizes the messages based on size, so big messages no longer block the small ones and so it's no longer necessary to chunk them.

Closes #1695 