### PR TITLE
refactor chain accumulation and add tests

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -184,15 +184,11 @@ impl Chain {
             return Ok(());
         }
 
-        match self
-            .chain_accumulator
-            .entry_or_default(event)
-            .map(|proofset| proofset.add_proof(proof))
-        {
-            Err(InsertError::AlreadyComplete) | Err(InsertError::ReplacedAlreadyInserted) => {
+        match self.chain_accumulator.add_proof(event, proof) {
+            Err(InsertError::AlreadyComplete) => {
                 // Ignore further votes for completed events.
             }
-            Ok(false) => {
+            Err(InsertError::ReplacedAlreadyInserted) => {
                 // TODO: If detecting duplicate vote from peer, penalise.
                 log_or_panic!(
                     LogLevel::Warn,
@@ -202,7 +198,7 @@ impl Chain {
                     self.chain_accumulator.incomplete_events().collect_vec()
                 );
             }
-            Ok(true) => {
+            Ok(()) => {
                 // Proof added.
             }
         }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -8,6 +8,7 @@
 
 use super::{
     candidate::Candidate,
+    chain_accumulator::{ChainAccumulator, InsertError},
     shared_state::{PrefixChange, SectionKeyInfo, SharedState},
     GenesisPfxInfo, NetworkEvent, OnlinePayload, Proof, ProofSet, SectionInfo, SectionProofChain,
 };
@@ -23,10 +24,13 @@ use crate::{
 use itertools::Itertools;
 use log::LogLevel;
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::{self, Debug, Display, Formatter};
-use std::iter;
-use std::mem;
+#[cfg(feature = "mock_base")]
+use std::collections::BTreeMap;
+use std::{
+    collections::BTreeSet,
+    fmt::{self, Debug, Display, Formatter},
+    iter, mem,
+};
 
 /// Amount added to `min_section_size` when deciding whether a bucket split can happen. This helps
 /// protect against rapid splitting and merging in the face of moderate churn.
@@ -49,13 +53,8 @@ pub struct Chain {
     /// If we're a member of the section yet. This will be toggled once we get a `SectionInfo`
     /// block accumulated which bears `our_id` as one of the members
     is_member: bool,
-    /// A map containing network events that have not been handled yet, together with their proofs
-    /// that have been collected so far. We are still waiting for more proofs, or to reach a state
-    /// where we can handle the event.
-    // FIXME: Purge votes that are older than a given period.
-    chain_accumulator: BTreeMap<NetworkEvent, ProofSet>,
-    /// Events that were handled: Further incoming proofs for these can be ignored.
-    completed_events: BTreeSet<NetworkEvent>,
+    /// Accumulate NetworkEvent that do not have yet enough vote/proofs.
+    chain_accumulator: ChainAccumulator,
     /// Pending events whose handling has been deferred due to an ongoing split or merge.
     event_cache: BTreeSet<NetworkEvent>,
     /// Current consensused candidate.
@@ -94,7 +93,6 @@ impl Chain {
             state: SharedState::new(gen_info.first_info),
             is_member,
             chain_accumulator: Default::default(),
-            completed_events: Default::default(),
             event_cache: Default::default(),
             candidate: Candidate::None,
         }
@@ -147,25 +145,25 @@ impl Chain {
             return Ok(());
         }
 
-        if self.completed_events.contains(event) {
-            log_or_panic!(
-                LogLevel::Error,
-                "{} Duplicate membership change event.",
-                self
-            );
-            return Ok(());
-        }
-
-        if self
+        match self
             .chain_accumulator
-            .insert(event.clone(), proof_set)
-            .is_some()
+            .insert_with_proof_set(event, proof_set)
         {
-            log_or_panic!(
-                LogLevel::Warn,
-                "{} Ejected existing ProofSet while handling membership mutation.",
-                self
-            );
+            Err(InsertError::AlreadyComplete) => {
+                log_or_panic!(
+                    LogLevel::Error,
+                    "{} Duplicate membership change event.",
+                    self
+                );
+            }
+            Err(InsertError::ReplacedAlreadyInserted) => {
+                log_or_panic!(
+                    LogLevel::Warn,
+                    "{} Ejected existing ProofSet while handling membership mutation.",
+                    self
+                );
+            }
+            Ok(()) => (),
         }
 
         Ok(())
@@ -186,24 +184,27 @@ impl Chain {
             return Ok(());
         }
 
-        if self.completed_events.contains(event) {
-            return Ok(());
-        }
-
-        if !self
+        match self
             .chain_accumulator
-            .entry(event.clone())
-            .or_insert_with(ProofSet::new)
-            .add_proof(proof)
+            .entry_or_default(event)
+            .map(|proofset| proofset.add_proof(proof))
         {
-            // TODO: If detecting duplicate vote from peer, penalise.
-            log_or_panic!(
-                LogLevel::Warn,
-                "{} Duplicate proof for {:?} in chain accumulator. {:?}",
-                self,
-                event,
-                self.chain_accumulator
-            );
+            Err(InsertError::AlreadyComplete) | Err(InsertError::ReplacedAlreadyInserted) => {
+                // Ignore further votes for completed events.
+            }
+            Ok(false) => {
+                // TODO: If detecting duplicate vote from peer, penalise.
+                log_or_panic!(
+                    LogLevel::Warn,
+                    "{} Duplicate proof for {:?} in chain accumulator. {:?}",
+                    self,
+                    event,
+                    self.chain_accumulator.incomplete_events().collect_vec()
+                );
+            }
+            Ok(true) => {
+                // Proof added.
+            }
         }
         Ok(())
     }
@@ -213,19 +214,21 @@ impl Chain {
     /// If the event is a `SectionInfo` or `NeighbourInfo`, it also updates the corresponding
     /// containers.
     pub fn poll(&mut self) -> Result<Option<NetworkEvent>, RoutingError> {
-        let opt_event_proofs = self
-            .chain_accumulator
-            .iter()
-            .find(|&(event, proofs)| self.is_valid_transition(event, proofs))
-            .map(|(event, proofs)| (event.clone(), proofs.clone()));
-        let (event, proofs) = match opt_event_proofs {
-            None => return Ok(None),
-            Some((event, proofs)) => (event, proofs),
+        let (event, proofs) = {
+            let opt_event = self
+                .chain_accumulator
+                .incomplete_events()
+                .find(|(event, proofs)| self.is_valid_transition(event, proofs))
+                .map(|(event, _)| event.clone());
+
+            let opt_event_proofs =
+                opt_event.and_then(|event| self.chain_accumulator.poll_event(event));
+
+            match opt_event_proofs {
+                None => return Ok(None),
+                Some((event, proofs)) => (event, proofs),
+            }
         };
-        if !self.completed_events.insert(event.clone()) {
-            log_or_panic!(LogLevel::Warn, "Duplicate insert in completed events.");
-        }
-        let _ = self.chain_accumulator.remove(&event);
 
         match event {
             NetworkEvent::SectionInfo(ref sec_info) => {
@@ -384,8 +387,7 @@ impl Chain {
         self.check_and_clean_neighbour_infos(None);
         self.state.change = PrefixChange::None;
 
-        let completed_events = mem::replace(&mut self.completed_events, Default::default());
-        let chain_acc = mem::replace(&mut self.chain_accumulator, Default::default());
+        let remaining = self.chain_accumulator.reset_accumulator(&self.our_id);
         let event_cache = mem::replace(&mut self.event_cache, Default::default());
         let merges = mem::replace(&mut self.state.merging, Default::default())
             .into_iter()
@@ -404,16 +406,13 @@ impl Chain {
                 first_state_serialized: self.get_genesis_related_info()?,
                 latest_info: Default::default(),
             },
-            cached_events: chain_acc
+            cached_events: remaining
+                .cached_events
                 .into_iter()
-                .filter(|&(ref event, ref proofs)| {
-                    !completed_events.contains(event) && proofs.contains_id(&self.our_id)
-                })
-                .map(|(event, _)| event)
                 .chain(event_cache)
                 .chain(merges)
                 .collect(),
-            completed_events,
+            completed_events: remaining.completed_events,
         })
     }
 
@@ -874,7 +873,7 @@ impl Chain {
     /// Returns all network events that we have signed but haven't accumulated yet.
     fn signed_events(&self) -> impl Iterator<Item = &NetworkEvent> {
         self.chain_accumulator
-            .iter()
+            .incomplete_events()
             .filter(move |(_, proofs)| proofs.contains_id(&self.our_id))
             .map(|(event, _)| event)
     }

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -20,6 +20,7 @@ pub(super) struct ChainAccumulator {
     // FIXME: Purge votes that are older than a given period.
     chain_accumulator: BTreeMap<NetworkEvent, ProofSet>,
     /// Events that were handled: Further incoming proofs for these can be ignored.
+    /// When an event is completed, it cannot be or inserted in chain_accumulator.
     completed_events: BTreeSet<NetworkEvent>,
 }
 
@@ -76,9 +77,7 @@ impl ChainAccumulator {
         RemainingEvents {
             cached_events: chain_acc
                 .into_iter()
-                .filter(|&(ref event, ref proofs)| {
-                    !completed_events.contains(event) && proofs.contains_id(our_id)
-                })
+                .filter(|&(_, ref proofs)| proofs.contains_id(our_id))
                 .map(|(event, _)| event)
                 .collect(),
             completed_events,

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -1,0 +1,280 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{NetworkEvent, ProofSet};
+use crate::id::PublicId;
+use log::LogLevel;
+use std::collections::{BTreeMap, BTreeSet};
+use std::mem;
+
+#[derive(Default)]
+pub(super) struct ChainAccumulator {
+    /// A map containing network events that have not been handled yet, together with their proofs
+    /// that have been collected so far. We are still waiting for more proofs, or to reach a state
+    /// where we can handle the event.
+    // FIXME: Purge votes that are older than a given period.
+    chain_accumulator: BTreeMap<NetworkEvent, ProofSet>,
+    /// Events that were handled: Further incoming proofs for these can be ignored.
+    completed_events: BTreeSet<NetworkEvent>,
+}
+
+impl ChainAccumulator {
+    pub fn insert_with_proof_set(
+        &mut self,
+        event: &NetworkEvent,
+        proof_set: ProofSet,
+    ) -> Result<(), InsertError> {
+        if self.completed_events.contains(event) {
+            return Err(InsertError::AlreadyComplete);
+        }
+
+        if self
+            .chain_accumulator
+            .insert(event.clone(), proof_set)
+            .is_some()
+        {
+            return Err(InsertError::ReplacedAlreadyInserted);
+        }
+
+        Ok(())
+    }
+
+    pub fn entry_or_default(&mut self, event: &NetworkEvent) -> Result<&mut ProofSet, InsertError> {
+        if self.completed_events.contains(event) {
+            return Err(InsertError::AlreadyComplete);
+        }
+
+        Ok(self
+            .chain_accumulator
+            .entry(event.clone())
+            .or_insert_with(ProofSet::new))
+    }
+
+    pub fn poll_event(&mut self, event: NetworkEvent) -> Option<(NetworkEvent, ProofSet)> {
+        let proofs = self.chain_accumulator.remove(&event)?;
+
+        if !self.completed_events.insert(event.clone()) {
+            log_or_panic!(LogLevel::Warn, "Duplicate insert in completed events.");
+        }
+
+        Some((event, proofs))
+    }
+
+    pub fn incomplete_events(&self) -> impl Iterator<Item = (&NetworkEvent, &ProofSet)> {
+        self.chain_accumulator.iter()
+    }
+
+    pub fn reset_accumulator(&mut self, our_id: &PublicId) -> RemainingEvents {
+        let completed_events = mem::replace(&mut self.completed_events, Default::default());
+        let chain_acc = mem::replace(&mut self.chain_accumulator, Default::default());
+
+        RemainingEvents {
+            cached_events: chain_acc
+                .into_iter()
+                .filter(|&(ref event, ref proofs)| {
+                    !completed_events.contains(event) && proofs.contains_id(our_id)
+                })
+                .map(|(event, _)| event)
+                .collect(),
+            completed_events,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum InsertError {
+    AlreadyComplete,
+    ReplacedAlreadyInserted,
+}
+
+/// The outcome of a prefix change.
+#[derive(Default, PartialEq, Eq, Debug)]
+pub struct RemainingEvents {
+    /// The cached events that should be revoted.
+    pub cached_events: BTreeSet<NetworkEvent>,
+    /// The completed events.
+    pub completed_events: BTreeSet<NetworkEvent>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::id::FullId;
+    use parsec::SecretId;
+    use std::iter;
+    use unwrap::unwrap;
+
+    fn test_event_and_proof_set() -> (NetworkEvent, ProofSet) {
+        let id = FullId::new();
+        let pub_id = *id.public_id();
+        let sig = id.sign_detached(&[1]);
+
+        (
+            NetworkEvent::OurMerge,
+            ProofSet {
+                sigs: iter::once((pub_id, sig)).collect(),
+            },
+        )
+    }
+
+    fn incomplete_events(acc: &ChainAccumulator) -> Vec<(NetworkEvent, ProofSet)> {
+        acc.incomplete_events()
+            .map(|(e, p)| (e.clone(), p.clone()))
+            .collect()
+    }
+
+    fn completed_events(acc: &ChainAccumulator) -> Vec<NetworkEvent> {
+        acc.completed_events.iter().cloned().collect()
+    }
+
+    #[test]
+    fn insert_with_proof_set() {
+        let (event, proofs) = test_event_and_proof_set();
+
+        let mut acc = ChainAccumulator::default();
+        let result = acc.insert_with_proof_set(&event, proofs.clone());
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(incomplete_events(&acc), vec![(event, proofs)]);
+    }
+
+    #[test]
+    fn poll_proof() {
+        let (event, proofs) = test_event_and_proof_set();
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+
+        let event_to_poll = unwrap!(acc.incomplete_events().next()).0.clone();
+        let result = acc.poll_event(event_to_poll);
+
+        assert_eq!(result, Some((event, proofs)));
+        assert_eq!(incomplete_events(&acc), vec![]);
+    }
+
+    #[test]
+    fn re_insert_with_proof_set() {
+        let (event, proofs) = test_event_and_proof_set();
+        let (_, proofs2) = test_event_and_proof_set();
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+
+        let result = acc.insert_with_proof_set(&event, proofs2.clone());
+
+        assert_eq!(result, Err(InsertError::ReplacedAlreadyInserted));
+        assert_eq!(incomplete_events(&acc), vec![(event, proofs2)]);
+    }
+
+    #[test]
+    fn re_insert_with_proof_set_after_poll() {
+        let (event, proofs) = test_event_and_proof_set();
+        let (_, proofs2) = test_event_and_proof_set();
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+        let _ = acc.poll_event(event.clone());
+
+        let result = acc.insert_with_proof_set(&event, proofs2.clone());
+
+        assert_eq!(result, Err(InsertError::AlreadyComplete));
+        assert_eq!(incomplete_events(&acc), vec![]);
+    }
+
+    #[test]
+    fn entry_or_default() {
+        let (event, proofs) = test_event_and_proof_set();
+
+        let mut acc = ChainAccumulator::default();
+        let result = acc.entry_or_default(&event).map(|p| {
+            *p = proofs.clone();
+        });
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(incomplete_events(&acc), vec![(event, proofs)]);
+    }
+
+    #[test]
+    fn re_entry_or_default() {
+        let (event, proofs) = test_event_and_proof_set();
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.entry_or_default(&event).map(|p| {
+            *p = proofs.clone();
+        });
+
+        let result = acc.entry_or_default(&event).map(|p| p.clone());
+
+        assert_eq!(result, Ok(proofs.clone()));
+        assert_eq!(incomplete_events(&acc), vec![(event, proofs)]);
+    }
+
+    #[test]
+    fn re_entry_or_default_after_poll() {
+        let (event, _proofs) = test_event_and_proof_set();
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.entry_or_default(&event);
+        let _ = acc.poll_event(event.clone());
+
+        let result = acc.entry_or_default(&event).map(|p| p.clone());
+
+        assert_eq!(result, Err(InsertError::AlreadyComplete));
+        assert_eq!(incomplete_events(&acc), vec![]);
+    }
+
+    #[test]
+    fn reset_all_completed() {
+        let (event, proofs) = test_event_and_proof_set();
+        let our_id = *unwrap!(proofs.ids().next());
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+        let _ = acc.poll_event(event.clone());
+
+        let result = acc.reset_accumulator(&our_id);
+
+        assert_eq!(
+            result,
+            RemainingEvents {
+                cached_events: BTreeSet::new(),
+                completed_events: vec![event.clone()].into_iter().collect()
+            }
+        );
+        assert_eq!(incomplete_events(&acc), vec![]);
+        assert_eq!(completed_events(&acc), vec![]);
+    }
+
+    #[test]
+    fn reset_none_completed() {
+        let (event, proofs) = test_event_and_proof_set();
+        let our_id = *unwrap!(proofs.ids().next());
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+
+        let result = acc.reset_accumulator(&our_id);
+
+        assert_eq!(
+            result,
+            RemainingEvents {
+                cached_events: vec![event].into_iter().collect(),
+                completed_events: BTreeSet::new(),
+            }
+        );
+        assert_eq!(incomplete_events(&acc), vec![]);
+        assert_eq!(completed_events(&acc), vec![]);
+    }
+
+    #[test]
+    fn reset_none_completed_none_our_id() {
+        let (event, proofs) = test_event_and_proof_set();
+        let our_id = *FullId::new().public_id();
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+
+        let result = acc.reset_accumulator(&our_id);
+
+        assert_eq!(result, RemainingEvents::default());
+        assert_eq!(incomplete_events(&acc), vec![]);
+        assert_eq!(completed_events(&acc), vec![]);
+    }
+}

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod bls_emu;
 mod candidate;
 #[allow(clippy::module_inception)]
 mod chain;
+mod chain_accumulator;
 mod network_event;
 mod proof;
 mod section_info;


### PR DESCRIPTION
chain_accumulator & completed_events work together.
We will need to update them to handle signing BLS key, so extract them and add unit test.

Partially address https://github.com/maidsafe/routing/issues/1768