### PR TITLE
Clean ups related to neighbour info

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 //! Types emulating the BLS functionality until proper BLS lands
-use super::{NetworkEvent, ProofSet, SectionInfo};
+use super::{NetworkEvent, ProofSet, SectionInfo, SectionKeyInfo};
 use crate::{
     id::{FullId, PublicId},
     QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
@@ -128,6 +128,17 @@ impl PublicKey {
 
     pub fn as_event(&self) -> parsec::Observation<NetworkEvent, PublicId> {
         parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(self.0.sec_info.clone()))
+    }
+
+    pub fn as_section_key_info(&self) -> SectionKeyInfo {
+        // Because of the current implementation all the required information is in the stored
+        // SectionInfo that is also trusted. When moving to real BLS, we will likely need to store
+        // and sign TheirKeyInfo into the SectionProofChain
+        SectionKeyInfo {
+            prefix: *self.0.sec_info.prefix(),
+            version: *self.0.sec_info.version(),
+            key: self.clone(),
+        }
     }
 }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -864,8 +864,11 @@ impl Chain {
                 }
 
                 // Remove older compatible neighbour prefixes.
+                // DO NOT SUPPORT MERGE: Not consider newer if the older one was extension (split).
                 let is_newer = |(other_pfx, other_sec_info): (&Prefix<XorName>, &SectionInfo)| {
-                    other_pfx.is_compatible(pfx) && other_sec_info.version() > sec_info.version()
+                    other_pfx.is_compatible(pfx)
+                        && other_sec_info.version() > sec_info.version()
+                        && !pfx.is_extension_of(other_pfx)
                 };
 
                 if self.state.neighbour_infos.iter().any(is_newer) {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -8,7 +8,7 @@
 
 use super::{
     candidate::Candidate,
-    shared_state::{PrefixChange, SectionProofBlock, SharedState, TheirKeyInfo},
+    shared_state::{PrefixChange, SectionKeyInfo, SectionProofBlock, SharedState},
     GenesisPfxInfo, NetworkEvent, OnlinePayload, Proof, ProofSet, SectionInfo, SectionProofChain,
 };
 use crate::{
@@ -495,7 +495,7 @@ impl Chain {
     }
 
     /// Return the keys we know
-    pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &TheirKeyInfo)> {
+    pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
         self.state.get_their_keys_info()
     }
 
@@ -730,7 +730,7 @@ impl Chain {
                     &sec_info,
                     proofs.clone(),
                 ));
-            self.update_their_keys(&TheirKeyInfo {
+            self.update_their_keys(&SectionKeyInfo {
                 prefix: *sec_info.prefix(),
                 version: *sec_info.version(),
                 key: self.state.our_history.last_public_key().clone(),
@@ -798,7 +798,7 @@ impl Chain {
     }
 
     /// Updates `their_keys` in the shared state
-    pub fn update_their_keys(&mut self, key_info: &TheirKeyInfo) {
+    pub fn update_their_keys(&mut self, key_info: &SectionKeyInfo) {
         trace!(
             "{:?} attempts to update their_keys for {:?} ",
             self.our_id(),

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     },
     proof::{Proof, ProofSet},
     section_info::SectionInfo,
-    shared_state::{PrefixChange, SectionProofChain, TheirKeyInfo},
+    shared_state::{PrefixChange, SectionKeyInfo, SectionProofChain},
 };
 use std::fmt::{self, Debug, Formatter};
 

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{ProofSet, SectionInfo, TheirKeyInfo};
+use super::{ProofSet, SectionInfo, SectionKeyInfo};
 use crate::id::PublicId;
 use crate::parsec;
 use crate::routing_table::Prefix;
@@ -81,7 +81,7 @@ pub enum NetworkEvent {
     PurgeCandidate(PublicId),
 
     // Voted for received message with keys to we can update their_keys
-    TheirKeyInfo(TheirKeyInfo),
+    TheirKeyInfo(SectionKeyInfo),
 
     // Voted for received AckMessage to update their_knowledge
     AckMessage(AckMessagePayload),

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -142,6 +142,15 @@ impl SectionInfo {
         NetworkEvent::SectionInfo(self)
     }
 
+    #[cfg(test)]
+    pub fn new_for_test(
+        members: BTreeSet<PublicId>,
+        prefix: Prefix<XorName>,
+        version: u64,
+    ) -> Result<Self, RoutingError> {
+        Self::new_with_fields(members, version, prefix, BTreeSet::new())
+    }
+
     /// Creates a new instance with the given fields, and computes its hash.
     fn new_with_fields(
         members: BTreeSet<PublicId>,

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -58,6 +58,9 @@ impl SharedState {
     pub fn new(section_info: SectionInfo) -> Self {
         let pk = BlsPublicKey::from_section_info(&section_info);
         let our_history = SectionProofChain::from_genesis(pk);
+        let their_key_info = our_history.last_public_key().as_section_key_info();
+        let their_keys = iter::once((their_key_info.prefix, their_key_info)).collect();
+
         Self {
             new_info: section_info.clone(),
             our_infos: NonEmptyList::new((section_info, Default::default())),
@@ -66,7 +69,7 @@ impl SharedState {
             split_cache: None,
             merging: Default::default(),
             our_history,
-            their_keys: Default::default(),
+            their_keys,
             their_knowledge: Default::default(),
             their_recent_keys: Default::default(),
         }
@@ -234,6 +237,17 @@ impl SharedState {
         };
 
         neighbour_infos.into_iter().any(needs_merge)
+    }
+
+    pub fn push_our_new_info(&mut self, sec_info: SectionInfo, proofs: ProofSet) {
+        self.our_history
+            .push(SectionProofBlock::from_sec_info_with_proofs(
+                &sec_info,
+                proofs.clone(),
+            ));
+        self.our_infos.push((sec_info, proofs));
+
+        self.update_their_keys(&self.our_history.last_public_key().as_section_key_info());
     }
 
     /// Updates the entry in `their_keys` for `prefix` to the latest known key; if a split
@@ -480,74 +494,72 @@ mod test {
     use std::str::FromStr;
     use unwrap::unwrap;
 
-    fn gen_section_info(pfx: Prefix<XorName>) -> SectionInfo {
+    fn gen_section_info(pfx: Prefix<XorName>, version: u64) -> SectionInfo {
         let sec_size = 5;
         let mut members = BTreeSet::new();
         for _ in 0..sec_size {
             let id = FullId::within_range(&pfx.range_inclusive());
             let _ = members.insert(*id.public_id());
         }
-        unwrap!(SectionInfo::new(members, pfx, None))
-    }
-
-    fn gen_pk(pfx: Prefix<XorName>) -> BlsPublicKey {
-        BlsPublicKey::from_section_info(&gen_section_info(pfx))
+        unwrap!(SectionInfo::new_for_test(members, pfx, version))
     }
 
     // start_pfx: the prefix of our section as string
-    // updates: the prefixes of the sections we update the keys for, in sequence; every entry in
-    //          the vector will get its own key
+    // updates: our section prefix followed by the prefixes of the sections we update the keys for,
+    //          in sequence; every entry in the vector will get its own key.
     // expected: vec of pairs (prefix, index)
     //           the prefix is the prefix of the section whose key we check
     //           the index is the index in the `updates` vector, which should have generated the
     //           key we expect to get for the given prefix
-    fn update_keys_and_check(start_pfx: &str, updates: Vec<&str>, expected: Vec<(&str, usize)>) {
-        update_keys_and_check_with_version(
-            start_pfx,
-            updates.into_iter().enumerate().collect(),
-            expected,
-        )
+    fn update_keys_and_check(updates: Vec<&str>, expected: Vec<(&str, usize)>) {
+        update_keys_and_check_with_version(updates.into_iter().enumerate().collect(), expected)
     }
 
     fn update_keys_and_check_with_version(
-        start_pfx: &str,
         updates: Vec<(usize, &str)>,
         expected: Vec<(&str, usize)>,
     ) {
+        //
+        // Arrange
+        //
         let keys_to_update = updates
             .into_iter()
             .map(|(version, pfx_str)| {
                 let pfx = unwrap!(Prefix::<XorName>::from_str(pfx_str));
-                (pfx, version, gen_pk(pfx))
+                let sec_info = gen_section_info(pfx, version as u64);
+                let pk = BlsPublicKey::from_section_info(&sec_info);
+                (pk, sec_info)
             })
             .collect::<Vec<_>>();
         let expected_keys = expected
             .into_iter()
             .map(|(pfx_str, index)| {
                 let pfx = unwrap!(Prefix::<XorName>::from_str(pfx_str));
-                (pfx, Some(index)) // keys_to_update[index].2.clone())
+                (pfx, Some(index))
             })
             .collect::<Vec<_>>();
 
-        let start_section = gen_section_info(unwrap!(Prefix::from_str(start_pfx)));
-        let mut state = SharedState::new(start_section);
+        let mut state = {
+            let start_section = unwrap!(keys_to_update.first()).1.clone();
+            SharedState::new(start_section)
+        };
 
-        for (prefix, version, key) in keys_to_update.iter() {
-            state.update_their_keys(&SectionKeyInfo {
-                prefix: *prefix,
-                version: *version as u64,
-                key: key.clone(),
-            });
+        //
+        // Act
+        //
+        for (key, _) in keys_to_update.iter().skip(1) {
+            state.update_their_keys(&key.as_section_key_info());
         }
 
+        //
+        // Assert
+        //
         let actual_keys = state
             .get_their_keys_info()
             .map(|(p, info)| {
                 (
                     *p,
-                    keys_to_update
-                        .iter()
-                        .position(|(_, _, key)| *key == info.key),
+                    keys_to_update.iter().position(|(key, _)| *key == info.key),
                 )
             })
             .collect::<Vec<_>>();
@@ -558,9 +570,8 @@ mod test {
     #[test]
     fn single_prefix_multiple_updates() {
         update_keys_and_check(
-            "0",
-            vec!["1", "1", "1", "1"],
-            vec![("1", 3), ("1", 2), ("1", 1), ("1", 0)],
+            vec!["0", "1", "1", "1", "1"],
+            vec![("0", 0), ("1", 4), ("1", 3), ("1", 2), ("1", 1)],
         );
     }
 
@@ -568,18 +579,16 @@ mod test {
     fn single_prefix_multiple_updates_out_of_order() {
         // Late version ignored
         update_keys_and_check_with_version(
-            "0",
-            vec![(0, "1"), (2, "1"), (1, "1"), (3, "1")],
-            vec![("1", 3), ("1", 1), ("1", 0)],
+            vec![(0, "0"), (0, "1"), (2, "1"), (1, "1"), (3, "1")],
+            vec![("0", 0), ("1", 4), ("1", 2), ("1", 1)],
         );
     }
 
     #[test]
     fn simple_split() {
         update_keys_and_check(
-            "0",
-            vec!["10", "11", "101"],
-            vec![("100", 0), ("101", 2), ("11", 1), ("10", 0)],
+            vec!["0", "10", "11", "101"],
+            vec![("0", 0), ("100", 1), ("101", 3), ("11", 2), ("10", 1)],
         );
     }
 
@@ -587,35 +596,34 @@ mod test {
     fn simple_split_out_of_order() {
         // Late version ignored
         update_keys_and_check_with_version(
-            "0",
-            vec![(5, "10"), (5, "11"), (7, "101"), (6, "10")],
-            vec![("100", 0), ("101", 2), ("11", 1), ("10", 0)],
+            vec![(0, "0"), (5, "10"), (5, "11"), (7, "101"), (6, "10")],
+            vec![("0", 0), ("100", 1), ("101", 3), ("11", 2), ("10", 1)],
         );
     }
 
     #[test]
     fn our_section_not_sibling_of_ancestor() {
+        // 01 Not the sibling of the single bit parent prefix of 111
         update_keys_and_check(
-            "01", // Not the sibling of the single bit parent prefix of 111
-            vec!["1", "111"],
-            vec![("10", 0), ("110", 0), ("111", 1), ("1", 0)],
+            vec!["01", "1", "111"],
+            vec![("01", 0), ("10", 1), ("110", 1), ("111", 2), ("1", 1)],
         );
     }
 
     #[test]
     fn multiple_split() {
         update_keys_and_check(
-            "0",
-            vec!["1", "1011001"],
+            vec!["0", "1", "1011001"],
             vec![
-                ("100", 0),
-                ("1010", 0),
-                ("1011000", 0),
-                ("1011001", 1),
-                ("101101", 0),
-                ("10111", 0),
-                ("11", 0),
-                ("1", 0),
+                ("0", 0),
+                ("100", 1),
+                ("1010", 1),
+                ("1011000", 1),
+                ("1011001", 2),
+                ("101101", 1),
+                ("10111", 1),
+                ("11", 1),
+                ("1", 1),
             ],
         );
     }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -47,11 +47,11 @@ pub struct SharedState {
     /// Our section's key history for Secure Message Delivery
     pub our_history: SectionProofChain,
     /// BLS public keys of other sections
-    pub their_keys: BTreeMap<Prefix<XorName>, TheirKeyInfo>,
+    pub their_keys: BTreeMap<Prefix<XorName>, SectionKeyInfo>,
     /// Other sections' knowledge of us
     pub their_knowledge: BTreeMap<Prefix<XorName>, u64>,
     /// Recent keys removed from their_keys
-    pub their_recent_keys: VecDeque<(Prefix<XorName>, TheirKeyInfo)>,
+    pub their_recent_keys: VecDeque<(Prefix<XorName>, SectionKeyInfo)>,
 }
 
 impl SharedState {
@@ -240,7 +240,7 @@ impl SharedState {
     /// occurred in the meantime, the keys for sections covering the rest of the address space are
     /// initialised to the old key that was stored for their common ancestor
     /// NOTE: the function as it is currently is not merge-safe.
-    pub fn update_their_keys(&mut self, key_info: &TheirKeyInfo) {
+    pub fn update_their_keys(&mut self, key_info: &SectionKeyInfo) {
         if let Some((&old_pfx, old_version)) = self
             .their_keys
             .iter()
@@ -308,7 +308,7 @@ impl SharedState {
     }
 
     /// Returns the reference to their_keys and any recent keys we still hold.
-    pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &TheirKeyInfo)> {
+    pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
         self.their_keys
             .iter()
             .chain(self.their_recent_keys.iter().map(|(p, k)| (p, k)))
@@ -466,7 +466,7 @@ impl SectionProofChain {
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
-pub struct TheirKeyInfo {
+pub struct SectionKeyInfo {
     pub prefix: Prefix<XorName>,
     pub version: u64,
     pub key: BlsPublicKey,
@@ -533,7 +533,7 @@ mod test {
         let mut state = SharedState::new(start_section);
 
         for (prefix, version, key) in keys_to_update.iter() {
-            state.update_their_keys(&TheirKeyInfo {
+            state.update_their_keys(&SectionKeyInfo {
                 prefix: *prefix,
                 version: *version as u64,
                 key: key.clone(),

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -16,8 +16,8 @@ use super::{
 use crate::{
     cache::Cache,
     chain::{
-        Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload, SectionInfo,
-        SendAckMessagePayload, TheirKeyInfo,
+        Chain, ExpectCandidatePayload, GenesisPfxInfo, OnlinePayload, SectionInfo, SectionKeyInfo,
+        SendAckMessagePayload,
     },
     error::RoutingError,
     event::Event,
@@ -403,7 +403,10 @@ impl Approved for Adult {
         }
     }
 
-    fn handle_their_key_info_event(&mut self, _key_info: TheirKeyInfo) -> Result<(), RoutingError> {
+    fn handle_their_key_info_event(
+        &mut self,
+        _key_info: SectionKeyInfo,
+    ) -> Result<(), RoutingError> {
         Ok(())
     }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -10,7 +10,7 @@ use super::Relocated;
 use crate::{
     chain::{
         Chain, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof, ProofSet, SectionInfo,
-        SendAckMessagePayload, TheirKeyInfo,
+        SectionKeyInfo, SendAckMessagePayload,
     },
     error::RoutingError,
     id::PublicId,
@@ -68,7 +68,8 @@ pub trait Approved: Relocated {
     ) -> Result<Transition, RoutingError>;
 
     /// Handle an accumulated `TheirKeyInfo` event
-    fn handle_their_key_info_event(&mut self, key_info: TheirKeyInfo) -> Result<(), RoutingError>;
+    fn handle_their_key_info_event(&mut self, key_info: SectionKeyInfo)
+        -> Result<(), RoutingError>;
 
     /// Handle an accumulated `SendAckMessage` event
     fn handle_send_ack_message_event(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     chain::{
         delivery_group_size, AckMessagePayload, Chain, ExpectCandidatePayload, GenesisPfxInfo,
         NetworkEvent, OnlinePayload, PrefixChange, PrefixChangeOutcome, SectionInfo,
-        SendAckMessagePayload, TheirKeyInfo,
+        SectionKeyInfo, SendAckMessagePayload,
     },
     config_handler,
     error::{BootstrapResponseError, InterfaceError, RoutingError},
@@ -1181,7 +1181,7 @@ impl Elder {
         });
 
         if new_key_info {
-            self.vote_for_event(NetworkEvent::TheirKeyInfo(TheirKeyInfo {
+            self.vote_for_event(NetworkEvent::TheirKeyInfo(SectionKeyInfo {
                 prefix: *sec_info.prefix(),
                 version: *sec_info.version(),
                 key: BlsPublicKey::from_section_info(&sec_info),
@@ -2078,7 +2078,10 @@ impl Approved for Elder {
         Ok(Transition::Stay)
     }
 
-    fn handle_their_key_info_event(&mut self, key_info: TheirKeyInfo) -> Result<(), RoutingError> {
+    fn handle_their_key_info_event(
+        &mut self,
+        key_info: SectionKeyInfo,
+    ) -> Result<(), RoutingError> {
         self.vote_send_section_info_ack(SendAckMessagePayload {
             ack_prefix: key_info.prefix,
             ack_version: key_info.version,

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -443,7 +443,7 @@ impl Elder {
     fn send_neighbour_infos(&mut self) {
         self.chain.other_prefixes().iter().for_each(|pfx| {
             let payload = *self.chain.our_info().hash();
-            let src = Authority::ManagedNode(*self.full_id.public_id().name());
+            let src = Authority::Section(self.our_prefix().name());
             let dst = Authority::PrefixSection(*pfx);
             let content = MessageContent::NeighbourInfo(payload);
             if let Err(err) = self.send_routing_message(src, dst, content) {
@@ -603,7 +603,7 @@ impl Elder {
                 src @ ManagedNode(_),
                 dst @ ManagedNode(_),
             ) => self.handle_connection_request(&encrypted_conn_info, pub_id, src, dst, outbox),
-            (NeighbourInfo(_digest), ManagedNode(_), PrefixSection(_)) => Ok(()),
+            (NeighbourInfo(_digest), Section(_), PrefixSection(_)) => Ok(()),
             (Merge(digest), PrefixSection(_), PrefixSection(_)) => self.handle_merge(digest),
             (UserMessage { content, .. }, src, dst) => {
                 outbox.send_event(content.into_event(src, dst));


### PR DESCRIPTION
Prepare to address https://github.com/maidsafe/routing/issues/1748.

-NeighbourInfo sent as a Section message like other messages so we can trust the content and reduce number of messages
-Rename to SectionKeyInfo as it will be used in multiple context to address #1748 
-Clean up handling of message from self, ensuring their_keys are propulated with our keys from the very first block.