### PR TITLE
Approve candidate earlier to allow them to participate in DKG

### DIFF
--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -370,7 +370,11 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_online_event(&mut self, _: OnlinePayload) -> Result<(), RoutingError> {
+    fn handle_online_event(
+        &mut self,
+        _: OnlinePayload,
+        _: &mut dyn EventBox,
+    ) -> Result<(), RoutingError> {
         Ok(())
     }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -48,7 +48,11 @@ pub trait Approved: Relocated {
     ) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `Online` event.
-    fn handle_online_event(&mut self, online_payload: OnlinePayload) -> Result<(), RoutingError>;
+    fn handle_online_event(
+        &mut self,
+        online_payload: OnlinePayload,
+        outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `Offline` event.
     fn handle_offline_event(&mut self, pub_id: PublicId) -> Result<(), RoutingError>;
@@ -222,7 +226,7 @@ pub trait Approved: Relocated {
                     self.handle_remove_elder_event(pub_id, outbox)?;
                 }
                 NetworkEvent::Online(info) => {
-                    self.handle_online_event(info)?;
+                    self.handle_online_event(info, outbox)?;
                 }
                 NetworkEvent::Offline(pub_id) => {
                     self.handle_offline_event(pub_id)?;


### PR DESCRIPTION
This PR changes the candidate approval process so that it now happens on consensusing `Online`. This promotes the candidate to Adult which allows them to participate in parsec gossip and thus in the DKG. This PR does not implement the DKG handling itself though.

Closes #1773 