### PR TITLE
Secure Message Delivery initial changes

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -9,7 +9,10 @@
 //! Types emulating the BLS functionality until proper BLS lands
 use super::SectionInfo;
 use crate::id::{FullId, PublicId};
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct PublicKeySet {
@@ -99,5 +102,11 @@ impl PublicKey {
             })
             .count()
             > self.0.threshold
+    }
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "BLS-PublicKey({:?})", self.0.sec_info)
     }
 }

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -1,0 +1,103 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Types emulating the BLS functionality until proper BLS lands
+use super::SectionInfo;
+use crate::id::{FullId, PublicId};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PublicKeySet {
+    keys: BTreeSet<PublicId>,
+    threshold: usize,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PublicKey(PublicKeySet);
+
+pub type SignatureShare = ::safe_crypto::Signature;
+
+pub struct SecretKeyShare(FullId);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PublicKeyShare(PublicId);
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Signature {
+    sigs: BTreeMap<PublicId, SignatureShare>,
+}
+
+impl SecretKeyShare {
+    #[allow(unused)]
+    pub fn public_key_share(&self) -> PublicKeyShare {
+        PublicKeyShare(*self.0.public_id())
+    }
+
+    #[allow(unused)]
+    pub fn sign<M: AsRef<[u8]>>(&self, message: M) -> SignatureShare {
+        self.0.signing_private_key().sign_detached(message.as_ref())
+    }
+}
+
+impl PublicKeyShare {
+    #[allow(unused)]
+    pub fn verify<M: AsRef<[u8]>>(&self, sig: &SignatureShare, msg: M) -> bool {
+        self.0
+            .signing_public_key()
+            .verify_detached(sig, msg.as_ref())
+    }
+}
+
+impl PublicKeySet {
+    #[allow(unused)]
+    pub fn threshold(&self) -> usize {
+        self.threshold
+    }
+
+    #[allow(unused)]
+    pub fn combine_signatures<'a, I>(&self, shares: I) -> Option<Signature>
+    where
+        I: IntoIterator<Item = (PublicKeyShare, &'a SignatureShare)>,
+    {
+        let sigs: BTreeMap<_, _> = shares
+            .into_iter()
+            .map(|(pk, ss)| (pk.0, *ss))
+            .collect();
+        // In the BLS scheme, more than `threshold` valid signatures are needed to obtain a
+        // combined signature - copy this behaviour
+        if sigs.len() <= self.threshold {
+            None
+        } else {
+            Some(Signature { sigs })
+        }
+    }
+
+    #[allow(unused)]
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.clone())
+    }
+}
+
+impl PublicKey {
+    pub fn from_section_info(sec_info: &SectionInfo) -> Self {
+        let keys = sec_info.members().clone();
+        let threshold = (keys.len() + 2) / 3;
+        PublicKey(PublicKeySet { keys, threshold })
+    }
+
+    #[allow(unused)]
+    pub fn verify<M: AsRef<[u8]>>(&self, sig: &Signature, msg: M) -> bool {
+        sig.sigs
+            .iter()
+            .filter(|&(pk, ss)| {
+                self.0.keys.contains(pk) && PublicKeyShare(*pk).verify(ss, msg.as_ref())
+            })
+            .count()
+            > self.0.threshold
+    }
+}

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1355,6 +1355,13 @@ impl Chain {
 }
 
 #[cfg(test)]
+impl Chain {
+    pub fn validate_our_history(&self) -> bool {
+        self.state.our_history.validate()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::super::{GenesisPfxInfo, Proof, ProofSet, SectionInfo};
     use super::Chain;
@@ -1517,6 +1524,7 @@ mod tests {
             full_ids.extend(new_ids);
             let proofs = gen_proofs(&full_ids, chain.our_info().members(), &new_info);
             unwrap!(chain.add_section_info(new_info, proofs));
+            assert!(chain.validate_our_history());
             check_infos_for_duplication(&chain);
         }
     }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -8,7 +8,7 @@
 
 use super::{
     candidate::Candidate,
-    shared_state::{PrefixChange, SharedState},
+    shared_state::{PrefixChange, SectionProofBlock, SharedState},
     GenesisPfxInfo, NeighbourSigs, NetworkEvent, OnlinePayload, Proof, ProofSet, ProvingSection,
     SectionInfo,
 };
@@ -775,6 +775,12 @@ impl Chain {
     ) -> Result<(), RoutingError> {
         let pfx = *sec_info.prefix();
         if pfx.matches(self.our_id.name()) {
+            self.state
+                .our_history
+                .push(SectionProofBlock::from_sec_info_with_proofs(
+                    &sec_info,
+                    proofs.clone(),
+                ));
             self.state.our_infos.push((sec_info.clone(), proofs));
             if !self.is_member && sec_info.members().contains(&self.our_id) {
                 self.is_member = true;

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 // The `chain` submodule contains the `Chain` implementation, which we reexport here.
+pub(crate) mod bls_emu;
 mod candidate;
 #[allow(clippy::module_inception)]
 mod chain;

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -243,7 +243,6 @@ impl SectionProofBlock {
         SectionProofBlock { key, sig }
     }
 
-    #[allow(unused)]
     pub fn verify_with_pk(&self, pk: &BlsPublicKey) -> bool {
         let to_verify = self.key.as_event();
         match serialisation::serialise(&to_verify) {
@@ -269,6 +268,18 @@ impl SectionProofChain {
 
     pub fn push(&mut self, block: SectionProofBlock) {
         self.blocks.push(block);
+    }
+
+    #[allow(unused)]
+    pub fn validate(&self) -> bool {
+        let mut current_pk = &self.genesis_pk;
+        for block in &self.blocks {
+            if !block.verify_with_pk(current_pk) {
+                return false;
+            }
+            current_pk = &block.key;
+        }
+        true
     }
 }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -10,7 +10,7 @@ use super::{ProofSet, ProvingSection, SectionInfo};
 use crate::{error::RoutingError, sha3::Digest256, BlsPublicKey, BlsSignature, Prefix, XorName};
 use itertools::Itertools;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     fmt::{self, Debug, Formatter},
     iter, mem,
 };
@@ -33,6 +33,8 @@ pub struct SharedState {
     pub merging: BTreeSet<Digest256>,
     /// Our section's key history for Secure Message Delivery
     pub our_history: SectionProofChain,
+    /// BLS public keys of other sections
+    pub their_keys: HashMap<Prefix<XorName>, BlsPublicKey>,
 }
 
 impl SharedState {
@@ -46,6 +48,7 @@ impl SharedState {
             split_cache: None,
             merging: Default::default(),
             our_history,
+            their_keys: Default::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,9 +256,12 @@ pub(crate) type NetworkBytes = bytes::Bytes;
 #[cfg(feature = "mock_serialise")]
 pub(crate) type NetworkBytes = std::rc::Rc<crate::messages::Message>;
 
-pub(crate) use self::network_service::NetworkService;
 pub use self::quic_p2p::Config as NetworkConfig;
-pub(crate) use self::quic_p2p::{Event as NetworkEvent, Peer as ConnectionInfo, QuicP2p};
+pub(crate) use self::{
+    chain::bls_emu::{PublicKey as BlsPublicKey, Signature as BlsSignature},
+    network_service::NetworkService,
+    quic_p2p::{Event as NetworkEvent, Peer as ConnectionInfo, QuicP2p},
+};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR makes some initial changes related to SMD:
- Add a BLS emulation layer in order to enable writing code that pretends to use BLS before BLS is merged in
- Add `our_history` and `their_keys` to the shared state
- Update `our_history` together with `our_infos`

Closes #1672
Closes #1673
Closes #1674 
Closes #1675 