### PR TITLE
feat/routing: disable merge in tests - panic on merge

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -237,6 +237,11 @@ impl Chain {
                 let our_hash = *self.state.new_info.hash();
                 let _ = self.state.merging.insert(our_hash);
                 self.state.change = PrefixChange::Merging;
+                panic!(
+                    "Merge not supported: NetworkEvent::OurMerge {:?}: {:?}",
+                    self.our_id(),
+                    self.state.new_info
+                );
             }
             NetworkEvent::NeighbourMerge(digest) => {
                 // TODO: Check that the section is known and not already merged.
@@ -317,6 +322,11 @@ impl Chain {
             // set to merge state to prevent extending chain any further.
             // We'd still not Vote for OurMerge until we've updated our_infos
             self.state.change = PrefixChange::Merging;
+            panic!(
+                "Merge not supported: remove_member < min_sec_size {:?}: {:?}",
+                self.our_id(),
+                self.state.new_info
+            );
         }
 
         Ok(self.state.new_info.clone())

--- a/tests/mock_network/merge.rs
+++ b/tests/mock_network/merge.rs
@@ -70,26 +70,31 @@ fn merge(prefix_lengths: Vec<usize>) {
 }
 
 #[test]
+#[ignore]
 fn merge_three_sections_into_one() {
     merge(vec![1, 2, 2])
 }
 
 #[test]
+#[ignore]
 fn merge_four_unbalanced_sections_into_one() {
     merge(vec![1, 2, 3, 3])
 }
 
 #[test]
+#[ignore]
 fn merge_four_balanced_sections_into_one() {
     merge(vec![2, 2, 2, 2])
 }
 
 #[test]
+#[ignore]
 fn merge_five_sections_into_one() {
     merge(vec![1, 3, 3, 3, 3])
 }
 
 #[test]
+#[ignore]
 fn concurrent_merge() {
     let min_section_size = 4;
     let network = Network::new(min_section_size, None);
@@ -150,6 +155,7 @@ fn concurrent_merge() {
 }
 
 #[test]
+#[ignore]
 fn merge_drop_multiple_nodes() {
     let min_section_size = 7;
     let nodes_to_drop = (min_section_size - 1) / 3;


### PR DESCRIPTION
Merge functionality is partially broken and will be more as
development continue ignoring it. New functionality will break down
on Merge.

We may want to completely strip the merge functionality out since it
is now untested and will rapidely bit-rot requiring a rewrite if we
want to re-add it.

-Ensure that no test proceed to trigger merge: panic if merge occur.
-Update churn tests to not trigger merge, but still cover churn and
 prefix change (split).

Test:
Run soak tests.