### PR TITLE
feat/routing: sign and check single source message with ED key

### DIFF
--- a/src/routing_table/authority.rs
+++ b/src/routing_table/authority.rs
@@ -8,6 +8,7 @@
 
 use super::{Prefix, Xorable};
 use crate::id::PublicId;
+use crate::xor_name::XorName;
 use std::fmt::{self, Binary, Debug, Display, Formatter};
 
 /// An entity that can act as a source or destination of a message.
@@ -92,6 +93,21 @@ impl<N: Xorable + Clone + Copy + Binary + Default> Authority<N> {
                 ref proxy_node_name,
                 ..
             } => *proxy_node_name,
+        }
+    }
+}
+
+impl Authority<XorName> {
+    /// provide the name mathching a single node's public key
+    pub fn single_signing_name(&self) -> Option<&XorName> {
+        match *self {
+            Authority::ClientManager(_)
+            | Authority::NaeManager(_)
+            | Authority::Section(_)
+            | Authority::PrefixSection(_)
+            | Authority::NodeManager(_) => None,
+            Authority::ManagedNode(ref name) => Some(name),
+            Authority::Client { ref client_id, .. } => Some(client_id.name()),
         }
     }
 }

--- a/src/states/common/relocated.rs
+++ b/src/states/common/relocated.rs
@@ -86,10 +86,15 @@ pub trait Relocated: Bootstrapped {
         &mut self,
         encrypted_their_conn_info: &[u8],
         their_pub_id: PublicId,
-        _src: Authority<XorName>,
+        src: Authority<XorName>,
         _dst: Authority<XorName>,
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
+        if src.single_signing_name() != Some(their_pub_id.name()) {
+            // Connection info not from the source node.
+            return Err(RoutingError::InvalidMessage);
+        }
+
         let shared_secret = self
             .full_id()
             .encrypting_private_key()

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1815,7 +1815,7 @@ impl Bootstrapped for Elder {
 
         // If the source is single, we don't even need to send signatures, so let's cut this short
         if !routing_msg.src.is_multiple() {
-            let mut msg = SignedRoutingMessage::insecure(routing_msg.clone());
+            let mut msg = SignedRoutingMessage::single_source(routing_msg, &self.full_id)?;
             if self.in_authority(&msg.routing_message().dst) {
                 self.handle_signed_message(msg)?;
             } else {


### PR DESCRIPTION
Closes #1738 

- This only provide moderate additional security: We validate that the
  'src' of the message has signed the message (src+dst+content).
- Also use that to check that new connection are comming from the 'src'.

Note: For ManagedNodes (but not for Client Authority), it would be
possible to ensure the node is a valid member of a section
(https://github.com/maidsafe/routing/issues/1751).

Note: We are still allowing untrusted communication. We will need to
ensure that we do not treat untrusted communication as trusted (see
https://github.com/maidsafe/routing/issues/1756)

Test:
Clippy + soak test