### PR TITLE
feat/routing: prune parsec as requested

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -293,6 +293,7 @@ impl Chain {
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::StartDkg(_)
             | AccumulatingEvent::User(_)
+            | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::SendAckMessage(_) => (),
         }
 
@@ -569,7 +570,10 @@ impl Chain {
     }
 
     /// Gets the data needed to initialise a new Parsec instance
-    pub fn prepare_parsec_reset(&mut self) -> Result<ParsecResetData, RoutingError> {
+    pub fn prepare_parsec_reset(
+        &mut self,
+        parsec_version: u64,
+    ) -> Result<ParsecResetData, RoutingError> {
         let remaining = self.chain_accumulator.reset_accumulator(&self.our_id);
         let event_cache = mem::replace(&mut self.event_cache, Default::default());
         let merges = mem::replace(&mut self.state.merging, Default::default())
@@ -584,6 +588,7 @@ impl Chain {
                 first_state_serialized: self.get_genesis_related_info()?,
                 first_ages: self.get_age_counters(),
                 latest_info: Default::default(),
+                parsec_version,
             },
             cached_events: remaining
                 .cached_events
@@ -597,7 +602,10 @@ impl Chain {
 
     /// Finalises a split or merge - creates a `GenesisPfxInfo` for the new graph and returns the
     /// cached and currently accumulated events.
-    pub fn finalise_prefix_change(&mut self) -> Result<ParsecResetData, RoutingError> {
+    pub fn finalise_prefix_change(
+        &mut self,
+        parsec_version: u64,
+    ) -> Result<ParsecResetData, RoutingError> {
         // Clear any relocation overrides
         #[cfg(feature = "mock_base")]
         {
@@ -612,7 +620,7 @@ impl Chain {
         info!("{} - finalise_prefix_change: {:?}", self, self.our_prefix());
         trace!("{} - finalise_prefix_change state: {:?}", self, self.state);
 
-        self.prepare_parsec_reset()
+        self.prepare_parsec_reset(parsec_version)
     }
 
     /// Returns our public ID
@@ -819,6 +827,11 @@ impl Chain {
     pub fn check_vote_status(&mut self) -> BTreeSet<PublicId> {
         let members = self.our_info().member_ids();
         self.chain_accumulator.check_vote_status(members)
+    }
+
+    /// Returns whether a churning is in progress.
+    pub fn is_churn_in_progress(&self) -> bool {
+        self.churn_in_progress
     }
 
     /// Returns `true` if the given `NetworkEvent` is already accumulated and can be skipped.
@@ -1680,6 +1693,7 @@ mod tests {
             first_state_serialized: Vec::new(),
             first_ages,
             latest_info: Default::default(),
+            parsec_version: 0,
         };
 
         let mut chain = Chain::new(

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -45,16 +45,18 @@ pub struct GenesisPfxInfo {
     pub first_state_serialized: Vec<u8>,
     pub first_ages: BTreeMap<PublicId, AgeCounter>,
     pub latest_info: EldersInfo,
+    pub parsec_version: u64,
 }
 
 impl Debug for GenesisPfxInfo {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "GenesisPfxInfo({:?}, gen_version: {}, latest_version: {})",
+            "GenesisPfxInfo({:?}, gen_version: {}, latest_version: {}, parsec_version {})",
             self.first_info.prefix(),
             self.first_info.version(),
             self.latest_info.version(),
+            self.parsec_version,
         )
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -483,12 +483,6 @@ impl Node {
     pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
         self.machine.current().in_authority(auth)
     }
-
-    /// Get the number of accumulated `ParsecPrune` events. This is only used until we have
-    /// implemented acting on the accumulated events, at which point this function will be removed.
-    pub fn parsec_prune_accumulated(&self) -> Option<usize> {
-        self.chain().map(Chain::parsec_prune_accumulated)
-    }
 }
 
 #[cfg(feature = "mock_base")]

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -49,10 +49,10 @@ const MAX_PARSECS: usize = 10;
 const PARSEC_SIZE_LIMIT: u64 = 1_000_000_000;
 // Limit in integration tests
 #[cfg(all(feature = "mock_base", not(feature = "mock_parsec")))]
-const PARSEC_SIZE_LIMIT: u64 = 10_000_000;
+const PARSEC_SIZE_LIMIT: u64 = 20_000_000;
 // Limit for integration tests with mock-parsec
 #[cfg(feature = "mock_parsec")]
-const PARSEC_SIZE_LIMIT: u64 = 100;
+const PARSEC_SIZE_LIMIT: u64 = 500;
 
 // Keep track of size in case we need to prune.
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -228,17 +228,6 @@ impl ParsecMap {
             .flatten()
     }
 
-    #[cfg(feature = "mock_base")]
-    pub fn has_unpolled_observations(&self) -> bool {
-        let parsec = if let Some(parsec) = self.map.values().last() {
-            parsec
-        } else {
-            return false;
-        };
-
-        parsec.has_unpolled_observations()
-    }
-
     pub fn needs_pruning(&self) -> bool {
         self.size_counter.needs_pruning()
     }
@@ -284,6 +273,23 @@ impl ParsecMap {
             .take(MAX_PARSECS)
             .rev()
             .collect();
+    }
+}
+
+#[cfg(feature = "mock_base")]
+impl ParsecMap {
+    pub fn has_unpolled_observations(&self) -> bool {
+        let parsec = if let Some(parsec) = self.map.values().last() {
+            parsec
+        } else {
+            return false;
+        };
+
+        parsec.has_unpolled_observations()
+    }
+
+    pub fn get_size(&self) -> u64 {
+        self.size_counter.size_counter
     }
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 #[cfg(feature = "mock_parsec")]
+use crate::crypto;
+#[cfg(feature = "mock_parsec")]
 use crate::mock::parsec as inner;
 use crate::{
     chain::{self, GenesisPfxInfo},
@@ -23,6 +25,8 @@ use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt, mem,
 };
+#[cfg(feature = "mock_parsec")]
+use unwrap::unwrap;
 
 #[cfg(feature = "mock_parsec")]
 pub use crate::mock::parsec::{
@@ -45,7 +49,7 @@ const MAX_PARSECS: usize = 10;
 const PARSEC_SIZE_LIMIT: u64 = 1_000_000_000;
 // Limit in integration tests
 #[cfg(all(feature = "mock_base", not(feature = "mock_parsec")))]
-const PARSEC_SIZE_LIMIT: u64 = 200_000;
+const PARSEC_SIZE_LIMIT: u64 = 10_000_000;
 // Limit for integration tests with mock-parsec
 #[cfg(feature = "mock_parsec")]
 const PARSEC_SIZE_LIMIT: u64 = 100;
@@ -86,7 +90,7 @@ impl ParsecMap {
     pub fn new(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Self {
         let mut map = BTreeMap::new();
         let _ = map.insert(
-            *gen_pfx_info.first_info.version(),
+            gen_pfx_info.parsec_version,
             create(rng, full_id, gen_pfx_info),
         );
         let size_counter = ParsecSizeCounter::default();
@@ -262,7 +266,7 @@ impl ParsecMap {
         gen_pfx_info: &GenesisPfxInfo,
         log_ident: &LogIdent,
     ) {
-        if let Entry::Vacant(entry) = self.map.entry(*gen_pfx_info.first_info.version()) {
+        if let Entry::Vacant(entry) = self.map.entry(gen_pfx_info.parsec_version) {
             let _ = entry.insert(create(rng, full_id, gen_pfx_info));
             self.size_counter = ParsecSizeCounter::default();
             info!(
@@ -285,10 +289,16 @@ impl ParsecMap {
 
 /// Create Parsec instance.
 fn create(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
+    #[cfg(feature = "mock_parsec")]
+    let hash = {
+        let fields = (gen_pfx_info.first_info.hash(), gen_pfx_info.parsec_version);
+        crypto::sha3_256(&unwrap!(serialisation::serialise(&fields)))
+    };
+
     if gen_pfx_info.first_info.is_member(full_id.public_id()) {
         Parsec::from_genesis(
             #[cfg(feature = "mock_parsec")]
-            *gen_pfx_info.first_info.hash(),
+            hash,
             full_id,
             &gen_pfx_info.first_info.member_ids().copied().collect(),
             gen_pfx_info.first_state_serialized.clone(),
@@ -298,7 +308,7 @@ fn create(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> 
     } else {
         Parsec::from_existing(
             #[cfg(feature = "mock_parsec")]
-            *gen_pfx_info.first_info.hash(),
+            hash,
             full_id,
             &gen_pfx_info.first_info.member_ids().copied().collect(),
             &gen_pfx_info.latest_info.member_ids().copied().collect(),
@@ -367,6 +377,7 @@ mod tests {
             first_state_serialized: Vec::new(),
             first_ages,
             latest_info: EldersInfo::default(),
+            parsec_version: version,
         }
     }
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -214,7 +214,7 @@ impl Adult {
     // Can also just be a single target once node-ageing makes Offline votes Opaque which should
     // remove invalid test failures for unaccumulated parsec::Remove blocks.
     fn send_parsec_poke(&mut self) {
-        let version = *self.gen_pfx_info.first_info.version();
+        let version = self.gen_pfx_info.parsec_version;
         let recipients = self
             .gen_pfx_info
             .latest_info
@@ -605,6 +605,11 @@ impl Approved for Adult {
 
     fn handle_neighbour_merge_event(&mut self) -> Result<(), RoutingError> {
         debug!("{} - Unhandled NeighbourMerge event", self);
+        Ok(())
+    }
+
+    fn handle_prune(&mut self) -> Result<(), RoutingError> {
+        debug!("{} - Unhandled ParsecPrune event", self);
         Ok(())
     }
 }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -101,6 +101,9 @@ pub trait Approved: Base {
         Ok(())
     }
 
+    /// Handles an accumulated `ParsecPrune` event.
+    fn handle_prune(&mut self) -> Result<(), RoutingError>;
+
     fn handle_parsec_request(
         &mut self,
         msg_version: u64,
@@ -322,12 +325,7 @@ pub trait Approved: Base {
                 AccumulatingEvent::SendAckMessage(payload) => {
                     self.handle_send_ack_message_event(payload)?
                 }
-                AccumulatingEvent::ParsecPrune => {
-                    info!(
-                        "{} Handling chain {:?} not yet implemented, ignoring.",
-                        self, event
-                    );
-                }
+                AccumulatingEvent::ParsecPrune => self.handle_prune()?,
                 AccumulatingEvent::Relocate(payload) => {
                     self.invoke_handle_relocate_event(payload, event.signature, outbox)?
                 }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1472,6 +1472,10 @@ impl Elder {
     ) {
         self.send_message_to_targets(dst_targets, dg_size, message)
     }
+
+    pub fn parsec_last_version(&self) -> u64 {
+        self.parsec_map.last_version()
+    }
 }
 
 impl Approved for Elder {

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -94,6 +94,7 @@ impl ElderUnderTest {
             first_state_serialized: Vec::new(),
             first_ages,
             latest_info: EldersInfo::default(),
+            parsec_version: 0,
         };
 
         let full_id = full_ids[0].clone();

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -596,8 +596,10 @@ fn remove_unresponsive_node() {
         let event: Vec<_> = rng.gen_iter().take(100).collect();
         nodes.iter_mut().for_each(|node| {
             if node.name() == non_responsive_name {
-                // The extra margin is to avoid votes like ParsecPrune affects the calculation.
-                if responded < (UNRESPONSIVE_WINDOW - UNRESPONSIVE_THRESHOLD - 3)
+                // `chain_accumulator` gets reset during parsec pruning, which will reset the
+                // tracking of unresponsiveness as well. So this test has to assume there is no
+                // parsec pruning being carried out.
+                if responded < UNRESPONSIVE_WINDOW - UNRESPONSIVE_THRESHOLD - 1
                     && rng.gen_weighted_bool(3)
                 {
                     responded += 1;


### PR DESCRIPTION
This PR contains the detailed operation when a ParsecPrune event reached consensus, and the test to confirm it.
The operation utilize the current split approach, so the most part of existing `finalise_prefix_change` handling can be retained.