### PR TITLE
Fix premature consensus in mock parsec

### DIFF
--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -192,6 +192,10 @@ where
     }
 
     fn compute_consensus(&mut self, state: &mut SectionState<T, S::PublicId>) {
+        // Call `update_blocks` once, to allow this node to catch up to the previously consensused
+        // blocks.
+        let _ = self.update_blocks(state);
+
         loop {
             state.compute_consensus(&self.peer_list, self.consensus_mode);
 


### PR DESCRIPTION
The bug happened in a situation like this:

Say there are 8 nodes in the section and the genesis group size is 4. A new node X joins. Another node Y is in the process of being voted in, but so far has only 4 votes. X receives a gossip which triggers the consensus calculation. In mock parsec, this means reaching into the shared state and picking the first unconsensused observation. That happens to be Add(Y). There are 4 votes for it. X only knows about 4 valid voters at this point (the genesis group), so it thinks there are enough votes and marks the observation as consensused. Thus Add(Y) is consensused prematurelly.

The fix is to make sure the new node catches up to all the previously consensused blocks before it itself performs the consensus calculation.