### PR TITLE
use security metadata and remove src section

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -500,17 +500,18 @@ impl Chain {
     }
 
     /// Returns `true` if the `proof_chain` contains a key we have in `their_keys` and that key is
-    /// for a prefix compatible with `prefix`
-    pub fn check_trust(&self, prefix: &Prefix<XorName>, proof_chain: &SectionProofChain) -> bool {
+    /// for a prefix compatible with proof_chain prefix.
+    pub fn check_trust(&self, proof_chain: &SectionProofChain) -> bool {
+        let last_prefix = proof_chain.last_public_key_info().prefix();
         let filtered_keys: BTreeSet<_> = self
             .state
             .get_their_keys_info()
-            .filter(|&(pfx, _)| prefix.is_compatible(pfx))
-            .map(|(_, info)| &info.key)
+            .filter(|&(pfx, _)| last_prefix.is_compatible(pfx))
+            .map(|(_, info)| info)
             .collect();
         proof_chain
-            .all_keys()
-            .any(|key| filtered_keys.contains(key))
+            .all_key_infos()
+            .any(|key_info| filtered_keys.contains(key_info))
     }
 
     /// Returns `true` if the `SectionInfo` isn't known to us yet.

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -442,7 +442,7 @@ fn packet_is_parsec_gossip() {
             message_id: MessageId::new(),
         },
     };
-    let msg = SignedRoutingMessage::insecure(msg, None);
+    let msg = SignedRoutingMessage::insecure(msg);
     let msg = unwrap!(HopMessage::new(msg));
     let msg = Message::Hop(msg);
     assert!(!Packet::Message(NetworkBytes::from(serialise(&msg)), 0).is_parsec_gossip());

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -74,7 +74,7 @@ impl SignatureAccumulator {
 mod tests {
     use super::*;
     use crate::{
-        chain::{SectionInfo, SectionProofChain},
+        chain::{SectionInfo, SectionKeyInfo, SectionProofChain},
         id::{FullId, PublicId},
         messages::{
             DirectMessage, MessageContent, RoutingMessage, SignedDirectMessage,
@@ -113,12 +113,12 @@ mod tests {
             let prefix = Prefix::new(0, *unwrap!(all_ids.iter().next()).name());
             let sec_info = unwrap!(SectionInfo::new(all_ids, prefix, None));
             let pk_set = BlsPublicKeySet::from_section_info(sec_info.clone());
-            let proof = SectionProofChain::from_genesis(pk_set.public_key());
+            let key_info = SectionKeyInfo::from_section_info(&sec_info);
+            let proof = SectionProofChain::from_genesis(key_info);
             let signed_msg = unwrap!(SignedRoutingMessage::new(
                 routing_msg.clone(),
                 msg_sender_id,
                 sec_info.clone(),
-                &prefix,
                 pk_set.clone(),
                 proof.clone(),
             ));
@@ -129,7 +129,6 @@ mod tests {
                             routing_msg.clone(),
                             id,
                             sec_info.clone(),
-                            &prefix,
                             pk_set.clone(),
                             proof.clone(),
                         ))),

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -118,7 +118,6 @@ mod tests {
             let signed_msg = unwrap!(SignedRoutingMessage::new(
                 routing_msg.clone(),
                 msg_sender_id,
-                sec_info.clone(),
                 pk_set.clone(),
                 proof.clone(),
             ));
@@ -128,7 +127,6 @@ mod tests {
                         DirectMessage::MessageSignature(unwrap!(SignedRoutingMessage::new(
                             routing_msg.clone(),
                             id,
-                            sec_info.clone(),
                             pk_set.clone(),
                             proof.clone(),
                         ))),

--- a/src/states/common/bootstrapped_not_established.rs
+++ b/src/states/common/bootstrapped_not_established.rs
@@ -70,7 +70,7 @@ pub trait BootstrappedNotEstablished: Bootstrapped {
             }
         };
 
-        let signed_msg = SignedRoutingMessage::insecure(routing_msg, None);
+        let signed_msg = SignedRoutingMessage::insecure(routing_msg);
 
         if !self.filter_outgoing_routing_msg(signed_msg.routing_message(), &proxy_pub_id) {
             let message = self.to_hop_message(signed_msg.clone())?;


### PR DESCRIPTION
Closes #1748 

src_section should not be part of SignedRoutingMessage. In order to remove it we need to first use security_metadata to update `their_keys`, second send the SectionInfo with NeighbourInfo.

The first commit restructure the code so the SectionProofChain contain the needed info to update their_keys. (BlsPublicKey, Version, Prefix, all held in SectionKeyInfo). All this info should be signed by the proof contained in SectionProofChain. Currently this is done by holding on to a signed SectionInfo under the hood. When using real BLS, we will need to sign the SectionKeyInfo, and that SectionKeyInfo will directly contain BlsPublicKey, Version, Prefix.

The second commit update NeighbourInfo, and remove the use of src_section.

