### PR TITLE
fix/routing: update their_knowledge for correct prefix

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -574,7 +574,7 @@ impl Chain {
             | NetworkEvent::Offline(_)
             | NetworkEvent::ExpectCandidate(_)
             | NetworkEvent::PurgeCandidate(_)
-            | NetworkEvent::AckMessage(_) => {
+            | NetworkEvent::AckMessage { .. } => {
                 self.state.change == PrefixChange::None && self.our_info().is_quorum(proofs)
             }
             NetworkEvent::ProvingSections(_, _) => true,
@@ -740,6 +740,16 @@ impl Chain {
             .find(|pfx| pfx.is_compatible(&prefix))
         {
             let old_version = unwrap!(self.their_knowledge.remove(&pfx));
+
+            trace!(
+                "{} update_their_knowledge {:?}/{:?} to {:?}/{:?}",
+                self.our_id(),
+                pfx,
+                old_version,
+                prefix,
+                version
+            );
+
             let old_pfx_sibling = pfx.sibling();
             let mut current_pfx = prefix.sibling();
             while !self.their_knowledge.contains_key(&current_pfx) && current_pfx != old_pfx_sibling
@@ -1273,9 +1283,9 @@ impl Chain {
 
 #[cfg(feature = "mock_base")]
 impl Chain {
-    /// returns the list of versions in `their_knowledge`
-    pub fn get_their_knowldege_versions(&self) -> impl Iterator<Item = &u64> {
-        self.their_knowledge.values()
+    /// Returns their_knowledge
+    pub fn get_their_knowldege(&self) -> &BTreeMap<Prefix<XorName>, u64> {
+        &self.their_knowledge
     }
 }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -22,7 +22,7 @@ mod test_utils;
 pub use self::test_utils::verify_chain_invariant;
 pub use self::{
     chain::{delivery_group_size, Chain, PrefixChangeOutcome},
-    network_event::{ExpectCandidatePayload, NetworkEvent, OnlinePayload},
+    network_event::{AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload},
     proof::{Proof, ProofSet, ProvingSection},
     section_info::SectionInfo,
     shared_state::PrefixChange,

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -9,6 +9,7 @@
 use super::{ProofSet, ProvingSection, SectionInfo};
 use crate::id::PublicId;
 use crate::parsec;
+use crate::routing_table::Prefix;
 use crate::sha3::Digest256;
 use crate::types::MessageId;
 use crate::{Authority, RoutingError, XorName};
@@ -36,6 +37,14 @@ pub struct OnlinePayload {
     pub old_public_id: PublicId,
     /// The joining node's current authority.
     pub client_auth: Authority<XorName>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct AckMessagePayload {
+    /// The prefix of our section when we acknowledge their SectionInfo of version ack_version.
+    pub src_prefix: Prefix<XorName>,
+    /// The version acknowledged.
+    pub ack_version: u64,
 }
 
 /// Routing Network events
@@ -66,7 +75,8 @@ pub enum NetworkEvent {
     /// A list of proofs for a neighbour section, starting from the current section.
     ProvingSections(Vec<ProvingSection>, SectionInfo),
 
-    AckMessage(SectionInfo),
+    // Voted for received AckMessage to update their_knowledge
+    AckMessage(AckMessagePayload),
 }
 
 impl NetworkEvent {
@@ -129,9 +139,7 @@ impl Debug for NetworkEvent {
             NetworkEvent::ProvingSections(_, ref sec_info) => {
                 write!(formatter, "ProvingSections(_, {:?})", sec_info)
             }
-            NetworkEvent::AckMessage(ref sec_info) => {
-                write!(formatter, "AckMessage(_, {:?})", sec_info)
-            }
+            NetworkEvent::AckMessage(ref payload) => write!(formatter, "AckMessage({:?})", payload),
         }
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -453,7 +453,12 @@ pub enum MessageContent {
     /// Sent from Group Y to the joining node.
     NodeApproval(GenesisPfxInfo),
     /// Acknowledgement of a consensused section info.
-    AckMessage(SectionInfo),
+    AckMessage {
+        /// The prefix of our section when we acknowledge their SectionInfo of version ack_version.
+        src_prefix: Prefix<XorName>,
+        /// The version acknowledged.
+        ack_version: u64,
+    },
 }
 
 impl MessageContent {
@@ -533,7 +538,10 @@ impl Debug for MessageContent {
                 content, priority,
             ),
             NodeApproval(ref gen_info) => write!(formatter, "NodeApproval {{ {:?} }}", gen_info),
-            AckMessage(ref sec_info) => write!(formatter, "AckMessage({:?})", sec_info),
+            AckMessage {
+                ref src_prefix,
+                ref ack_version,
+            } => write!(formatter, "AckMessage({:?}, {})", src_prefix, ack_version),
         }
     }
 }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -16,7 +16,8 @@ use super::{
 use crate::{
     cache::Cache,
     chain::{
-        Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload, ProvingSection, SectionInfo,
+        AckMessagePayload, Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload,
+        ProvingSection, SectionInfo,
     },
     error::RoutingError,
     event::Event,
@@ -402,7 +403,10 @@ impl Approved for Adult {
         }
     }
 
-    fn handle_ack_message_event(&mut self, _sec_info: SectionInfo) -> Result<(), RoutingError> {
+    fn handle_ack_message_event(
+        &mut self,
+        _ack_payload: AckMessagePayload,
+    ) -> Result<(), RoutingError> {
         debug!("{} - Unhandled UpdateSharedState event", self);
         Ok(())
     }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -9,8 +9,8 @@
 use super::Relocated;
 use crate::{
     chain::{
-        Chain, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof, ProofSet,
-        ProvingSection, SectionInfo,
+        AckMessagePayload, Chain, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof,
+        ProofSet, ProvingSection, SectionInfo,
     },
     error::RoutingError,
     id::PublicId,
@@ -68,7 +68,10 @@ pub trait Approved: Relocated {
     ) -> Result<Transition, RoutingError>;
 
     /// Handles an accumulated `UpdateSharedState` event.
-    fn handle_ack_message_event(&mut self, sec_info: SectionInfo) -> Result<(), RoutingError>;
+    fn handle_ack_message_event(
+        &mut self,
+        ack_payload: AckMessagePayload,
+    ) -> Result<(), RoutingError>;
 
     // Handles an accumulated `ExpectCandidate` event.
     // Context: a node is joining our section. Send the node our section. If the
@@ -235,7 +238,7 @@ pub trait Approved: Relocated {
                         transition => return Ok(transition),
                     }
                 }
-                NetworkEvent::AckMessage(sec_info) => self.handle_ack_message_event(sec_info)?,
+                NetworkEvent::AckMessage(payload) => self.handle_ack_message_event(payload)?,
                 NetworkEvent::ExpectCandidate(vote) => self.handle_expect_candidate_event(vote)?,
                 NetworkEvent::PurgeCandidate(old_public_id) => {
                     self.handle_purge_candidate_event(old_public_id)?

--- a/src/states/relocating_node.rs
+++ b/src/states/relocating_node.rs
@@ -132,7 +132,7 @@ impl RelocatingNode {
             | Merge(..)
             | UserMessage { .. }
             | NodeApproval { .. }
-            | AckMessage(..) => {
+            | AckMessage { .. } => {
                 warn!(
                     "{} Not joined yet. Not handling {:?} from {:?} to {:?}",
                     self, routing_msg.content, routing_msg.src, routing_msg.dst

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -446,7 +446,11 @@ fn check_section_info_ack() {
     // sending out `section_info_ack`. Hence only one section shall consensus on it eventually.
     let num_of_consensus = nodes
         .iter()
-        .filter(|node| node.chain().get_their_knowldege_versions().count() > 0)
+        .filter(|node| {
+            node.chain()
+                .get_their_knowldege()
+                .contains_key(&node.chain().our_prefix().sibling())
+        })
         .count();
     assert!(num_of_consensus >= min_section_size);
     assert!(num_of_consensus < 2 * min_section_size);


### PR DESCRIPTION
Partial fix for #1670

Their knowledge is a map of their prefix to our version that they know.
The AckMessage need to contain the prefix, and the consensused message
need to consensus that prefix with the version.

We incorrectly used our own section that we consensused and then update
our prefix and version.

Test:
Update check_section_info_ack so it fails without this fix.
Run clippy+ soak test