### PR TITLE
Move unit test to mock_base

### DIFF
--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -219,7 +219,7 @@ impl SignedDirectMessage {
     }
 
     /// Content of the message.
-    #[cfg(any(test, feature = "mock_serialise"))]
+    #[cfg(any(all(test, feature = "mock_base"), feature = "mock_serialise"))]
     pub fn content(&self) -> &DirectMessage {
         &self.content
     }

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -71,6 +71,7 @@ impl SignatureAccumulator {
 }
 
 #[cfg(test)]
+#[cfg(feature = "mock_base")]
 mod tests {
     use super::*;
     use crate::{


### PR DESCRIPTION
The test `section_src_add_signature_last` relies on using using mocked time.

Fixes `cargo test` when run without `mock`.