### PR TITLE
Change the threshold in BLS to just one third of the members

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -11,8 +11,11 @@ use super::{ProofSet, SectionInfo};
 use crate::id::{FullId, PublicId};
 use std::{collections::BTreeMap, fmt};
 
-const THRESHOLD_NUMERATOR: usize = 1;
-const THRESHOLD_DENOMINATOR: usize = 3;
+/// The BLS scheme will require more than `THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR`
+/// shares in order to construct a full key or signature.
+pub const THRESHOLD_NUMERATOR: usize = 1;
+/// See `THRESHOLD_NUMERATOR`.
+pub const THRESHOLD_DENOMINATOR: usize = 3;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -8,11 +8,11 @@
 
 //! Types emulating the BLS functionality until proper BLS lands
 use super::{ProofSet, SectionInfo};
-use crate::{
-    id::{FullId, PublicId},
-    QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
-};
+use crate::id::{FullId, PublicId};
 use std::{collections::BTreeMap, fmt};
+
+const THRESHOLD_NUMERATOR: usize = 1;
+const THRESHOLD_DENOMINATOR: usize = 3;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {
@@ -63,7 +63,7 @@ impl PublicKeyShare {
 
 impl PublicKeySet {
     pub fn from_section_info(sec_info: SectionInfo) -> Self {
-        let threshold = sec_info.members().len() * QUORUM_NUMERATOR / QUORUM_DENOMINATOR;
+        let threshold = sec_info.members().len() * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
         Self {
             threshold,
             sec_info,
@@ -161,7 +161,7 @@ mod test {
     #[test]
     fn test_signature() {
         let section_size = 10;
-        let min_sigs = section_size * QUORUM_NUMERATOR / QUORUM_DENOMINATOR + 1;
+        let min_sigs = section_size * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR + 1;
 
         let (pk_set, sk_shares) = gen_section(section_size);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,9 @@ pub(crate) use self::{
     quic_p2p::{Event as NetworkEvent, Peer as ConnectionInfo, QuicP2p},
 };
 
+#[cfg(feature = "mock_base")]
+pub use self::chain::bls_emu::{THRESHOLD_DENOMINATOR, THRESHOLD_NUMERATOR};
+
 #[cfg(test)]
 mod tests {
     use super::{QUORUM_DENOMINATOR, QUORUM_NUMERATOR};

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -209,7 +209,11 @@ mod tests {
             });
         });
 
-        assert_eq!(count, expected_msgs_count);
+        // we expect every message to accumulate twice - as we will accumulate 8 signatures, and 3
+        // are enough to construct a fully signed message; once we get the first 3 signatures, the
+        // message will accumulate, get removed from the accumulator, and the remaining 5 sigs are
+        // enough for it to accumulate again
+        assert_eq!(count, expected_msgs_count * 2);
 
         FakeClock::advance_time(ACCUMULATION_TIMEOUT.as_secs() * 1000 + 1000);
 


### PR DESCRIPTION
This makes the emulated BLS more compatible with the real BLS. Some tests had to be updated, because they were making explicit assumptions about the number of signatures needed for a message to accumulate.

Parts of the `messages_accumulate_with_quorum` test are being removed, because they became irrelevant. The reason is explained below.

In earlier versions of the code, only the accumulating nodes would generate the full message, and the others would only send signed hashes. Because of that, a message couldn't accumulate until an accumulating node also generated a signature and the message itself along with it. That's the case these parts of the code were testing.

However, since RMD and SMD, all nodes send full messages when they send signatures. This means that the case they were testing is now impossible - whichever nodes send the signatures, the full message is available and it should accumulate correctly. So these pieces of code are now irrelevant.

What was happening prior to this removal was that if no accumulating node signed the message (accumulating nodes being the ones that were a part of the delivery group), there wasn't enough of the other nodes for the message to accumulate, as there was N/3 accumulating nodes, and we required over 2N/3 signatures for a message to accumulate. This wasn't really what the code intended to test, but the test still worked.

This now changes, though - N/3 signatures are enough, which means that other nodes' signatures are enough and this code makes no sense whatsoever. That's why it is being removed.

Closes #1770 .