### PR TITLE
feat/routing: ensure part of our state is shared our_infos/our_history

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -15,13 +15,13 @@ use std::{
     fmt,
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicKeySet {
     sec_info: SectionInfo,
     threshold: usize,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicKey(PublicKeySet);
 
 pub type SignatureShare = ::safe_crypto::Signature;
@@ -31,7 +31,7 @@ pub struct SecretKeyShare(FullId);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PublicKeyShare(PublicId);
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Signature {
     sigs: BTreeMap<PublicId, SignatureShare>,
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -34,6 +34,7 @@ use std::fmt::{self, Debug, Formatter};
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct GenesisPfxInfo {
     pub first_info: SectionInfo,
+    pub first_state_serialized: Vec<u8>,
     pub latest_info: SectionInfo,
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -182,7 +182,7 @@ fn create(full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
             *gen_pfx_info.first_info.hash(),
             full_id,
             &gen_pfx_info.first_info.members(),
-            vec![],
+            gen_pfx_info.first_state_serialized.clone(),
             ConsensusMode::Single,
             Box::new(rand::os::OsRng::new().unwrap()),
         )

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -137,8 +137,13 @@ pub trait Approved: Relocated {
                     // FIXME: Handle properly
                     unreachable!("...")
                 }
-                Observation::Genesis { .. } => {
+                Observation::Genesis {
+                    group,
+                    related_info,
+                } => {
                     // FIXME: Validate with Chain info.
+                    self.chain_mut()
+                        .handle_genesis_event(&group, &related_info)?;
                     self.set_pfx_successfully_polled(true);
                     continue;
                 }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -148,6 +148,7 @@ impl Elder {
         let public_id = *full_id.public_id();
         let gen_pfx_info = GenesisPfxInfo {
             first_info: create_first_section_info(public_id)?,
+            first_state_serialized: Vec::new(),
             latest_info: SectionInfo::default(),
         };
         let parsec_map = ParsecMap::new(full_id.clone(), &gen_pfx_info);
@@ -736,6 +737,7 @@ impl Elder {
 
         let trimmed_info = GenesisPfxInfo {
             first_info: self.gen_pfx_info.first_info.clone(),
+            first_state_serialized: self.gen_pfx_info.first_state_serialized.clone(),
             latest_info: self.chain.our_info().clone(),
         };
 

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -108,6 +108,7 @@ impl ElderUnderTest {
 
         let gen_pfx_info = GenesisPfxInfo {
             first_info: section_info.clone(),
+            first_state_serialized: Vec::new(),
             latest_info: SectionInfo::default(),
         };
 


### PR DESCRIPTION
This place the building block of sharing state with only part of
SharedState. Follow up will add their_keys, and neighbour_infos as
weel as their_knowledge.

Disable prunning our_infos, this is required until their_knowledge
is solid and shared state as we require updates to our_infos to be
shared by all peers in exactly the same way.

Test:
Run soak tests.