### PR TITLE
fix/mock: catch up with the change in quic-p2p

### DIFF
--- a/src/mock/quic_p2p/mod.rs
+++ b/src/mock/quic_p2p/mod.rs
@@ -195,6 +195,8 @@ pub enum Event {
     ConnectionFailure {
         /// Address of the peer we attempted connecting to.
         peer_addr: SocketAddr,
+        /// Error explaining connection failure.
+        err: Error,
     },
     /// Message sent by us but not delivered due to connection drop.
     UnsentUserMessage {

--- a/src/mock/quic_p2p/node.rs
+++ b/src/mock/quic_p2p/node.rs
@@ -189,7 +189,10 @@ impl Node {
             }),
             Packet::Disconnect => {
                 if self.peers.remove(&src).is_some() {
-                    self.fire_event(Event::ConnectionFailure { peer_addr: src })
+                    self.fire_event(Event::ConnectionFailure {
+                        peer_addr: src,
+                        err: Error,
+                    })
                 }
             }
         }

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -579,7 +579,7 @@ impl Agent {
     fn expect_connection_failure(&self, addr: &SocketAddr) {
         let actual_addr = assert_match!(
             self.rx.try_recv(),
-            Ok(Event::ConnectionFailure { peer_addr }) => peer_addr
+            Ok(Event::ConnectionFailure { peer_addr, .. }) => peer_addr
         );
         assert_eq!(actual_addr, *addr);
     }

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -143,7 +143,9 @@ pub trait Base: Display {
             BootstrappedTo { node } => self.handle_bootstrapped_to(node),
             BootstrapFailure => self.handle_bootstrap_failure(outbox),
             ConnectedTo { peer } => self.handle_connected_to(peer, outbox),
-            ConnectionFailure { peer_addr } => self.handle_connection_failure(peer_addr, outbox),
+            ConnectionFailure { peer_addr, .. } => {
+                self.handle_connection_failure(peer_addr, outbox)
+            }
             NewMessage { peer_addr, msg } => self.handle_new_message(peer_addr, msg, outbox),
             UnsentUserMessage { .. } => {
                 // TODO (quic-p2p): handle unsent messages


### PR DESCRIPTION
This PR contains the change to resolve a clippy error due to the change in quic-p2p crate.