### PR TITLE
Implement sender verification

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -15,13 +15,13 @@ use std::{
     fmt,
 };
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {
     sec_info: SectionInfo,
     threshold: usize,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKey(PublicKeySet);
 
 pub type SignatureShare = ::safe_crypto::Signature;
@@ -31,7 +31,7 @@ pub struct SecretKeyShare(FullId);
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PublicKeyShare(PublicId);
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct Signature {
     sigs: BTreeMap<PublicId, SignatureShare>,
 }

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -17,7 +17,7 @@ use parsec;
 use std::collections::BTreeSet;
 use std::{collections::BTreeMap, fmt};
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {
     sec_info: SectionInfo,
     threshold: usize,

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -28,8 +28,8 @@ pub type SignatureShare = ::safe_crypto::Signature;
 
 pub struct SecretKeyShare(FullId);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct PublicKeyShare(PublicId);
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, Debug)]
+pub struct PublicKeyShare(pub PublicId);
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct Signature {
@@ -55,7 +55,6 @@ impl SecretKeyShare {
 }
 
 impl PublicKeyShare {
-    #[allow(unused)]
     pub fn verify<M: AsRef<[u8]>>(&self, sig: &SignatureShare, msg: M) -> bool {
         self.0
             .signing_public_key()
@@ -81,12 +80,10 @@ impl PublicKeySet {
         }
     }
 
-    #[allow(unused)]
     pub fn threshold(&self) -> usize {
         self.threshold
     }
 
-    #[allow(unused)]
     pub fn combine_signatures<'a, I>(&self, shares: I) -> Option<Signature>
     where
         I: IntoIterator<Item = (PublicKeyShare, &'a SignatureShare)>,

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -28,7 +28,7 @@ pub type SignatureShare = ::safe_crypto::Signature;
 
 pub struct SecretKeyShare(FullId);
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, Debug)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Hash, Serialize, Deserialize, Debug)]
 pub struct PublicKeyShare(pub PublicId);
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -7,13 +7,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 //! Types emulating the BLS functionality until proper BLS lands
-use super::{delivery_group_size, NetworkEvent, ProofSet, SectionInfo};
-use crate::id::{FullId, PublicId};
-use parsec;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
+use super::{NetworkEvent, ProofSet, SectionInfo};
+use crate::{
+    id::{FullId, PublicId},
+    QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
 };
+use parsec;
+#[cfg(test)]
+use std::collections::BTreeSet;
+use std::{collections::BTreeMap, fmt};
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {
@@ -63,7 +65,7 @@ impl PublicKeyShare {
 }
 
 impl PublicKeySet {
-    #[allow(unused)]
+    #[cfg(test)]
     pub fn new(threshold: usize, keys: BTreeSet<PublicId>) -> Self {
         let sec_info = SectionInfo::new(keys, Default::default(), None).unwrap();
         Self {
@@ -73,7 +75,7 @@ impl PublicKeySet {
     }
 
     pub fn from_section_info(sec_info: SectionInfo) -> Self {
-        let threshold = delivery_group_size(sec_info.members().len()) - 1;
+        let threshold = sec_info.members().len() * QUORUM_NUMERATOR / QUORUM_DENOMINATOR;
         Self {
             threshold,
             sec_info,
@@ -102,7 +104,7 @@ impl PublicKeySet {
         }
     }
 
-    #[allow(unused)]
+    #[cfg(test)]
     pub fn public_key(&self) -> PublicKey {
         PublicKey(self.clone())
     }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -491,6 +491,11 @@ impl Chain {
         }
     }
 
+    /// Return the keys we know
+    pub fn get_their_keys(&self) -> impl Iterator<Item = (&Prefix<XorName>, &BlsPublicKey)> {
+        self.state.get_their_keys()
+    }
+
     /// Returns `true` if the `proof_chain` contains a key we have in `their_keys` and that key is
     /// for a prefix compatible with `prefix`
     pub fn check_trust(&self, prefix: &Prefix<XorName>, proof_chain: &SectionProofChain) -> bool {
@@ -499,7 +504,6 @@ impl Chain {
         } else {
             self.state
                 .get_their_keys()
-                .iter()
                 .filter(|&(pfx, _)| prefix.is_compatible(pfx))
                 .map(|(_, key)| key)
                 .collect()

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -18,7 +18,7 @@ use crate::{
     sha3::Digest256,
     utils::LogIdent,
     utils::XorTargetInterval,
-    BlsPublicKey, BlsSignature, Prefix, XorName, Xorable,
+    BlsPublicKey, Prefix, XorName, Xorable,
 };
 use itertools::Itertools;
 use log::LogLevel;
@@ -543,26 +543,9 @@ impl Chain {
 
     /// Provide a SectionProofChain that proves the given signature to the section with a given
     /// prefix
-    pub fn prove(
-        &self,
-        target: &Authority<XorName>,
-        signature: &BlsSignature,
-        data: &[u8],
-    ) -> SectionProofChain {
+    pub fn prove(&self, target: &Authority<XorName>) -> SectionProofChain {
         let first_index = self.proving_index(target);
-        let keys_len = self.state.our_history.len();
-        let last_index = self
-            .state
-            .our_history
-            .all_keys()
-            .rev()
-            .enumerate()
-            // .enumerate().rev() is impossible due to iter::Chain not implementing
-            // ExactSizeIterator
-            .map(|(index, key)| (keys_len - index, key))
-            .find(|(_, key)| key.verify(signature, data))
-            .map(|(index, _)| index)
-            .unwrap_or_else(|| self.state.our_history.last_index());
+        let last_index = self.state.our_history.last_index();
         self.state
             .our_history
             .slice(first_index as usize, last_index)

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -551,10 +551,7 @@ impl Chain {
     pub fn prove(&self, _target: &Authority<XorName>) -> SectionProofChain {
         // TODO: change to self.proving_index(target); when their_knowledge is functioning properly
         let first_index = 0;
-        let last_index = self.state.our_history.last_index();
-        self.state
-            .our_history
-            .slice(first_index as usize, last_index)
+        self.state.our_history.slice_from(first_index as usize)
     }
 
     /// Returns `true` if the given `NetworkEvent` is already accumulated and can be skipped.

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -532,6 +532,7 @@ impl Chain {
 
     /// Returns the index of the public key in our_history that will be trusted by the target
     /// Authority
+    #[allow(unused)]
     fn proving_index(&self, target: &Authority<XorName>) -> u64 {
         self.state
             .their_knowledge
@@ -543,8 +544,9 @@ impl Chain {
 
     /// Provide a SectionProofChain that proves the given signature to the section with a given
     /// prefix
-    pub fn prove(&self, target: &Authority<XorName>) -> SectionProofChain {
-        let first_index = self.proving_index(target);
+    pub fn prove(&self, _target: &Authority<XorName>) -> SectionProofChain {
+        // TODO: change to self.proving_index(target); when their_knowledge is functioning properly
+        let first_index = 0;
         let last_index = self.state.our_history.last_index();
         self.state
             .our_history

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -790,7 +790,7 @@ impl Chain {
 
     /// Updates `their_keys` in the shared state
     pub fn update_their_keys(&mut self, prefix: Prefix<XorName>, bls_key: BlsPublicKey) {
-        self.state.update_their_keys(prefix, bls_key);
+        self.state.update_their_keys(prefix, bls_key, &self.our_id);
     }
 
     /// Returns whether we should split into two sections.

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
     network_event::{AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload},
     proof::{Proof, ProofSet, ProvingSection},
     section_info::SectionInfo,
-    shared_state::PrefixChange,
+    shared_state::{PrefixChange, SectionProofChain},
 };
 use std::fmt::{self, Debug, Formatter};
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -20,6 +20,9 @@ use std::{
 };
 use unwrap::unwrap;
 
+// Number of recent keys we keep: i.e how many other section churns we can handle before a
+// message send with a previous version of a section is no longer trusted.
+// With low churn rate, a ad hoc 10 should be big enough to avoid losing messages.
 const MAX_THEIR_RECENT_KEYS: usize = 10;
 
 /// Section state that is shared among all elders of a section via Parsec consensus.
@@ -306,7 +309,7 @@ impl SharedState {
         let _ = self.their_knowledge.insert(prefix, version);
     }
 
-    /// Returns the reference to their_keys
+    /// Returns the reference to their_keys and any recent keys we still hold.
     pub fn get_their_keys(&self) -> impl Iterator<Item = (&Prefix<XorName>, &BlsPublicKey)> {
         self.their_keys
             .iter()

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -440,31 +440,25 @@ impl SectionProofChain {
             .unwrap_or(&self.genesis_pk)
     }
 
-    pub fn last_index(&self) -> usize {
-        self.blocks.len()
-    }
-
     pub fn all_keys(&self) -> impl DoubleEndedIterator<Item = &BlsPublicKey> {
         iter::once(&self.genesis_pk).chain(self.blocks.iter().map(|block| &block.key))
     }
 
-    pub fn len(&self) -> usize {
-        self.blocks.len() + 1
-    }
+    pub fn slice_from(&self, first_index: usize) -> SectionProofChain {
+        if first_index == 0 || self.blocks.is_empty() {
+            return self.clone();
+        }
 
-    pub fn slice(&self, first_index: usize, last_index: usize) -> SectionProofChain {
-        let genesis_pk = if first_index == 0 {
-            self.genesis_pk.clone()
-        } else {
-            self.blocks[first_index - 1].key.clone()
-        };
-        let blocks = if last_index == 0 {
+        let genesis_index = std::cmp::min(first_index, self.blocks.len()) - 1;
+        let genesis_pk = self.blocks[genesis_index].key.clone();
+
+        let block_first_index = genesis_index + 1;
+        let blocks = if block_first_index >= self.blocks.len() {
             vec![]
-        } else if last_index < self.blocks.len() {
-            self.blocks[first_index..last_index].to_vec()
         } else {
-            self.blocks[first_index..].to_vec()
+            self.blocks[block_first_index..].to_vec()
         };
+
         SectionProofChain { genesis_pk, blocks }
     }
 }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -264,7 +264,6 @@ impl SharedState {
         let _ = self.their_knowledge.insert(prefix, version);
     }
 
-    #[cfg(test)]
     /// Returns the reference to their_keys
     pub fn get_their_keys(&self) -> &BTreeMap<Prefix<XorName>, BlsPublicKey> {
         &self.their_keys
@@ -366,7 +365,6 @@ impl SectionProofChain {
         self.blocks.push(block);
     }
 
-    #[allow(unused)]
     pub fn validate(&self) -> bool {
         let mut current_pk = &self.genesis_pk;
         for block in &self.blocks {
@@ -376,6 +374,17 @@ impl SectionProofChain {
             current_pk = &block.key;
         }
         true
+    }
+
+    pub fn last_public_key(&self) -> &BlsPublicKey {
+        self.blocks
+            .last()
+            .map(|block| &block.key)
+            .unwrap_or(&self.genesis_pk)
+    }
+
+    pub fn all_keys(&self) -> impl DoubleEndedIterator<Item = &BlsPublicKey> {
+        iter::once(&self.genesis_pk).chain(self.blocks.iter().map(|block| &block.key))
     }
 }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -326,7 +326,7 @@ where
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct SectionProofBlock {
     key: BlsPublicKey,
     sig: BlsSignature,
@@ -348,7 +348,7 @@ impl SectionProofBlock {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct SectionProofChain {
     genesis_pk: BlsPublicKey,
     blocks: Vec<SectionProofBlock>,

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -44,7 +44,7 @@ pub struct SharedState {
     /// BLS public keys of other sections
     pub their_keys: BTreeMap<Prefix<XorName>, BlsPublicKey>,
     /// Other sections' knowledge of us
-    their_knowledge: BTreeMap<Prefix<XorName>, u64>,
+    pub their_knowledge: BTreeMap<Prefix<XorName>, u64>,
 }
 
 impl SharedState {
@@ -383,8 +383,32 @@ impl SectionProofChain {
             .unwrap_or(&self.genesis_pk)
     }
 
+    pub fn last_index(&self) -> usize {
+        self.blocks.len()
+    }
+
     pub fn all_keys(&self) -> impl DoubleEndedIterator<Item = &BlsPublicKey> {
         iter::once(&self.genesis_pk).chain(self.blocks.iter().map(|block| &block.key))
+    }
+
+    pub fn len(&self) -> usize {
+        self.blocks.len() + 1
+    }
+
+    pub fn slice(&self, first_index: usize, last_index: usize) -> SectionProofChain {
+        let genesis_pk = if first_index == 0 {
+            self.genesis_pk.clone()
+        } else {
+            self.blocks[first_index - 1].key.clone()
+        };
+        let blocks = if last_index == 0 {
+            vec![]
+        } else if last_index < self.blocks.len() {
+            self.blocks[first_index..last_index].to_vec()
+        } else {
+            self.blocks[first_index..].to_vec()
+        };
+        SectionProofChain { genesis_pk, blocks }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -145,6 +145,8 @@ pub enum RoutingError {
     UnknownPrevHop,
     /// A signed message's chain of proving sections is invalid.
     InvalidProvingSection,
+    /// A signed message could not be trusted
+    UntrustedMessage,
     /// Crypto related error.
     Crypto(safe_crypto::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,9 @@ pub(crate) type NetworkBytes = std::rc::Rc<crate::messages::Message>;
 pub use self::quic_p2p::Config as NetworkConfig;
 pub(crate) use self::{
     chain::bls_emu::{
-        PublicKey as BlsPublicKey, Signature as BlsSignature, SignatureShare as BlsSignatureShare,
+        PublicKey as BlsPublicKey, PublicKeySet as BlsPublicKeySet,
+        PublicKeyShare as BlsPublicKeyShare, Signature as BlsSignature,
+        SignatureShare as BlsSignatureShare,
     },
     network_service::NetworkService,
     quic_p2p::{Event as NetworkEvent, Peer as ConnectionInfo, QuicP2p},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,9 @@ pub(crate) type NetworkBytes = std::rc::Rc<crate::messages::Message>;
 
 pub use self::quic_p2p::Config as NetworkConfig;
 pub(crate) use self::{
-    chain::bls_emu::{PublicKey as BlsPublicKey, Signature as BlsSignature},
+    chain::bls_emu::{
+        PublicKey as BlsPublicKey, Signature as BlsSignature, SignatureShare as BlsSignatureShare,
+    },
     network_service::NetworkService,
     quic_p2p::{Event as NetworkEvent, Peer as ConnectionInfo, QuicP2p},
 };

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -113,6 +113,16 @@ impl FullSecurityMetadata {
     }
 }
 
+impl Debug for FullSecurityMetadata {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "FullSecurityMetadata {{ sender_prefix: {:?}, proof: {:?}, .. }}",
+            self.sender_prefix, self.proof
+        )
+    }
+}
+
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum SecurityMetadata {
@@ -550,15 +560,15 @@ impl Debug for HopMessage {
 
 impl Debug for SignedRoutingMessage {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        let security_metadata_str = match self.security_metadata {
-            SecurityMetadata::None => "None",
-            SecurityMetadata::Partial(_) => "Partial",
-            SecurityMetadata::Full(_) => "Full",
+        let security_metadata_str = match &self.security_metadata {
+            SecurityMetadata::None => "None".to_owned(),
+            SecurityMetadata::Partial(_) => "Partial".to_owned(),
+            SecurityMetadata::Full(smd) => format!("{:?}", smd),
         };
         write!(
             formatter,
             "SignedRoutingMessage {{ content: {:?}, sending nodes: {:?}, \
-             security_metadata: {:?} }}",
+             security_metadata: {} }}",
             self.content, self.src_section, security_metadata_str
         )
     }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -78,7 +78,9 @@ impl HopMessage {
     }
 }
 
-/// Metadata needed for verification of the sender
+/// Metadata needed for verification of the sender.
+/// Contain shares of the section signature before combining into a BLS signature
+/// and into a FullSecurityMetadata.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PartialSecurityMetadata {
     proof: SectionProofChain,
@@ -87,7 +89,7 @@ pub struct PartialSecurityMetadata {
     pk_set: BlsPublicKeySet,
 }
 
-/// Metadata needed for verification of the sender
+/// Metadata needed for verification of the sender.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct FullSecurityMetadata {
     proof: SectionProofChain,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -146,6 +146,18 @@ impl SignedRoutingMessage {
         })
     }
 
+    /// Creates a `SignedRoutingMessage` without security metadata
+    pub fn insecure<T: Into<Option<SectionInfo>>>(
+        content: RoutingMessage,
+        src_section: T,
+    ) -> SignedRoutingMessage {
+        SignedRoutingMessage {
+            content,
+            src_section: src_section.into(),
+            security_metadata: SecurityMetadata::None,
+        }
+    }
+
     /// Confirms the signatures.
     pub fn check_integrity(&self) -> Result<()> {
         match self.security_metadata {

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -442,7 +442,7 @@ fn packet_is_parsec_gossip() {
             message_id: MessageId::new(),
         },
     };
-    let msg = unwrap!(SignedRoutingMessage::new(msg, &full_id, None));
+    let msg = SignedRoutingMessage::insecure(msg, None);
     let msg = unwrap!(HopMessage::new(msg));
     let msg = Message::Hop(msg);
     assert!(!Packet::Message(NetworkBytes::from(serialise(&msg)), 0).is_parsec_gossip());

--- a/src/states/common/bootstrapped_not_established.rs
+++ b/src/states/common/bootstrapped_not_established.rs
@@ -70,7 +70,7 @@ pub trait BootstrappedNotEstablished: Bootstrapped {
             }
         };
 
-        let signed_msg = SignedRoutingMessage::new(routing_msg, self.full_id(), None)?;
+        let signed_msg = SignedRoutingMessage::insecure(routing_msg, None);
 
         if !self.filter_outgoing_routing_msg(signed_msg.routing_message(), &proxy_pub_id) {
             let message = self.to_hop_message(signed_msg.clone())?;

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -548,7 +548,16 @@ impl Elder {
         }
 
         if self.in_authority(&signed_msg.routing_message().dst) {
-            // The message is addressed to our section. Verify its integrity.
+            // The message is addressed to our section. Verify its integrity and trust
+            if !signed_msg.check_trust(&self.chain) {
+                log_or_panic!(
+                    LogLevel::Error,
+                    "{} Untrusted SignedRoutingMessage: {:?}",
+                    self,
+                    signed_msg
+                );
+                return Err(RoutingError::UntrustedMessage);
+            }
             signed_msg.check_integrity()?;
 
             if signed_msg.routing_message().dst.is_multiple() {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -534,9 +534,10 @@ impl Elder {
             if !signed_msg.check_trust(&self.chain) {
                 log_or_panic!(
                     LogLevel::Error,
-                    "{} Untrusted SignedRoutingMessage: {:?}",
+                    "{} Untrusted SignedRoutingMessage: {:?} --- {:?}",
                     self,
-                    signed_msg
+                    signed_msg,
+                    self.chain.get_their_keys().collect::<Vec<_>>()
                 );
                 return Err(RoutingError::UntrustedMessage);
             }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -497,10 +497,11 @@ impl Elder {
             return Err(RoutingError::UnknownConnection(pub_id));
         }
 
-        if let Some(signed_msg) = self
+        if let Some(mut signed_msg) = self
             .sig_accumulator
             .add_proof(msg.clone(), &self.public_key_set())
         {
+            signed_msg.attach_proof(&self.chain);
             self.handle_signed_message(signed_msg)?;
         }
         Ok(())
@@ -1866,6 +1867,7 @@ impl Bootstrapped for Elder {
                     .sig_accumulator
                     .add_proof(signed_msg.clone(), &self.public_key_set())
                 {
+                    msg.attach_proof(&self.chain);
                     if self.in_authority(&msg.routing_message().dst) {
                         self.handle_signed_message(msg)?;
                     } else {


### PR DESCRIPTION
This is completing PR https://github.com/maidsafe/routing/pull/1721

This adds the facilities in SignedRoutingMessage and Chain necessary for checking whether a message can be trusted: Closes #1668 
Also fill the security metadata in appropriate places in the code Closes #1669 

This is the first building block of the end to end solution.
There are some limitations. In particular:
 - This security is only done for Message with Section as the source.
 - their_knowledge is not used as it can be unreliable so we send the full proof from genesis with all messages.
 - We are filtering before the signature check
 - We are adding SectionInfo before signature check

Test:
Run soak tests + clippy