### PR TITLE
fix split their knowledge

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -229,13 +229,12 @@ impl Chain {
 
         match event {
             NetworkEvent::SectionInfo(ref sec_info) => {
-                if !sec_info.prefix().matches(self.our_id.name()) {
-                    self.update_their_keys(TheirKeyInfo {
-                        prefix: *sec_info.prefix(),
-                        version: *sec_info.version(),
-                        key: BlsPublicKey::from_section_info(&sec_info),
-                    });
-                }
+                self.update_their_keys(TheirKeyInfo {
+                    prefix: *sec_info.prefix(),
+                    version: *sec_info.version(),
+                    key: BlsPublicKey::from_section_info(&sec_info),
+                });
+
                 self.add_section_info(sec_info.clone(), proofs)?;
                 if let Some((ref cached_sec_info, _)) = self.state.split_cache {
                     if cached_sec_info == sec_info {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -18,7 +18,7 @@ use crate::{
     sha3::Digest256,
     utils::LogIdent,
     utils::XorTargetInterval,
-    BlsPublicKey, Prefix, XorName, Xorable,
+    Prefix, XorName, Xorable,
 };
 use itertools::Itertools;
 use log::LogLevel;
@@ -229,18 +229,15 @@ impl Chain {
 
         match event {
             NetworkEvent::SectionInfo(ref sec_info) => {
-                self.update_their_keys(TheirKeyInfo {
-                    prefix: *sec_info.prefix(),
-                    version: *sec_info.version(),
-                    key: BlsPublicKey::from_section_info(&sec_info),
-                });
-
                 self.add_section_info(sec_info.clone(), proofs)?;
                 if let Some((ref cached_sec_info, _)) = self.state.split_cache {
                     if cached_sec_info == sec_info {
                         return Ok(None);
                     }
                 }
+            }
+            NetworkEvent::TheirKeyInfo(ref key_info) => {
+                self.update_their_keys(key_info);
             }
             NetworkEvent::AckMessage(ref ack_payload) => {
                 self.update_their_knowledge(ack_payload.src_prefix, ack_payload.ack_version);
@@ -261,7 +258,14 @@ impl Chain {
                 // TODO: Check that the section is known and not already merged.
                 let _ = self.state.merging.insert(digest);
             }
-            _ => (),
+            NetworkEvent::AddElder(_, _)
+            | NetworkEvent::RemoveElder(_)
+            | NetworkEvent::Online(_)
+            | NetworkEvent::Offline(_)
+            | NetworkEvent::ExpectCandidate(_)
+            | NetworkEvent::PurgeCandidate(_)
+            | NetworkEvent::SendAckMessage(_)
+            | NetworkEvent::ProvingSections(_, _) => (),
         }
         Ok(Some(event))
     }
@@ -613,6 +617,7 @@ impl Chain {
             | NetworkEvent::Offline(_)
             | NetworkEvent::ExpectCandidate(_)
             | NetworkEvent::PurgeCandidate(_)
+            | NetworkEvent::TheirKeyInfo(_)
             | NetworkEvent::AckMessage(_) => {
                 self.state.change == PrefixChange::None && self.our_info().is_quorum(proofs)
             }
@@ -728,6 +733,12 @@ impl Chain {
                     &sec_info,
                     proofs.clone(),
                 ));
+            self.update_their_keys(&TheirKeyInfo {
+                prefix: *sec_info.prefix(),
+                version: *sec_info.version(),
+                key: self.state.our_history.last_public_key().clone(),
+            });
+
             self.state.our_infos.push((sec_info.clone(), proofs));
             if !self.is_member && sec_info.members().contains(&self.our_id) {
                 self.is_member = true;
@@ -790,7 +801,7 @@ impl Chain {
     }
 
     /// Updates `their_keys` in the shared state
-    pub fn update_their_keys(&mut self, key_info: TheirKeyInfo) {
+    pub fn update_their_keys(&mut self, key_info: &TheirKeyInfo) {
         trace!(
             "{:?} attempts to update their_keys for {:?} ",
             self.our_id(),

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     },
     proof::{Proof, ProofSet, ProvingSection},
     section_info::SectionInfo,
-    shared_state::{PrefixChange, SectionProofChain},
+    shared_state::{PrefixChange, SectionProofChain, TheirKeyInfo},
 };
 use std::fmt::{self, Debug, Formatter};
 

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{ProofSet, ProvingSection, SectionInfo};
+use super::{ProofSet, ProvingSection, SectionInfo, TheirKeyInfo};
 use crate::id::PublicId;
 use crate::parsec;
 use crate::routing_table::Prefix;
@@ -83,6 +83,9 @@ pub enum NetworkEvent {
     /// A list of proofs for a neighbour section, starting from the current section.
     ProvingSections(Vec<ProvingSection>, SectionInfo),
 
+    // Voted for received message with keys to we can update their_keys
+    TheirKeyInfo(TheirKeyInfo),
+
     // Voted for received AckMessage to update their_knowledge
     AckMessage(AckMessagePayload),
 
@@ -149,6 +152,9 @@ impl Debug for NetworkEvent {
             NetworkEvent::PurgeCandidate(ref id) => write!(formatter, "PurgeCandidate({})", id),
             NetworkEvent::ProvingSections(_, ref sec_info) => {
                 write!(formatter, "ProvingSections(_, {:?})", sec_info)
+            }
+            NetworkEvent::TheirKeyInfo(ref payload) => {
+                write!(formatter, "TheirKeyInfo({:?})", payload)
             }
             NetworkEvent::AckMessage(ref payload) => write!(formatter, "AckMessage({:?})", payload),
             NetworkEvent::SendAckMessage(ref payload) => {

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -240,7 +240,7 @@ impl SharedState {
     /// occurred in the meantime, the keys for sections covering the rest of the address space are
     /// initialised to the old key that was stored for their common ancestor
     /// NOTE: the function as it is currently is not merge-safe.
-    pub fn update_their_keys(&mut self, key_info: TheirKeyInfo) {
+    pub fn update_their_keys(&mut self, key_info: &TheirKeyInfo) {
         if let Some((&old_pfx, old_version)) = self
             .their_keys
             .iter()
@@ -268,7 +268,7 @@ impl SharedState {
                 current_pfx = current_pfx.popped().sibling();
             }
         }
-        let _ = self.their_keys.insert(key_info.prefix, key_info);
+        let _ = self.their_keys.insert(key_info.prefix, key_info.clone());
     }
 
     /// Updates the entry in `their_knowledge` for `prefix` to the `version`; if a split
@@ -533,7 +533,7 @@ mod test {
         let mut state = SharedState::new(start_section);
 
         for (prefix, version, key) in keys_to_update.iter() {
-            state.update_their_keys(TheirKeyInfo {
+            state.update_their_keys(&TheirKeyInfo {
                 prefix: *prefix,
                 version: *version as u64,
                 key: key.clone(),

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -416,6 +416,10 @@ impl SectionProofChain {
         }
     }
 
+    pub fn blocks_len(&self) -> usize {
+        self.blocks.len()
+    }
+
     pub fn push(&mut self, block: SectionProofBlock) {
         self.blocks.push(block);
     }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -119,8 +119,10 @@ impl Debug for FullSecurityMetadata {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "FullSecurityMetadata {{ sender_prefix: {:?}, proof: {:?}, .. }}",
-            self.sender_prefix, self.proof
+            "FullSecurityMetadata {{ sender_prefix: {:?}, proof.blocks_len: {}, proof: {:?}, .. }}",
+            self.sender_prefix,
+            self.proof.blocks_len(),
+            self.proof
         )
     }
 }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -17,7 +17,7 @@ use crate::{
     cache::Cache,
     chain::{
         Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload, ProvingSection, SectionInfo,
-        SendAckMessagePayload,
+        SendAckMessagePayload, TheirKeyInfo,
     },
     error::RoutingError,
     event::Event,
@@ -401,6 +401,10 @@ impl Approved for Adult {
             debug!("{} - Unhandled SectionInfo event", self);
             Ok(Transition::Stay)
         }
+    }
+
+    fn handle_their_key_info_event(&mut self, _key_info: TheirKeyInfo) -> Result<(), RoutingError> {
+        Ok(())
     }
 
     fn handle_send_ack_message_event(

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -10,7 +10,7 @@ use super::Relocated;
 use crate::{
     chain::{
         Chain, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof, ProofSet,
-        ProvingSection, SectionInfo, SendAckMessagePayload,
+        ProvingSection, SectionInfo, SendAckMessagePayload, TheirKeyInfo,
     },
     error::RoutingError,
     id::PublicId,
@@ -66,6 +66,9 @@ pub trait Approved: Relocated {
         old_pfx: Prefix<XorName>,
         outbox: &mut EventBox,
     ) -> Result<Transition, RoutingError>;
+
+    /// Handle an accumulated `TheirKeyInfo` event
+    fn handle_their_key_info_event(&mut self, key_info: TheirKeyInfo) -> Result<(), RoutingError>;
 
     /// Handle an accumulated `SendAckMessage` event
     fn handle_send_ack_message_event(
@@ -237,6 +240,9 @@ pub trait Approved: Relocated {
                         Transition::Stay => (),
                         transition => return Ok(transition),
                     }
+                }
+                NetworkEvent::TheirKeyInfo(key_info) => {
+                    self.handle_their_key_info_event(key_info)?
                 }
                 NetworkEvent::AckMessage(_payload) => {
                     // Update their_knowledge is handled within the chain.

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -2097,9 +2097,9 @@ impl Approved for Elder {
             // Vote for neighbour update if we haven't done so already.
             // vote_for_event is expected to only generate a new vote if required.
             self.vote_for_event(sec_info.clone().into_network_event());
-
-            self.vote_send_section_info_ack(sec_info)
         }
+
+        self.vote_send_section_info_ack(sec_info);
 
         let _ = self.merge_if_necessary();
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -510,13 +510,6 @@ impl Elder {
         &mut self,
         mut signed_msg: SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
-        if !signed_msg.routing_message().src.is_client() {
-            // Inform our peers about any new sections.
-            if let Some(si) = signed_msg.source_section() {
-                let _ = self.add_new_section(si);
-            }
-        }
-
         let filter_res = self
             .routing_msg_filter
             .filter_incoming(signed_msg.routing_message());
@@ -543,6 +536,13 @@ impl Elder {
                 return Err(RoutingError::UntrustedMessage);
             }
             signed_msg.check_integrity()?;
+
+            if !signed_msg.routing_message().src.is_client() {
+                // Inform our peers about any new sections.
+                if let Some(si) = signed_msg.source_section() {
+                    let _ = self.add_new_section(si);
+                }
+            }
 
             if signed_msg.routing_message().dst.is_multiple() {
                 // Broadcast to the rest of the section.

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -437,21 +437,29 @@ fn check_close_names_for_min_section_size_nodes() {
 
 #[test]
 fn check_section_info_ack() {
+    //
+    // Arrange
+    //
     let min_section_size = 8;
     let network = Network::new(min_section_size, None);
 
+    //
+    // Act
+    //
     let nodes = create_connected_nodes_until_split(&network, vec![1, 1], true);
-
-    // Due to the behaviour in the `create nodes until split`, there shall only be one section nodes
-    // sending out `section_info_ack`. Hence only one section shall consensus on it eventually.
-    let num_of_consensus = nodes
+    let node_with_sibling_knowledge: Vec<_> = nodes
         .iter()
         .filter(|node| {
             node.chain()
                 .get_their_knowldege()
                 .contains_key(&node.chain().our_prefix().sibling())
         })
-        .count();
-    assert!(num_of_consensus >= min_section_size);
-    assert!(num_of_consensus < 2 * min_section_size);
+        .map(|node| node.id())
+        .collect();
+
+    //
+    // Assert
+    //
+    let expected_all: Vec<_> = nodes.iter().map(|node| node.id()).collect();
+    assert_eq!(node_with_sibling_knowledge, expected_all);
 }


### PR DESCRIPTION
Closes #1740 
Closes #1744 
Closes #1746 

- Ensure we update their_keys/their_knowledge for ourselves so we can trust message from self section, and send minimal proof to self section: prune proof similarly when we receive an AckMessage.
- Move adding received messages src SectionInfo/SecurityMetadata only when we are the final recipient and have check the signature.
- Use new NetworkEvent to handle receiving Section Signatures:
  => Fix their_knowledge after split since we no longer ignore that version when sending Ack.
  => Ensure we get their_keys, and send AckMessage for non neighbour sections that were filtered in `add_new_section`.