### PR TITLE
WIP/FIRST DRAFT: Update shared state on genesis

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -130,6 +130,10 @@ impl PublicKey {
     pub fn as_event(&self) -> parsec::Observation<NetworkEvent, PublicId> {
         parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(self.0.sec_info.clone()))
     }
+
+    pub fn version(&self) -> &u64 {
+        self.0.sec_info.version()
+    }
 }
 
 impl fmt::Debug for PublicKey {

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -15,13 +15,13 @@ use std::{
     fmt,
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicKeySet {
     sec_info: SectionInfo,
     threshold: usize,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicKey(PublicKeySet);
 
 pub type SignatureShare = ::safe_crypto::Signature;
@@ -31,7 +31,7 @@ pub struct SecretKeyShare(FullId);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PublicKeyShare(PublicId);
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Signature {
     sigs: BTreeMap<PublicId, SignatureShare>,
 }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -244,6 +244,16 @@ impl Chain {
 
         match event {
             NetworkEvent::SectionInfo(ref sec_info) => {
+                info!("chain::poll1: {:?}, sec_info.prefix(): {:?}, matches: {}",
+                    self.our_id(), sec_info.prefix(), sec_info.prefix().matches(self.our_id.name()));
+
+                info!("chain::poll2: {:?}", self.state.get_their_keys_versions().collect::<BTreeMap<_,_>>());
+                if format!("{:?}", self.our_id()) == "PublicId(name: af7022..)"
+                    //&& format!("{:?}", sec_info.prefix()) == "Prefix(101)"
+                     {
+                    info!("OUR_ITEM: {:?}", self.state);
+                }
+
                 if !sec_info.prefix().matches(self.our_id.name()) {
                     self.update_their_keys(
                         *sec_info.prefix(),

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -257,6 +257,7 @@ impl Chain {
                 if !sec_info.prefix().matches(self.our_id.name()) {
                     self.update_their_keys(
                         *sec_info.prefix(),
+                        *sec_info.version(),
                         BlsPublicKey::from_section_info(&sec_info),
                     );
                 }
@@ -878,8 +879,8 @@ impl Chain {
     }
 
     /// Updates `their_keys` in the shared state
-    pub fn update_their_keys(&mut self, prefix: Prefix<XorName>, bls_key: BlsPublicKey) {
-        self.state.update_their_keys(prefix, bls_key);
+    pub fn update_their_keys(&mut self, prefix: Prefix<XorName>, version: u64, bls_key: BlsPublicKey) {
+        self.state.update_their_keys(prefix, version, bls_key);
     }
 
     /// Returns whether we should split into two sections.

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -34,7 +34,7 @@ use std::fmt::{self, Debug, Formatter};
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct GenesisPfxInfo {
     pub first_info: SectionInfo,
-    pub first_state_serialized : Vec<u8>,
+    pub first_state_serialized: Vec<u8>,
     pub latest_info: SectionInfo,
 }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -34,6 +34,7 @@ use std::fmt::{self, Debug, Formatter};
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct GenesisPfxInfo {
     pub first_info: SectionInfo,
+    pub first_state_serialized : Vec<u8>,
     pub latest_info: SectionInfo,
 }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -168,8 +168,8 @@ impl SharedState {
             .iter()
             .find(|(pfx, _)| pfx.is_compatible(&prefix))
         {
-            if version <= key_version {
-                // Older version
+            if version <= *key_version {
+                // Ignore older versions
                 return;
             }
 
@@ -371,7 +371,7 @@ mod test {
             .into_iter()
             .map(|(pfx_str, index)| {
                 let pfx = unwrap!(Prefix::<XorName>::from_str(pfx_str));
-                (pfx, keys_to_update[index].1.clone())
+                (pfx, (0, keys_to_update[index].1.clone()))
             })
             .collect::<BTreeMap<_, _>>();
 
@@ -379,7 +379,7 @@ mod test {
         let mut state = SharedState::new(start_section);
 
         for (pfx, key) in keys_to_update {
-            state.update_their_keys(pfx, key);
+            state.update_their_keys(pfx, 0, key);
         }
 
         assert_eq!(state.get_their_keys(), &expected_keys);

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -184,6 +184,10 @@ impl SharedState {
     pub fn get_their_keys(&self) -> &BTreeMap<Prefix<XorName>, BlsPublicKey> {
         &self.their_keys
     }
+
+    pub fn get_their_keys_versions(&self) -> impl Iterator<Item = (&Prefix<XorName>, &u64)> {
+        self.their_keys.iter().map(|(prefix, key)| (prefix, key.version()))
+    }
 }
 
 /// The prefix-affecting change (split or merge) to our own section that is currently in progress.
@@ -412,6 +416,21 @@ mod test {
                 ("101101", 0),
                 ("1011000", 0),
                 ("1011001", 1),
+            ],
+        );
+    }
+
+
+    #[test]
+    fn update_after_split() {
+        update_keys_and_check(
+            "101",
+            vec!["10", "01", "11", "00", "100"],
+            vec![
+                ("01", 1),
+                ("11", 2),
+                ("00", 3),
+                ("100", 4),
             ],
         );
     }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -18,7 +18,7 @@ use std::{
 use unwrap::unwrap;
 
 /// Section state that is shared among all elders of a section via Parsec consensus.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SharedState {
     /// The new self section info, that doesn't necessarily have a full set of signatures yet.
     pub new_info: SectionInfo,
@@ -187,7 +187,7 @@ impl SharedState {
 }
 
 /// The prefix-affecting change (split or merge) to our own section that is currently in progress.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PrefixChange {
     None,
     Splitting,
@@ -195,7 +195,7 @@ pub enum PrefixChange {
 }
 
 /// Vec-like container that is guaranteed to contain at least one element.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
 pub struct NonEmptyList<T> {
     head: Vec<T>,
     tail: T,
@@ -258,7 +258,7 @@ impl NonEmptyList<(SectionInfo, ProofSet)> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SectionProofBlock {
     key: BlsPublicKey,
     sig: BlsSignature,
@@ -280,7 +280,7 @@ impl SectionProofBlock {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SectionProofChain {
     genesis_pk: BlsPublicKey,
     blocks: Vec<SectionProofBlock>,

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -11,7 +11,7 @@ use crate::{error::RoutingError, sha3::Digest256, BlsPublicKey, BlsSignature, Pr
 use itertools::Itertools;
 use maidsafe_utilities::serialisation;
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, BTreeMap},
     fmt::{self, Debug, Formatter},
     iter, mem,
 };
@@ -36,7 +36,7 @@ pub struct SharedState {
     /// Our section's key history for Secure Message Delivery
     pub our_history: SectionProofChain,
     /// BLS public keys of other sections
-    pub their_keys: HashMap<Prefix<XorName>, BlsPublicKey>,
+    pub their_keys: BTreeMap<Prefix<XorName>, BlsPublicKey>,
 }
 
 impl SharedState {
@@ -181,7 +181,7 @@ impl SharedState {
 
     #[cfg(test)]
     /// Returns the reference to their_keys
-    pub fn get_their_keys(&self) -> &HashMap<Prefix<XorName>, BlsPublicKey> {
+    pub fn get_their_keys(&self) -> &BTreeMap<Prefix<XorName>, BlsPublicKey> {
         &self.their_keys
     }
 }
@@ -325,7 +325,7 @@ impl Debug for SectionProofChain {
 mod test {
     use super::*;
     use crate::{chain::SectionInfo, BlsPublicKey, FullId, Prefix, XorName};
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::{BTreeSet, BTreeMap};
     use std::str::FromStr;
     use unwrap::unwrap;
 
@@ -364,7 +364,7 @@ mod test {
                 let pfx = unwrap!(Prefix::<XorName>::from_str(pfx_str));
                 (pfx, keys_to_update[index].1.clone())
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         let start_section = gen_section_info(unwrap!(Prefix::from_str(start_pfx)));
         let mut state = SharedState::new(start_section);

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -40,7 +40,7 @@ impl ParsecMap {
         let mut map = BTreeMap::new();
         let _ = map.insert(
             *gen_pfx_info.first_info.version(),
-            create(full_id, gen_pfx_info),
+            create(full_id, gen_pfx_info, Vec::new()),
         );
 
         Self { map }
@@ -48,7 +48,7 @@ impl ParsecMap {
 
     pub fn init(&mut self, full_id: FullId, gen_pfx_info: &GenesisPfxInfo, log_ident: &LogIdent) {
         if let Entry::Vacant(entry) = self.map.entry(*gen_pfx_info.first_info.version()) {
-            let _ = entry.insert(create(full_id, gen_pfx_info));
+            let _ = entry.insert(create(full_id, gen_pfx_info, gen_pfx_info.first_state_serialized.clone()));
             info!(
                 "{}: Init new Parsec, genesis = {:?}",
                 log_ident, gen_pfx_info
@@ -171,7 +171,7 @@ impl ParsecMap {
 }
 
 /// Create Parsec instance.
-fn create(full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
+fn create(full_id: FullId, gen_pfx_info: &GenesisPfxInfo, related_info: Vec<u8>) -> Parsec {
     if gen_pfx_info
         .first_info
         .members()
@@ -182,7 +182,7 @@ fn create(full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
             *gen_pfx_info.first_info.hash(),
             full_id,
             &gen_pfx_info.first_info.members(),
-            vec![],
+            related_info,
             ConsensusMode::Single,
             Box::new(rand::os::OsRng::new().unwrap()),
         )

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -48,10 +48,14 @@ impl ParsecMap {
 
     pub fn init(&mut self, full_id: FullId, gen_pfx_info: &GenesisPfxInfo, log_ident: &LogIdent) {
         if let Entry::Vacant(entry) = self.map.entry(*gen_pfx_info.first_info.version()) {
-            let _ = entry.insert(create(full_id, gen_pfx_info, gen_pfx_info.first_state_serialized.clone()));
+            let _ = entry.insert(create(
+                full_id,
+                gen_pfx_info,
+                gen_pfx_info.first_state_serialized.clone(),
+            ));
             info!(
-                "{}: Init new Parsec, genesis = {:?}",
-                log_ident, gen_pfx_info
+                "{}: Init new Parsec, genesis = {:?}, info = {:?}",
+                log_ident, gen_pfx_info, gen_pfx_info.first_state_serialized
             );
         }
     }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -134,8 +134,9 @@ pub trait Approved: Relocated {
                     // FIXME: Handle properly
                     unreachable!("...")
                 }
-                Observation::Genesis { .. } => {
+                Observation::Genesis { group, related_info } => {
                     // FIXME: Validate with Chain info.
+                    self.chain_mut().handle_genesis_event(&group, &related_info)?;
                     self.set_pfx_successfully_polled(true);
                     continue;
                 }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -134,9 +134,14 @@ pub trait Approved: Relocated {
                     // FIXME: Handle properly
                     unreachable!("...")
                 }
-                Observation::Genesis { group, related_info } => {
+                Observation::Genesis {
+                    group,
+                    related_info,
+                } => {
                     // FIXME: Validate with Chain info.
-                    self.chain_mut().handle_genesis_event(&group, &related_info)?;
+                    trace!("{} Parsec Genesis: {:?}", self, group,);
+                    self.chain_mut()
+                        .handle_genesis_event(&group, &related_info)?;
                     self.set_pfx_successfully_polled(true);
                     continue;
                 }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -150,6 +150,7 @@ impl Elder {
         let public_id = *full_id.public_id();
         let gen_pfx_info = GenesisPfxInfo {
             first_info: create_first_section_info(public_id)?,
+            first_state_serialized: Vec::new(),
             latest_info: SectionInfo::default(),
         };
         let parsec_map = ParsecMap::new(full_id.clone(), &gen_pfx_info);
@@ -737,6 +738,7 @@ impl Elder {
 
         let trimmed_info = GenesisPfxInfo {
             first_info: self.gen_pfx_info.first_info.clone(),
+            first_state_serialized: self.gen_pfx_info.first_state_serialized.clone(),
             latest_info: self.chain.our_info().clone(),
         };
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     types::MessageId,
     utils::{self, DisplayDuration, XorTargetInterval},
     xor_name::XorName,
-    BlsPublicKey, ConnectionInfo, NetworkService,
+    ConnectionInfo, NetworkService,
 };
 use itertools::Itertools;
 use log::LogLevel;
@@ -2118,11 +2118,7 @@ impl Approved for Elder {
             self.send_neighbour_infos();
         } else {
             self.remove_from_proving_section_cache(&sec_info);
-            // Update their_keys in chain
-            self.chain.update_their_keys(
-                *sec_info.prefix(),
-                BlsPublicKey::from_section_info(&sec_info),
-            );
+
             // Vote for neighbour update if we haven't done so already.
             // vote_for_event is expected to only generate a new vote if required.
             self.vote_for_event(sec_info.clone().into_network_event());

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -108,6 +108,7 @@ impl ElderUnderTest {
 
         let gen_pfx_info = GenesisPfxInfo {
             first_info: section_info.clone(),
+            first_state_serialized: Vec::new(),
             latest_info: SectionInfo::default(),
         };
 

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -192,7 +192,8 @@ fn joining_node_with_ignoring_candidate_info() {
 
 #[test]
 fn multiple_joining_nodes() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let _ = maidsafe_utilities::log::init(false);
+    let network = Network::new(MIN_SECTION_SIZE, Some([1463356228, 652298051, 1604270005, 2737306343]));
     let mut nodes = create_connected_nodes(&network, MIN_SECTION_SIZE);
 
     while nodes.len() < 40 {

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -192,8 +192,10 @@ fn joining_node_with_ignoring_candidate_info() {
 
 #[test]
 fn multiple_joining_nodes() {
-    let _ = maidsafe_utilities::log::init(false);
-    let network = Network::new(MIN_SECTION_SIZE, Some([1463356228, 652298051, 1604270005, 2737306343]));
+    //let _ = maidsafe_utilities::log::init(false);
+    let network = Network::new(MIN_SECTION_SIZE,
+    //Some([1463356228, 652298051, 1604270005, 2737306343])
+    None );
     let mut nodes = create_connected_nodes(&network, MIN_SECTION_SIZE);
 
     while nodes.len() < 40 {


### PR DESCRIPTION
Many thing will need to be cleaned and changed as well as test fixed

Version is needed in update_their_keys otherwise we try to update a key that had a latter version.
(their_keys != neighour_infos).

Moved calling update_their_keys into chain that is called also in adult state.
This is probably what we would want to do if we had another NetworkEvent, we would handle it in chain poll.


The following are passing:
loop -q target/release/deps/mock_network_tests-7b7d27ed1ac1950c --skip merge --skip churn

merge tests and churn that also do some merge are not passing.
This is expected as after merge, the 2 side would vote for different genesis block related_info.

Also, did not fix shared_state tests.

