### PR TITLE
feat/routing: do not implicitly trust unsigned messages

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -242,8 +242,9 @@ impl SignedRoutingMessage {
     /// Confirms the signatures.
     pub fn check_integrity(&self) -> Result<()> {
         match self.security_metadata {
-            SecurityMetadata::None => Ok(()),
-            SecurityMetadata::Partial(_) => Err(RoutingError::FailedSignature),
+            SecurityMetadata::None | SecurityMetadata::Partial(_) => {
+                Err(RoutingError::FailedSignature)
+            }
             SecurityMetadata::Single(ref security_metadata) => {
                 if self.content.src.single_signing_name()
                     != Some(security_metadata.public_id.name())
@@ -800,7 +801,7 @@ mod tests {
 
         signed_msg.security_metadata = SecurityMetadata::None;
 
-        assert!(signed_msg.check_integrity().is_ok());
+        assert!(signed_msg.check_integrity().is_err());
     }
 
     #[test]

--- a/src/states/common/bootstrapped_not_established.rs
+++ b/src/states/common/bootstrapped_not_established.rs
@@ -70,7 +70,7 @@ pub trait BootstrappedNotEstablished: Bootstrapped {
             }
         };
 
-        let signed_msg = SignedRoutingMessage::insecure(routing_msg);
+        let signed_msg = SignedRoutingMessage::single_source(routing_msg, self.full_id())?;
 
         if !self.filter_outgoing_routing_msg(signed_msg.routing_message(), &proxy_pub_id) {
             let message = self.to_hop_message(signed_msg.clone())?;


### PR DESCRIPTION
Closes #1756 

All routing messages should be signed as we then use the content to
make decision within routing base on the accuracy on the information.

Unsigned messages need to be handled separately as we cannot trust its
content. Currently they are not used, but for Vault to send RMD messages
this will probably be unsigned messages (though they could also be
single source signed like we do for relocate requests here).

Test:
Clippy + soak test