### PR TITLE
perf/quic_p2p: avoid many serialization on send/use Rc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ use quic_p2p;
 #[cfg(not(feature = "mock_serialise"))]
 pub(crate) type NetworkBytes = bytes::Bytes;
 #[cfg(feature = "mock_serialise")]
-pub(crate) type NetworkBytes = Box<crate::messages::Message>;
+pub(crate) type NetworkBytes = std::rc::Rc<crate::messages::Message>;
 
 pub(crate) use self::network_service::NetworkService;
 pub use self::quic_p2p::Config as NetworkConfig;

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -703,7 +703,7 @@ fn gen_message() -> NetworkBytes {
         // that carries some data.
         let content = DirectMessage::ParsecPoke(num as u64);
         let message = unwrap!(SignedDirectMessage::new(content, &*FULL_ID));
-        Box::new(Message::Direct(message))
+        NetworkBytes::new(Message::Direct(message))
     }
 
     #[cfg(not(feature = "mock_serialise"))]

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -167,8 +167,9 @@ impl BootstrappingPeer {
                 return;
             };
 
-        let next_id = self.network_service.next_msg_token();
-        self.send_message_over_network(Peer::Node { node_info: dst }, &message, next_id);
+        let conn_infos = vec![Peer::Node { node_info: dst }];
+        let dg_size = 1;
+        self.send_message_to_initial_targets(conn_infos, dg_size, message);
     }
 
     fn rebootstrap(&mut self) {


### PR DESCRIPTION
Spandan higlighted that Bytes is a reference counted type.
This clarified that we were being inefficient in memory and CPU when
sending 3 messages.

quic_p2p take in a Bytes type that is a reference counted type:
 - Refactor to do cheap operation multiple time (Rc clone) instead of
   expansive operation (serialize + allocate memory for message 3 times).
 - Refactor mock_serialize to follow the same pattern.

Ensure all messages go through the same resend process and hide the
token implementation detail.