### PR TITLE
feat/routing: use their_knowledge ensuring it is never ahead of a node

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -22,7 +22,10 @@ mod test_utils;
 pub use self::test_utils::verify_chain_invariant;
 pub use self::{
     chain::{delivery_group_size, Chain, PrefixChangeOutcome},
-    network_event::{AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload},
+    network_event::{
+        AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload,
+        SendAckMessagePayload,
+    },
     proof::{Proof, ProofSet, ProvingSection},
     section_info::SectionInfo,
     shared_state::{PrefixChange, SectionProofChain},

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -47,6 +47,14 @@ pub struct AckMessagePayload {
     pub ack_version: u64,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct SendAckMessagePayload {
+    /// The prefix acknowledged.
+    pub ack_prefix: Prefix<XorName>,
+    /// The version acknowledged.
+    pub ack_version: u64,
+}
+
 /// Routing Network events
 // TODO: Box `SectionInfo`?
 #[allow(clippy::large_enum_variant)]
@@ -77,6 +85,9 @@ pub enum NetworkEvent {
 
     // Voted for received AckMessage to update their_knowledge
     AckMessage(AckMessagePayload),
+
+    // Voted for sending AckMessage (Require 100% consensus)
+    SendAckMessage(SendAckMessagePayload),
 }
 
 impl NetworkEvent {
@@ -140,6 +151,9 @@ impl Debug for NetworkEvent {
                 write!(formatter, "ProvingSections(_, {:?})", sec_info)
             }
             NetworkEvent::AckMessage(ref payload) => write!(formatter, "AckMessage({:?})", payload),
+            NetworkEvent::SendAckMessage(ref payload) => {
+                write!(formatter, "SendAckMessage({:?})", payload)
+            }
         }
     }
 }

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -113,6 +113,11 @@ impl SectionInfo {
             > self.members.len() * QUORUM_NUMERATOR
     }
 
+    /// Returns `true` if the proofs are from all members of this section.
+    pub fn is_total_consensus(&self, proofs: &ProofSet) -> bool {
+        proofs.ids().filter(|id| self.members.contains(id)).count() == self.members.len()
+    }
+
     /// Returns `true` if `self` is a successor of `other_info`, according to its hash.
     pub fn is_successor_of(&self, other_info: &SectionInfo) -> bool {
         self.prev_hash.contains(&other_info.hash)

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -17,6 +17,7 @@ use crate::{
     cache::Cache,
     chain::{
         Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload, ProvingSection, SectionInfo,
+        SendAckMessagePayload,
     },
     error::RoutingError,
     event::Event,
@@ -400,6 +401,13 @@ impl Approved for Adult {
             debug!("{} - Unhandled SectionInfo event", self);
             Ok(Transition::Stay)
         }
+    }
+
+    fn handle_send_ack_message_event(
+        &mut self,
+        _ack_payload: SendAckMessagePayload,
+    ) -> Result<(), RoutingError> {
+        Ok(())
     }
 
     fn handle_our_merge_event(&mut self) -> Result<(), RoutingError> {


### PR DESCRIPTION
Closes #1737 
Closes #1667 

When updating their_knowledge, we need to ensure that all nodes we
will communicate with will have enough information to check trust.

In order to achieve this, we have to have all nodes in a section
acknowledging updating their_keys before sending the AckMessage.
This is not something we could do at the signature accumulation stage
as a malicious node could still send the message early.

The failure mode here is that we do not send AckMessage and we receive
more information than needed. It is much better than what we have
currently implemented as we currently send all proofs.

Additionally, we will be able in the future to detect this as Malice
and punish nodes. We will in the future also need to ensure this
SendAckMessage consensus even in case of membership change, this would
require Adult transitionning to Elder to vote, or limiting ourselves to
all the elder that should have voted intially (other will necessarily
have that information when they reach the parsec point that added them).

Note, this issue could also have been addressed by ensuring all
incomming messages go through Parsec, but it is a bigger change and
also have its own draw backs.

Test:
Run soak test