### PR TITLE
fix performance issue following PR 1705

### DIFF
--- a/src/chain/test_utils.rs
+++ b/src/chain/test_utils.rs
@@ -65,9 +65,11 @@ fn verify_single_chain(chain: &Chain, min_section_size: usize) {
         .find(|info| info.members().len() < min_section_size)
     {
         panic!(
-            "A section is below the minimum size: size({:?}) = {}",
+            "A section is below the minimum size: size({:?}) = {}; For ({:?}: {:?})",
             info.prefix(),
-            info.members().len()
+            info.members().len(),
+            chain.our_id(),
+            chain.our_info().prefix(),
         );
     }
 

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -323,12 +323,13 @@ pub trait Base: Display {
 
         if conn_infos.len() < dg_size {
             warn!(
-                "{} Less than dg_size valid targets! dg_size = {}; targets = {:?}",
+                "{} Less than dg_size valid targets! dg_size = {}; targets = {:?}; msg = {:?}",
                 self,
                 dg_size,
                 dst_targets
                     .iter()
-                    .filter(|pub_id| self.peer_map().get_connection_info(pub_id).is_some())
+                    .filter(|pub_id| self.peer_map().get_connection_info(pub_id).is_some()),
+                message
             );
         }
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -2147,9 +2147,16 @@ impl Approved for Elder {
                 trusted = Some(ps);
             }
         }
-        if validates(&trusted, &sec_info) || self.is_trusted(&sec_info)? {
-            let _ = self.add_new_section(&sec_info);
+        if !(validates(&trusted, &sec_info) || self.is_trusted(&sec_info)?) {
+            trace!(
+                "{} Adding untrusted neighbour section info {:?}",
+                self,
+                &sec_info
+            );
         }
+        // Always add section info until SMD is complete
+        // TODO: Fix for SMD.
+        let _ = self.add_new_section(&sec_info);
         Ok(())
     }
 }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1337,17 +1337,6 @@ impl Elder {
     ) -> Result<(), RoutingError> {
         let dst = signed_msg.routing_message().dst;
 
-        // TODO: Figure out when failure is expected, and in which cases we should still handle the
-        // message anyway.
-        if let Err(err) = self.chain.extend_proving_sections(signed_msg) {
-            debug!(
-                "{} Failed to add section infos to message {:?}: {:?}",
-                self,
-                signed_msg.routing_message(),
-                err
-            );
-        }
-
         if let Authority::Client { ref client_id, .. } = dst {
             if *self.name() == dst.name() {
                 // This is a message for a client we are the proxy of. Relay it.


### PR DESCRIPTION
Closes #1684

Because of additional messages sent, soak test experienced a performance hit.
Remove main bottle neck for performance that came from previous way of establishing trust that is disabled currently and will be replace by Secure Message Delivery.