### PR TITLE
Detect if PARSEC needs pruning

### DIFF
--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -256,21 +256,23 @@ where
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-pub struct Request<T: NetworkEvent, P: PublicId>(PhantomData<(T, P)>);
+// Contains an additional `u8` so that the size is > 0. This is needed when counting sizes to
+// determine parsec graph pruning.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, Default)]
+pub struct Request<T: NetworkEvent, P: PublicId>(PhantomData<(T, P)>, u8);
 
 impl<T: NetworkEvent, P: PublicId> Request<T, P> {
-    fn new() -> Self {
-        Request(PhantomData)
+    pub fn new() -> Self {
+        Request(PhantomData, 1)
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-pub struct Response<T: NetworkEvent, P: PublicId>(PhantomData<(T, P)>);
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, Default)]
+pub struct Response<T: NetworkEvent, P: PublicId>(PhantomData<(T, P)>, u8);
 
 impl<T: NetworkEvent, P: PublicId> Response<T, P> {
-    fn new() -> Self {
-        Response(PhantomData)
+    pub fn new() -> Self {
+        Response(PhantomData, 1)
     }
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -15,25 +15,59 @@ use crate::{
     utils::LogIdent,
 };
 use log::LogLevel;
+use maidsafe_utilities::serialisation;
 #[cfg(not(feature = "mock_parsec"))]
 use parsec as inner;
 use rand::Rng;
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    fmt,
+};
 
 #[cfg(feature = "mock_parsec")]
 pub use crate::mock::parsec::{
-    init_mock, ConsensusMode, NetworkEvent, Observation, Proof, PublicId, SecretId,
+    init_mock, ConsensusMode, Error, NetworkEvent, Observation, Proof, PublicId, SecretId,
 };
 #[cfg(not(feature = "mock_parsec"))]
-pub use parsec::{ConsensusMode, NetworkEvent, Observation, Proof, PublicId, SecretId};
+pub use parsec::{ConsensusMode, Error, NetworkEvent, Observation, Proof, PublicId, SecretId};
 
 pub type Block = inner::Block<chain::NetworkEvent, id::PublicId>;
 pub type Parsec = inner::Parsec<chain::NetworkEvent, FullId>;
 pub type Request = inner::Request<chain::NetworkEvent, id::PublicId>;
 pub type Response = inner::Response<chain::NetworkEvent, id::PublicId>;
 
+// TODO: we'll set PARSEC_SIZE_LIMIT to 1 GB once it's used outside of mock_parsec
+//#[cfg(not(feature = "mock_parsec"))]
+//const PARSEC_SIZE_LIMIT: u64 = 1_000_000_000;
+// Mock parsec request/responses are much smaller, so we need a lower limit.
+// TODO: once it's used outside of tests, this should be changed to cfg(feature = "mock_parsec")
+#[cfg(all(test, feature = "mock_parsec"))]
+const PARSEC_SIZE_LIMIT: u64 = 100;
+
+// Keep track of size in case we need to prune.
+#[derive(Default, Debug, PartialEq, Eq)]
+struct ParsecSizeCounter(u64);
+
+impl ParsecSizeCounter {
+    fn increase_size(&mut self, size: u64) {
+        self.0 += size;
+    }
+
+    #[cfg(all(test, feature = "mock_parsec"))]
+    fn needs_pruning(&self) -> bool {
+        self.0 > PARSEC_SIZE_LIMIT
+    }
+}
+
+impl fmt::Display for ParsecSizeCounter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "size: {}", self.0)
+    }
+}
+
 pub struct ParsecMap {
     map: BTreeMap<u64, Parsec>,
+    size_counter: ParsecSizeCounter,
 }
 
 impl ParsecMap {
@@ -43,13 +77,15 @@ impl ParsecMap {
             *gen_pfx_info.first_info.version(),
             create(full_id, gen_pfx_info),
         );
+        let size_counter = ParsecSizeCounter::default();
 
-        Self { map }
+        Self { map, size_counter }
     }
 
     pub fn init(&mut self, full_id: FullId, gen_pfx_info: &GenesisPfxInfo, log_ident: &LogIdent) {
         if let Entry::Vacant(entry) = self.map.entry(*gen_pfx_info.first_info.version()) {
             let _ = entry.insert(create(full_id, gen_pfx_info));
+            self.size_counter = ParsecSizeCounter::default();
             info!(
                 "{}: Init new Parsec, genesis = {:?}",
                 log_ident, gen_pfx_info
@@ -64,6 +100,13 @@ impl ParsecMap {
         pub_id: id::PublicId,
         log_ident: &LogIdent,
     ) -> (Option<DirectMessage>, bool) {
+        // Increase the size before fetching the parsec to satisfy the borrow checker
+        self.count_size(
+            serialisation::serialised_size(&request),
+            msg_version,
+            log_ident,
+        );
+
         let parsec = if let Some(parsec) = self.map.get_mut(&msg_version) {
             parsec
         } else {
@@ -90,6 +133,13 @@ impl ParsecMap {
         pub_id: id::PublicId,
         log_ident: &LogIdent,
     ) -> bool {
+        // Increase the size before fetching the parsec to satisfy the borrow checker
+        self.count_size(
+            serialisation::serialised_size(&response),
+            msg_version,
+            log_ident,
+        );
+
         let parsec = if let Some(parsec) = self.map.get_mut(&msg_version) {
             parsec
         } else {
@@ -169,6 +219,22 @@ impl ParsecMap {
 
         parsec.has_unpolled_observations()
     }
+
+    fn count_size(&mut self, size: u64, msg_version: u64, log_ident: &LogIdent) {
+        if self.last_version() == msg_version && self.map.contains_key(&msg_version) {
+            self.size_counter.increase_size(size);
+            trace!(
+                "{} - Parsec size is now estimated to: {}.",
+                log_ident,
+                self.size_counter,
+            );
+        }
+    }
+
+    #[cfg(all(test, feature = "mock_parsec"))]
+    fn needs_pruning(&self) -> bool {
+        self.size_counter.needs_pruning()
+    }
 }
 
 /// Create Parsec instance.
@@ -222,5 +288,173 @@ fn new_rng() -> Box<dyn Rng> {
         };
 
         Box::new(rng)
+    }
+}
+
+#[cfg(all(test, feature = "mock_parsec"))]
+mod tests {
+    use super::*;
+    use crate::{chain::SectionInfo, routing_table::Prefix, xor_name::XorName};
+    use serde::Serialize;
+    use unwrap::unwrap;
+
+    const DEFAULT_MIN_SECTION_SIZE: usize = 4;
+
+    #[test]
+    fn parsec_size_counter() {
+        let mut counter = ParsecSizeCounter::default();
+        assert!(!counter.needs_pruning());
+        counter.increase_size(PARSEC_SIZE_LIMIT);
+        assert!(!counter.needs_pruning());
+        counter.increase_size(1);
+        assert!(counter.needs_pruning());
+    }
+
+    fn create_full_ids() -> Vec<FullId> {
+        (0..DEFAULT_MIN_SECTION_SIZE)
+            .map(|_| FullId::new())
+            .collect()
+    }
+
+    fn create_gen_pfx_info(full_ids: Vec<FullId>, version: u64) -> GenesisPfxInfo {
+        let members = full_ids.iter().map(|id| *id.public_id()).collect();
+        let section_info = unwrap!(SectionInfo::new_for_test(
+            members,
+            Prefix::<XorName>::default(),
+            version
+        ));
+        GenesisPfxInfo {
+            first_info: section_info,
+            first_state_serialized: Vec::new(),
+            latest_info: SectionInfo::default(),
+        }
+    }
+
+    fn create_parsec_map(size: u64) -> ParsecMap {
+        let log_ident = LogIdent::new("node");
+        let full_ids = create_full_ids();
+        let full_id = full_ids[0].clone();
+
+        let gen_pfx_info = create_gen_pfx_info(full_ids.clone(), 0);
+        let mut parsec_map = ParsecMap::new(full_id.clone(), &gen_pfx_info);
+
+        for parsec_no in 1..=size {
+            let gen_pfx_info = create_gen_pfx_info(full_ids.clone(), parsec_no);
+            parsec_map.init(full_id.clone(), &gen_pfx_info, &log_ident);
+        }
+
+        parsec_map
+    }
+
+    fn add_to_parsec_map(parsec_map: &mut ParsecMap, version: u64) {
+        let log_ident = LogIdent::new("node");
+        let full_ids = create_full_ids();
+        let full_id = full_ids[0].clone();
+
+        let gen_pfx_info = create_gen_pfx_info(full_ids, version);
+        parsec_map.init(full_id, &gen_pfx_info, &log_ident);
+    }
+
+    trait HandleRequestResponse {
+        fn handle(
+            &self,
+            parsec_map: &mut ParsecMap,
+            msg_version: u64,
+            pub_id: &id::PublicId,
+            log_ident: &LogIdent,
+        );
+    }
+
+    impl HandleRequestResponse for Request {
+        fn handle(
+            &self,
+            parsec_map: &mut ParsecMap,
+            msg_version: u64,
+            pub_id: &id::PublicId,
+            log_ident: &LogIdent,
+        ) {
+            let _ = parsec_map.handle_request(msg_version, self.clone(), *pub_id, &log_ident);
+        }
+    }
+
+    impl HandleRequestResponse for Response {
+        fn handle(
+            &self,
+            parsec_map: &mut ParsecMap,
+            msg_version: u64,
+            pub_id: &id::PublicId,
+            log_ident: &LogIdent,
+        ) {
+            let _ = parsec_map.handle_response(msg_version, self.clone(), *pub_id, &log_ident);
+        }
+    }
+
+    fn handle_msgs_just_below_prune_limit<T: HandleRequestResponse + Serialize>(
+        parsec_map: &mut ParsecMap,
+        msg_version: u64,
+        msg: &T,
+        pub_id: &id::PublicId,
+        log_ident: &LogIdent,
+    ) {
+        let msg_size = serialisation::serialised_size(&msg);
+        let msg_size_limit = PARSEC_SIZE_LIMIT / msg_size;
+
+        // Handle msg_size_limit msgs which should trigger pruning needed on the next
+        // msg if it's against the latest parsec.
+        for _ in 0..msg_size_limit {
+            msg.handle(parsec_map, msg_version, pub_id, log_ident);
+        }
+
+        // Make sure we don't cross the prune limit
+        assert_eq!(parsec_map.needs_pruning(), false);
+    }
+
+    fn check_prune_needed_after_msg<T: HandleRequestResponse + Serialize>(
+        msg: T,
+        parsec_age: u64,
+        prune_needed: bool,
+    ) {
+        let full_id = FullId::new();
+        let pub_id = full_id.public_id();
+        let number_of_parsecs = 2;
+
+        let log_ident = LogIdent::new("node");
+        let mut parsec_map = create_parsec_map(number_of_parsecs);
+
+        // Sometimes send to an old parsec
+        let msg_version = number_of_parsecs - parsec_age;
+
+        handle_msgs_just_below_prune_limit(&mut parsec_map, msg_version, &msg, &pub_id, &log_ident);
+
+        msg.handle(&mut parsec_map, msg_version, pub_id, &log_ident);
+        assert_eq!(parsec_map.needs_pruning(), prune_needed);
+
+        // Add another parsec should always reset `needs_pruning()`
+        add_to_parsec_map(&mut parsec_map, number_of_parsecs + 1);
+        assert_eq!(parsec_map.needs_pruning(), false);
+    }
+
+    #[test]
+    fn prune_not_required_for_resp_to_old_parsec() {
+        let parsec_age = 1;
+        check_prune_needed_after_msg(Response::new(), parsec_age, false);
+    }
+
+    #[test]
+    fn prune_required_for_resp_to_latest_parsec() {
+        let parsec_age = 0;
+        check_prune_needed_after_msg(Response::new(), parsec_age, true);
+    }
+
+    #[test]
+    fn prune_not_required_for_req_to_old_parsec() {
+        let parsec_age = 1;
+        check_prune_needed_after_msg(Request::new(), parsec_age, false);
+    }
+
+    #[test]
+    fn prune_required_for_req_to_latest_parsec() {
+        let parsec_age = 0;
+        check_prune_needed_after_msg(Request::new(), parsec_age, true);
     }
 }


### PR DESCRIPTION
Resolves #1784

Keep track of size and number of requests/responses so we can prune/reset the parsec gossip graph before it becomes too bloated.

Note that we use `serialised_size` to accumulate the size. This may turn out to have a performance impact so we might need to address this properly in the future. Maybe to have parsec tell us the request/response size.