### PR TITLE
Print rng seed before tests start

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ build_script:
   - cargo check --verbose --release --lib --tests
 
 test_script:
-  - cargo test --verbose --release --features=mock_parsec
+  - cargo test --verbose --release --features=mock -- --nocapture

--- a/scripts/tests
+++ b/scripts/tests
@@ -2,7 +2,4 @@
 
 set -x -e
 export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
-DIR=`dirname "$0"`
-
-cargo test $@ --release --features=mock_parsec -- --skip aggressive_churn
-$DIR/travis_wait -l 1800 "cargo test $@ --release --features=mock_parsec aggressive_churn"
+cargo test $@ --release --features=mock -- --nocapture

--- a/src/mock/quic_p2p/network.rs
+++ b/src/mock/quic_p2p/network.rs
@@ -19,11 +19,14 @@ use std::{
     collections::{hash_map::Entry, VecDeque},
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     rc::{Rc, Weak},
+    sync::Once,
 };
 use unwrap::unwrap;
 
 const IP_BASE: Ipv4Addr = Ipv4Addr::LOCALHOST;
 const PORT: u16 = 9999;
+
+static PRINT_SEED: Once = Once::new();
 
 /// Handle to the mock network. Create one before testing with mocks. Call `set_next_node_addr` or
 /// `gen_next_node_addr` before creating a `QuicP2p` instance.
@@ -39,6 +42,8 @@ impl Network {
         } else {
             SeededRng::new()
         };
+
+        PRINT_SEED.call_once(|| println!("{:?}", rng));
 
         unwrap!(safe_crypto::init_with_rng(&mut rng));
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -465,7 +465,7 @@ pub fn create_connected_nodes_with_cache(network: &Network, size: usize, use_cac
             .create(),
     );
     let _ = nodes[0].poll();
-    println!("Seed node: {}", nodes[0].inner);
+    info!("Seed node: {}", nodes[0].inner);
 
     // Create other nodes using the seed node endpoint as bootstrap contact.
     for _ in 1..size {


### PR DESCRIPTION
So we still get the seed in case the tests get stuck.

Also modify the CI scripts to run tests with --features=mock instead of --features=mock_parsec to speed them up.