### PR TITLE
additional non accumulating signature share

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -8,7 +8,7 @@
 
 use super::{
     candidate::Candidate,
-    chain_accumulator::{ChainAccumulator, InsertError},
+    chain_accumulator::{AccumulatingEvent, ChainAccumulator, InsertError},
     shared_state::{PrefixChange, SectionKeyInfo, SharedState},
     GenesisPfxInfo, NetworkEvent, OnlinePayload, Proof, ProofSet, SectionInfo, SectionProofChain,
 };
@@ -145,9 +145,10 @@ impl Chain {
             return Ok(());
         }
 
+        let (acc_event, _signature) = AccumulatingEvent::from_network_event(event.clone());
         match self
             .chain_accumulator
-            .insert_with_proof_set(event, proof_set)
+            .insert_with_proof_set(acc_event, proof_set)
         {
             Err(InsertError::AlreadyComplete) => {
                 log_or_panic!(
@@ -184,7 +185,11 @@ impl Chain {
             return Ok(());
         }
 
-        match self.chain_accumulator.add_proof(event, proof) {
+        let (acc_event, signature) = AccumulatingEvent::from_network_event(event.clone());
+        match self
+            .chain_accumulator
+            .add_proof(acc_event, proof, signature)
+        {
             Err(InsertError::AlreadyComplete) => {
                 // Ignore further votes for completed events.
             }
@@ -209,12 +214,12 @@ impl Chain {
     ///
     /// If the event is a `SectionInfo` or `NeighbourInfo`, it also updates the corresponding
     /// containers.
-    pub fn poll(&mut self) -> Result<Option<NetworkEvent>, RoutingError> {
+    pub fn poll(&mut self) -> Result<Option<AccumulatingEvent>, RoutingError> {
         let (event, proofs) = {
             let opt_event = self
                 .chain_accumulator
                 .incomplete_events()
-                .find(|(event, proofs)| self.is_valid_transition(event, proofs))
+                .find(|(event, proofs)| self.is_valid_transition(event, proofs.parsec_proof_set()))
                 .map(|(event, _)| event.clone());
 
             let opt_event_proofs =
@@ -227,43 +232,43 @@ impl Chain {
         };
 
         match event {
-            NetworkEvent::SectionInfo(ref sec_info) => {
-                self.add_section_info(sec_info.clone(), proofs)?;
+            AccumulatingEvent::SectionInfo(ref sec_info) => {
+                self.add_section_info(sec_info.clone(), proofs.into_proof_set())?;
                 if let Some((ref cached_sec_info, _)) = self.state.split_cache {
                     if cached_sec_info == sec_info {
                         return Ok(None);
                     }
                 }
             }
-            NetworkEvent::TheirKeyInfo(ref key_info) => {
+            AccumulatingEvent::TheirKeyInfo(ref key_info) => {
                 self.update_their_keys(key_info);
             }
-            NetworkEvent::AckMessage(ref ack_payload) => {
+            AccumulatingEvent::AckMessage(ref ack_payload) => {
                 self.update_their_knowledge(ack_payload.src_prefix, ack_payload.ack_version);
             }
-            NetworkEvent::OurMerge => {
+            AccumulatingEvent::OurMerge => {
                 // use new_info here as our_info might still be accumulating signatures
                 // and we'd want to perform the merge eventually with our current latest state.
                 let our_hash = *self.state.new_info.hash();
                 let _ = self.state.merging.insert(our_hash);
                 self.state.change = PrefixChange::Merging;
                 panic!(
-                    "Merge not supported: NetworkEvent::OurMerge {:?}: {:?}",
+                    "Merge not supported: AccumulatingEvent::OurMerge {:?}: {:?}",
                     self.our_id(),
                     self.state.new_info
                 );
             }
-            NetworkEvent::NeighbourMerge(digest) => {
+            AccumulatingEvent::NeighbourMerge(digest) => {
                 // TODO: Check that the section is known and not already merged.
                 let _ = self.state.merging.insert(digest);
             }
-            NetworkEvent::AddElder(_, _)
-            | NetworkEvent::RemoveElder(_)
-            | NetworkEvent::Online(_)
-            | NetworkEvent::Offline(_)
-            | NetworkEvent::ExpectCandidate(_)
-            | NetworkEvent::PurgeCandidate(_)
-            | NetworkEvent::SendAckMessage(_) => (),
+            AccumulatingEvent::AddElder(_, _)
+            | AccumulatingEvent::RemoveElder(_)
+            | AccumulatingEvent::Online(_)
+            | AccumulatingEvent::Offline(_)
+            | AccumulatingEvent::ExpectCandidate(_)
+            | AccumulatingEvent::PurgeCandidate(_)
+            | AccumulatingEvent::SendAckMessage(_) => (),
         }
         Ok(Some(event))
     }
@@ -373,7 +378,8 @@ impl Chain {
             })
             || self
                 .signed_events()
-                .any(|ni_event| ni_event.proves_successor_info(sec_info, proofs))
+                .filter_map(|ni_event| ni_event.section_info())
+                .any(|si_event| si_event.proves_successor(sec_info, proofs))
     }
 
     /// Finalises a split or merge - creates a `GenesisPfxInfo` for the new graph and returns the
@@ -478,7 +484,9 @@ impl Chain {
     /// accumulated yet.
     pub fn is_trusted(&self, sec_info: &SectionInfo, check_signed: bool) -> bool {
         let is_proof = |si: &SectionInfo| si == sec_info || si.is_successor_of(sec_info);
-        let mut signed = self.signed_events().filter_map(NetworkEvent::section_info);
+        let mut signed = self
+            .signed_events()
+            .filter_map(AccumulatingEvent::section_info);
         if check_signed && signed.any(is_proof) {
             return true;
         }
@@ -514,7 +522,9 @@ impl Chain {
         let is_newer = |si: &SectionInfo| {
             si.version() >= sec_info.version() && si.prefix().is_compatible(sec_info.prefix())
         };
-        let mut signed = self.signed_events().filter_map(NetworkEvent::section_info);
+        let mut signed = self
+            .signed_events()
+            .filter_map(AccumulatingEvent::section_info);
         if signed.any(is_newer) {
             return false;
         }
@@ -552,7 +562,7 @@ impl Chain {
     fn should_skip_accumulator(&self, event: &NetworkEvent) -> bool {
         // FIXME: may also need to handle non SI votes to not get handled multiple times
         let si = match *event {
-            NetworkEvent::SectionInfo(ref si) => si,
+            NetworkEvent::SectionInfo(ref si, _) => si,
             _ => return false,
         };
 
@@ -578,9 +588,9 @@ impl Chain {
     /// `SectionInfo` in our_infos/neighbour_infos OR if its a valid neighbour pfx
     /// we do not currently have in our chain.
     /// Returns `true` for other types of `NetworkEvent`.
-    fn is_valid_transition(&self, network_event: &NetworkEvent, proofs: &ProofSet) -> bool {
+    fn is_valid_transition(&self, network_event: &AccumulatingEvent, proofs: &ProofSet) -> bool {
         match *network_event {
-            NetworkEvent::SectionInfo(ref info) => {
+            AccumulatingEvent::SectionInfo(ref info) => {
                 // Reject any info we have a newer compatible info for.
                 let is_newer = |i: &SectionInfo| {
                     info.prefix().is_compatible(i.prefix()) && i.version() >= info.version()
@@ -603,23 +613,23 @@ impl Chain {
                 self.our_info().is_quorum(proofs)
             }
 
-            NetworkEvent::AddElder(_, _)
-            | NetworkEvent::RemoveElder(_)
-            | NetworkEvent::Online(_)
-            | NetworkEvent::Offline(_)
-            | NetworkEvent::ExpectCandidate(_)
-            | NetworkEvent::PurgeCandidate(_)
-            | NetworkEvent::TheirKeyInfo(_)
-            | NetworkEvent::AckMessage(_) => {
+            AccumulatingEvent::AddElder(_, _)
+            | AccumulatingEvent::RemoveElder(_)
+            | AccumulatingEvent::Online(_)
+            | AccumulatingEvent::Offline(_)
+            | AccumulatingEvent::ExpectCandidate(_)
+            | AccumulatingEvent::PurgeCandidate(_)
+            | AccumulatingEvent::TheirKeyInfo(_)
+            | AccumulatingEvent::AckMessage(_) => {
                 self.state.change == PrefixChange::None && self.our_info().is_quorum(proofs)
             }
-            NetworkEvent::SendAckMessage(_) => {
+            AccumulatingEvent::SendAckMessage(_) => {
                 // We may not reach consensus if malicious peer, but when we do we know all our
                 // nodes have updated `their_keys`.
                 self.state.change == PrefixChange::None
                     && self.our_info().is_total_consensus(proofs)
             }
-            NetworkEvent::OurMerge | NetworkEvent::NeighbourMerge(_) => {
+            AccumulatingEvent::OurMerge | AccumulatingEvent::NeighbourMerge(_) => {
                 self.our_info().is_quorum(proofs)
             }
         }
@@ -643,7 +653,7 @@ impl Chain {
             (PrefixChange::None, _)
             | (PrefixChange::Merging, NetworkEvent::OurMerge)
             | (PrefixChange::Merging, NetworkEvent::NeighbourMerge(_)) => true,
-            (_, NetworkEvent::SectionInfo(sec_info)) => {
+            (_, NetworkEvent::SectionInfo(sec_info, _)) => {
                 if sec_info.prefix().is_compatible(self.our_prefix())
                     && sec_info.version() > self.state.new_info.version()
                 {
@@ -867,7 +877,7 @@ impl Chain {
     }
 
     /// Returns all network events that we have signed but haven't accumulated yet.
-    fn signed_events(&self) -> impl Iterator<Item = &NetworkEvent> {
+    fn signed_events(&self) -> impl Iterator<Item = &AccumulatingEvent> {
         self.chain_accumulator
             .incomplete_events()
             .filter(move |(_, proofs)| proofs.contains_id(&self.our_id))
@@ -1254,7 +1264,7 @@ pub struct PrefixChangeOutcome {
     /// The cached events that should be revoted.
     pub cached_events: BTreeSet<NetworkEvent>,
     /// The completed events.
-    pub completed_events: BTreeSet<NetworkEvent>,
+    pub completed_events: BTreeSet<AccumulatingEvent>,
 }
 
 impl Debug for Chain {

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -6,8 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{NetworkEvent, Proof, ProofSet};
+use super::{
+    AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof, ProofSet,
+    SectionInfo, SectionInfoSigPayload, SectionKeyInfo, SendAckMessagePayload,
+};
 use crate::id::PublicId;
+use crate::sha3::Digest256;
+use crate::{Authority, XorName};
 use log::LogLevel;
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
@@ -18,43 +23,45 @@ pub(super) struct ChainAccumulator {
     /// that have been collected so far. We are still waiting for more proofs, or to reach a state
     /// where we can handle the event.
     // FIXME: Purge votes that are older than a given period.
-    chain_accumulator: BTreeMap<NetworkEvent, ProofSet>,
+    chain_accumulator: BTreeMap<AccumulatingEvent, AccumulatingProof>,
     /// Events that were handled: Further incoming proofs for these can be ignored.
     /// When an event is completed, it cannot be or inserted in chain_accumulator.
-    completed_events: BTreeSet<NetworkEvent>,
+    completed_events: BTreeSet<AccumulatingEvent>,
 }
 
 impl ChainAccumulator {
     pub fn insert_with_proof_set(
         &mut self,
-        event: &NetworkEvent,
+        event: AccumulatingEvent,
         proof_set: ProofSet,
     ) -> Result<(), InsertError> {
-        if self.completed_events.contains(event) {
+        if self.completed_events.contains(&event) {
             return Err(InsertError::AlreadyComplete);
         }
 
-        if self
-            .chain_accumulator
-            .insert(event.clone(), proof_set)
-            .is_some()
-        {
+        let proof = AccumulatingProof::from_proof_set(proof_set);
+        if self.chain_accumulator.insert(event, proof).is_some() {
             return Err(InsertError::ReplacedAlreadyInserted);
         }
 
         Ok(())
     }
 
-    pub fn add_proof(&mut self, event: &NetworkEvent, proof: Proof) -> Result<(), InsertError> {
-        if self.completed_events.contains(event) {
+    pub fn add_proof(
+        &mut self,
+        event: AccumulatingEvent,
+        proof: Proof,
+        signature: Option<SectionInfoSigPayload>,
+    ) -> Result<(), InsertError> {
+        if self.completed_events.contains(&event) {
             return Err(InsertError::AlreadyComplete);
         }
 
         if !self
             .chain_accumulator
-            .entry(event.clone())
-            .or_insert_with(ProofSet::new)
-            .add_proof(proof)
+            .entry(event)
+            .or_insert_with(AccumulatingProof::default)
+            .add_proof(proof, signature)
         {
             return Err(InsertError::ReplacedAlreadyInserted);
         }
@@ -62,7 +69,10 @@ impl ChainAccumulator {
         Ok(())
     }
 
-    pub fn poll_event(&mut self, event: NetworkEvent) -> Option<(NetworkEvent, ProofSet)> {
+    pub fn poll_event(
+        &mut self,
+        event: AccumulatingEvent,
+    ) -> Option<(AccumulatingEvent, AccumulatingProof)> {
         let proofs = self.chain_accumulator.remove(&event)?;
 
         if !self.completed_events.insert(event.clone()) {
@@ -72,7 +82,9 @@ impl ChainAccumulator {
         Some((event, proofs))
     }
 
-    pub fn incomplete_events(&self) -> impl Iterator<Item = (&NetworkEvent, &ProofSet)> {
+    pub fn incomplete_events(
+        &self,
+    ) -> impl Iterator<Item = (&AccumulatingEvent, &AccumulatingProof)> {
         self.chain_accumulator.iter()
     }
 
@@ -83,11 +95,140 @@ impl ChainAccumulator {
         RemainingEvents {
             cached_events: chain_acc
                 .into_iter()
-                .filter(|&(_, ref proofs)| proofs.contains_id(our_id))
-                .map(|(event, _)| event)
+                .filter(|&(_, ref proofs)| proofs.parsec_proofs.contains_id(our_id))
+                .map(|(event, proofs)| {
+                    event.convert_to_network_event(proofs.into_sig_shares().remove(our_id))
+                })
                 .collect(),
             completed_events,
         }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub enum AccumulatingEvent {
+    /// Add new elder once we agreed to add a candidate
+    AddElder(PublicId, Authority<XorName>),
+    /// Remove elder once we agreed to remove the peer
+    RemoveElder(PublicId),
+
+    /// Voted for candidate that pass resource proof
+    Online(OnlinePayload),
+    /// Voted for candidate we no longer consider online.
+    Offline(PublicId),
+
+    OurMerge,
+    NeighbourMerge(Digest256),
+    SectionInfo(SectionInfo),
+
+    /// Voted for received ExpectCandidate Message.
+    ExpectCandidate(ExpectCandidatePayload),
+
+    // Voted for timeout expired for this candidate old_public_id.
+    PurgeCandidate(PublicId),
+
+    // Voted for received message with keys to we can update their_keys
+    TheirKeyInfo(SectionKeyInfo),
+
+    // Voted for received AckMessage to update their_knowledge
+    AckMessage(AckMessagePayload),
+
+    // Voted for sending AckMessage (Require 100% consensus)
+    SendAckMessage(SendAckMessagePayload),
+}
+
+impl AccumulatingEvent {
+    pub fn from_network_event(
+        event: NetworkEvent,
+    ) -> (AccumulatingEvent, Option<SectionInfoSigPayload>) {
+        let accumulating_event = match event {
+            NetworkEvent::SectionInfo(sec_info, sig) => {
+                return (AccumulatingEvent::SectionInfo(sec_info), sig)
+            }
+
+            NetworkEvent::AddElder(id, aux) => AccumulatingEvent::AddElder(id, aux),
+            NetworkEvent::RemoveElder(id) => AccumulatingEvent::RemoveElder(id),
+            NetworkEvent::Online(payload) => AccumulatingEvent::Online(payload),
+            NetworkEvent::Offline(id) => AccumulatingEvent::Offline(id),
+            NetworkEvent::OurMerge => AccumulatingEvent::OurMerge,
+            NetworkEvent::NeighbourMerge(digest) => AccumulatingEvent::NeighbourMerge(digest),
+            NetworkEvent::ExpectCandidate(vote) => AccumulatingEvent::ExpectCandidate(vote),
+            NetworkEvent::PurgeCandidate(id) => AccumulatingEvent::PurgeCandidate(id),
+            NetworkEvent::TheirKeyInfo(payload) => AccumulatingEvent::TheirKeyInfo(payload),
+            NetworkEvent::AckMessage(payload) => AccumulatingEvent::AckMessage(payload),
+            NetworkEvent::SendAckMessage(payload) => AccumulatingEvent::SendAckMessage(payload),
+        };
+
+        (accumulating_event, None)
+    }
+
+    pub fn convert_to_network_event(self, sig: Option<SectionInfoSigPayload>) -> NetworkEvent {
+        match self {
+            AccumulatingEvent::SectionInfo(sec_info) => NetworkEvent::SectionInfo(sec_info, sig),
+
+            AccumulatingEvent::AddElder(id, aux) => NetworkEvent::AddElder(id, aux),
+            AccumulatingEvent::RemoveElder(id) => NetworkEvent::RemoveElder(id),
+            AccumulatingEvent::Online(payload) => NetworkEvent::Online(payload),
+            AccumulatingEvent::Offline(id) => NetworkEvent::Offline(id),
+            AccumulatingEvent::OurMerge => NetworkEvent::OurMerge,
+            AccumulatingEvent::NeighbourMerge(digest) => NetworkEvent::NeighbourMerge(digest),
+            AccumulatingEvent::ExpectCandidate(vote) => NetworkEvent::ExpectCandidate(vote),
+            AccumulatingEvent::PurgeCandidate(id) => NetworkEvent::PurgeCandidate(id),
+            AccumulatingEvent::TheirKeyInfo(payload) => NetworkEvent::TheirKeyInfo(payload),
+            AccumulatingEvent::AckMessage(payload) => NetworkEvent::AckMessage(payload),
+            AccumulatingEvent::SendAckMessage(payload) => NetworkEvent::SendAckMessage(payload),
+        }
+    }
+
+    /// Returns the payload if this is a `SectionInfo` event.
+    pub fn section_info(&self) -> Option<&SectionInfo> {
+        match *self {
+            AccumulatingEvent::SectionInfo(ref self_si) => Some(self_si),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct AccumulatingProof {
+    parsec_proofs: ProofSet,
+    sig_shares: BTreeMap<PublicId, SectionInfoSigPayload>,
+}
+
+impl AccumulatingProof {
+    pub fn from_proof_set(parsec_proofs: ProofSet) -> AccumulatingProof {
+        AccumulatingProof {
+            parsec_proofs,
+            sig_shares: Default::default(),
+        }
+    }
+
+    /// Return false if share or proof is replaced
+    pub fn add_proof(&mut self, proof: Proof, info_sig: Option<SectionInfoSigPayload>) -> bool {
+        let new_share = info_sig.map_or(true, |share| {
+            self.sig_shares.insert(proof.pub_id, share).is_none()
+        });
+
+        let new_proof = self.parsec_proofs.add_proof(proof);
+        new_share && new_proof
+    }
+
+    /// Returns whether the set contains a signature by that ID.
+    pub fn contains_id(&self, id: &PublicId) -> bool {
+        self.parsec_proofs.contains_id(id)
+    }
+
+    pub fn parsec_proof_set(&self) -> &ProofSet {
+        &self.parsec_proofs
+    }
+
+    pub fn into_proof_set(self) -> ProofSet {
+        self.parsec_proofs
+    }
+
+    pub fn into_sig_shares(self) -> BTreeMap<PublicId, SectionInfoSigPayload> {
+        self.sig_shares
     }
 }
 
@@ -103,154 +244,258 @@ pub struct RemainingEvents {
     /// The cached events that should be revoted.
     pub cached_events: BTreeSet<NetworkEvent>,
     /// The completed events.
-    pub completed_events: BTreeSet<NetworkEvent>,
+    pub completed_events: BTreeSet<AccumulatingEvent>,
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::id::FullId;
+    use crate::{id::FullId, BlsPublicKeySet, BlsPublicKeyShare};
     use parsec::SecretId;
     use std::iter;
     use unwrap::unwrap;
 
-    fn test_event_and_proof_set() -> (NetworkEvent, ProofSet) {
+    struct TestData {
+        pub our_id: PublicId,
+        pub event: AccumulatingEvent,
+        pub network_event: NetworkEvent,
+        pub first_proof: Proof,
+        pub proofs: ProofSet,
+        pub acc_proofs: AccumulatingProof,
+        pub signature: Option<SectionInfoSigPayload>,
+    }
+
+    enum EventType {
+        WithSignature,
+        NoSignature,
+    }
+
+    fn empty_section_info() -> SectionInfo {
+        unwrap!(SectionInfo::new_for_test(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        ))
+    }
+
+    fn random_section_info_sig_payload() -> SectionInfoSigPayload {
+        let (id, first_proof) = random_ids_and_proof();
+        SectionInfoSigPayload {
+            share: (BlsPublicKeyShare(*id.public_id()), first_proof.sig),
+            pk_set: BlsPublicKeySet::from_section_info(empty_section_info()),
+        }
+    }
+
+    fn random_ids_and_proof() -> (FullId, Proof) {
         let id = FullId::new();
         let pub_id = *id.public_id();
         let sig = id.sign_detached(&[1]);
 
-        (
-            NetworkEvent::OurMerge,
-            ProofSet {
-                sigs: iter::once((pub_id, sig)).collect(),
-            },
-        )
+        (id, Proof { pub_id, sig })
     }
 
-    fn get_first_proof(proofs: &ProofSet) -> Proof {
-        let (pub_id, sig) = unwrap!(proofs.sigs.iter().next());
+    fn test_data_random_key(event_type: EventType) -> TestData {
+        let (id, first_proof) = random_ids_and_proof();
+        let proofs = ProofSet {
+            sigs: iter::once((first_proof.pub_id, first_proof.sig)).collect(),
+        };
 
-        Proof {
-            pub_id: *pub_id,
-            sig: *sig,
+        match event_type {
+            EventType::NoSignature => TestData {
+                our_id: *id.public_id(),
+                event: AccumulatingEvent::OurMerge,
+                network_event: NetworkEvent::OurMerge,
+                first_proof,
+                proofs: proofs.clone(),
+                acc_proofs: AccumulatingProof {
+                    parsec_proofs: proofs,
+                    sig_shares: Default::default(),
+                },
+                signature: None,
+            },
+            EventType::WithSignature => {
+                let sec_info = empty_section_info();
+                let sig_payload = random_section_info_sig_payload();
+
+                TestData {
+                    our_id: *id.public_id(),
+                    event: AccumulatingEvent::SectionInfo(sec_info.clone()),
+                    network_event: NetworkEvent::SectionInfo(
+                        sec_info.clone(),
+                        Some(sig_payload.clone()),
+                    ),
+                    first_proof,
+                    proofs: proofs.clone(),
+                    acc_proofs: AccumulatingProof {
+                        parsec_proofs: proofs,
+                        sig_shares: iter::once((first_proof.pub_id, sig_payload.clone())).collect(),
+                    },
+                    signature: Some(sig_payload.clone()),
+                }
+            }
         }
     }
 
-    fn incomplete_events(acc: &ChainAccumulator) -> Vec<(NetworkEvent, ProofSet)> {
+    fn incomplete_events(acc: &ChainAccumulator) -> Vec<(AccumulatingEvent, AccumulatingProof)> {
         acc.incomplete_events()
             .map(|(e, p)| (e.clone(), p.clone()))
             .collect()
     }
 
-    fn completed_events(acc: &ChainAccumulator) -> Vec<NetworkEvent> {
+    fn completed_events(acc: &ChainAccumulator) -> Vec<AccumulatingEvent> {
         acc.completed_events.iter().cloned().collect()
     }
 
     #[test]
-    fn insert_with_proof_set() {
-        let (event, proofs) = test_event_and_proof_set();
+    fn insert_with_proof_set_no_sig() {
+        insert_with_proof_set(test_data_random_key(EventType::NoSignature));
+    }
 
+    fn insert_with_proof_set(data: TestData) {
         let mut acc = ChainAccumulator::default();
-        let result = acc.insert_with_proof_set(&event, proofs.clone());
+        let result = acc.insert_with_proof_set(data.event.clone(), data.proofs.clone());
 
         assert_eq!(result, Ok(()));
-        assert_eq!(incomplete_events(&acc), vec![(event, proofs)]);
+        assert_eq!(incomplete_events(&acc), vec![(data.event, data.acc_proofs)]);
     }
 
     #[test]
-    fn poll_proof() {
-        let (event, proofs) = test_event_and_proof_set();
+    fn poll_proof_no_sig() {
+        poll_proof(test_data_random_key(EventType::NoSignature));
+    }
+
+    fn poll_proof(data: TestData) {
         let mut acc = ChainAccumulator::default();
-        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+        let _ = acc.insert_with_proof_set(data.event.clone(), data.proofs.clone());
 
         let event_to_poll = unwrap!(acc.incomplete_events().next()).0.clone();
         let result = acc.poll_event(event_to_poll);
 
-        assert_eq!(result, Some((event, proofs)));
+        assert_eq!(result, Some((data.event, data.acc_proofs)));
         assert_eq!(incomplete_events(&acc), vec![]);
     }
 
     #[test]
-    fn re_insert_with_proof_set() {
-        let (event, proofs) = test_event_and_proof_set();
-        let (_, proofs2) = test_event_and_proof_set();
-        let mut acc = ChainAccumulator::default();
-        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+    fn re_insert_with_proof_set_no_sig() {
+        re_insert_with_proof_set(
+            test_data_random_key(EventType::NoSignature),
+            test_data_random_key(EventType::NoSignature),
+        );
+    }
 
-        let result = acc.insert_with_proof_set(&event, proofs2.clone());
+    fn re_insert_with_proof_set(data: TestData, data2: TestData) {
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(data.event.clone(), data.proofs.clone());
+
+        let result = acc.insert_with_proof_set(data.event.clone(), data2.proofs.clone());
 
         assert_eq!(result, Err(InsertError::ReplacedAlreadyInserted));
-        assert_eq!(incomplete_events(&acc), vec![(event, proofs2)]);
+        assert_eq!(
+            incomplete_events(&acc),
+            vec![(data.event, data2.acc_proofs)]
+        );
     }
 
     #[test]
-    fn re_insert_with_proof_set_after_poll() {
-        let (event, proofs) = test_event_and_proof_set();
-        let (_, proofs2) = test_event_and_proof_set();
-        let mut acc = ChainAccumulator::default();
-        let _ = acc.insert_with_proof_set(&event, proofs.clone());
-        let _ = acc.poll_event(event.clone());
+    fn re_insert_with_proof_set_after_poll_no_sig() {
+        re_insert_with_proof_set_after_poll(
+            test_data_random_key(EventType::NoSignature),
+            test_data_random_key(EventType::NoSignature),
+        );
+    }
 
-        let result = acc.insert_with_proof_set(&event, proofs2.clone());
+    fn re_insert_with_proof_set_after_poll(data: TestData, data2: TestData) {
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.insert_with_proof_set(data.event.clone(), data.proofs.clone());
+        let _ = acc.poll_event(data.event.clone());
+
+        let result = acc.insert_with_proof_set(data.event.clone(), data2.proofs.clone());
 
         assert_eq!(result, Err(InsertError::AlreadyComplete));
         assert_eq!(incomplete_events(&acc), vec![]);
     }
 
     #[test]
-    fn add_proof() {
-        let (event, proofs) = test_event_and_proof_set();
-        let proof = get_first_proof(&proofs);
+    fn add_proof_no_sig() {
+        add_proof(test_data_random_key(EventType::NoSignature));
+    }
 
+    #[test]
+    fn add_proof_with_sig() {
+        add_proof(test_data_random_key(EventType::WithSignature));
+    }
+
+    fn add_proof(data: TestData) {
         let mut acc = ChainAccumulator::default();
-        let result = acc.add_proof(&event, proof);
+        let result = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
 
         assert_eq!(result, Ok(()));
-        assert_eq!(incomplete_events(&acc), vec![(event, proofs)]);
+        assert_eq!(incomplete_events(&acc), vec![(data.event, data.acc_proofs)]);
     }
 
     #[test]
-    fn re_add_proof() {
-        let (event, proofs) = test_event_and_proof_set();
-        let proof = get_first_proof(&proofs);
-        let mut acc = ChainAccumulator::default();
-        let _ = acc.add_proof(&event, proof);
+    fn re_add_proof_no_sig() {
+        re_add_proof(test_data_random_key(EventType::NoSignature));
+    }
 
-        let result = acc.add_proof(&event, proof);
+    #[test]
+    fn re_add_proof_with_sig() {
+        re_add_proof(test_data_random_key(EventType::WithSignature));
+    }
+
+    fn re_add_proof(data: TestData) {
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
+
+        let result = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
 
         assert_eq!(result, Err(InsertError::ReplacedAlreadyInserted));
-        assert_eq!(incomplete_events(&acc), vec![(event, proofs)]);
+        assert_eq!(incomplete_events(&acc), vec![(data.event, data.acc_proofs)]);
     }
 
     #[test]
-    fn re_add_proof_after_poll() {
-        let (event, proofs) = test_event_and_proof_set();
-        let proof = get_first_proof(&proofs);
-        let mut acc = ChainAccumulator::default();
-        let _ = acc.add_proof(&event, proof);
-        let _ = acc.poll_event(event.clone());
+    fn re_add_proof_after_poll_no_sig() {
+        re_add_proof_after_poll(test_data_random_key(EventType::NoSignature));
+    }
 
-        let result = acc.add_proof(&event, proof);
+    #[test]
+    fn re_add_proof_after_poll_with_sig() {
+        re_add_proof_after_poll(test_data_random_key(EventType::WithSignature));
+    }
+
+    fn re_add_proof_after_poll(data: TestData) {
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
+        let _ = acc.poll_event(data.event.clone());
+
+        let result = acc.add_proof(data.event, data.first_proof, data.signature);
 
         assert_eq!(result, Err(InsertError::AlreadyComplete));
         assert_eq!(incomplete_events(&acc), vec![]);
     }
 
     #[test]
-    fn reset_all_completed() {
-        let (event, proofs) = test_event_and_proof_set();
-        let our_id = *unwrap!(proofs.ids().next());
-        let mut acc = ChainAccumulator::default();
-        let _ = acc.insert_with_proof_set(&event, proofs.clone());
-        let _ = acc.poll_event(event.clone());
+    fn reset_all_completed_no_sig() {
+        reset_all_completed(test_data_random_key(EventType::NoSignature));
+    }
 
-        let result = acc.reset_accumulator(&our_id);
+    #[test]
+    fn reset_all_completed_with_sig() {
+        reset_all_completed(test_data_random_key(EventType::WithSignature));
+    }
+
+    fn reset_all_completed(data: TestData) {
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
+        let _ = acc.poll_event(data.event.clone());
+
+        let result = acc.reset_accumulator(&data.our_id);
 
         assert_eq!(
             result,
             RemainingEvents {
                 cached_events: BTreeSet::new(),
-                completed_events: vec![event.clone()].into_iter().collect()
+                completed_events: vec![data.event.clone()].into_iter().collect()
             }
         );
         assert_eq!(incomplete_events(&acc), vec![]);
@@ -258,18 +503,25 @@ mod test {
     }
 
     #[test]
-    fn reset_none_completed() {
-        let (event, proofs) = test_event_and_proof_set();
-        let our_id = *unwrap!(proofs.ids().next());
-        let mut acc = ChainAccumulator::default();
-        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+    fn reset_none_completed_no_sig() {
+        reset_none_completed(test_data_random_key(EventType::NoSignature));
+    }
 
-        let result = acc.reset_accumulator(&our_id);
+    #[test]
+    fn reset_none_completed_with_sig() {
+        reset_none_completed(test_data_random_key(EventType::WithSignature));
+    }
+
+    fn reset_none_completed(data: TestData) {
+        let mut acc = ChainAccumulator::default();
+        let _ = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
+
+        let result = acc.reset_accumulator(&data.our_id);
 
         assert_eq!(
             result,
             RemainingEvents {
-                cached_events: vec![event].into_iter().collect(),
+                cached_events: vec![data.network_event].into_iter().collect(),
                 completed_events: BTreeSet::new(),
             }
         );
@@ -278,11 +530,19 @@ mod test {
     }
 
     #[test]
-    fn reset_none_completed_none_our_id() {
-        let (event, proofs) = test_event_and_proof_set();
+    fn reset_none_completed_none_our_id_no_sig() {
+        reset_none_completed_none_our_id(test_data_random_key(EventType::NoSignature));
+    }
+
+    #[test]
+    fn reset_none_completed_none_our_id_with_sig() {
+        reset_none_completed_none_our_id(test_data_random_key(EventType::WithSignature));
+    }
+
+    fn reset_none_completed_none_our_id(data: TestData) {
         let our_id = *FullId::new().public_id();
         let mut acc = ChainAccumulator::default();
-        let _ = acc.insert_with_proof_set(&event, proofs.clone());
+        let _ = acc.add_proof(data.event.clone(), data.first_proof, data.signature.clone());
 
         let result = acc.reset_accumulator(&our_id);
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -23,9 +23,8 @@ mod test_utils;
 pub use self::test_utils::verify_chain_invariant;
 pub use self::{
     chain::{delivery_group_size, Chain, PrefixChangeOutcome},
-    chain_accumulator::AccumulatingEvent,
     network_event::{
-        AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload,
+        AccumulatingEvent, AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload,
         SectionInfoSigPayload, SendAckMessagePayload,
     },
     proof::{Proof, ProofSet},

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -23,9 +23,10 @@ mod test_utils;
 pub use self::test_utils::verify_chain_invariant;
 pub use self::{
     chain::{delivery_group_size, Chain, PrefixChangeOutcome},
+    chain_accumulator::AccumulatingEvent,
     network_event::{
         AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload,
-        SendAckMessagePayload,
+        SectionInfoSigPayload, SendAckMessagePayload,
     },
     proof::{Proof, ProofSet},
     section_info::SectionInfo,

--- a/src/chain/proof.rs
+++ b/src/chain/proof.rs
@@ -137,7 +137,7 @@ impl Debug for ProofSet {
 
 #[cfg(test)]
 mod tests {
-    use super::super::NetworkEvent;
+    use super::super::AccumulatingEvent;
     use super::Proof;
     use crate::id::FullId;
     use safe_crypto;
@@ -148,7 +148,7 @@ mod tests {
         unwrap!(safe_crypto::init());
         let full_id = FullId::new();
         let pub_id = *full_id.public_id();
-        let payload = NetworkEvent::OurMerge;
+        let payload = AccumulatingEvent::OurMerge;
         let proof = unwrap!(Proof::new(pub_id, full_id.signing_private_key(), &payload));
         assert!(proof.validate_signature(&payload));
     }
@@ -159,8 +159,8 @@ mod tests {
         unwrap!(safe_crypto::init());
         let full_id = FullId::new();
         let pub_id = *full_id.public_id();
-        let payload = NetworkEvent::OurMerge;
-        let other_payload = NetworkEvent::Offline(pub_id);
+        let payload = AccumulatingEvent::OurMerge;
+        let other_payload = AccumulatingEvent::Offline(pub_id);
         let proof = unwrap!(Proof::new(pub_id, full_id.signing_private_key(), &payload));
         assert!(!proof.validate_signature(&other_payload));
     }

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -127,7 +127,7 @@ impl SectionInfo {
     /// `other_event`.
     pub fn proves(&self, other_info: &SectionInfo, proofs: &ProofSet) -> bool {
         let other_event: parsec::Observation<NetworkEvent, PublicId> =
-            parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(other_info.clone()));
+            parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(other_info.clone(), None));
         self.is_quorum(proofs) && proofs.validate_signatures(&other_event)
     }
 
@@ -139,7 +139,7 @@ impl SectionInfo {
 
     /// To NetworkEvent::SectionInfo event
     pub fn into_network_event(self) -> NetworkEvent {
-        NetworkEvent::SectionInfo(self)
+        NetworkEvent::SectionInfo(self, None)
     }
 
     #[cfg(any(test, feature = "mock_base"))]

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{NetworkEvent, ProofSet};
+use super::{AccumulatingEvent, NetworkEvent, ProofSet};
 use crate::error::RoutingError;
 use crate::id::PublicId;
 use crate::parsec;
@@ -127,7 +127,7 @@ impl SectionInfo {
     /// `other_event`.
     pub fn proves(&self, other_info: &SectionInfo, proofs: &ProofSet) -> bool {
         let other_event: parsec::Observation<NetworkEvent, PublicId> =
-            parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(other_info.clone(), None));
+            parsec::Observation::OpaquePayload(other_info.clone().into_network_event());
         self.is_quorum(proofs) && proofs.validate_signatures(&other_event)
     }
 
@@ -137,9 +137,9 @@ impl SectionInfo {
         other_info.is_successor_of(self) && self.proves(other_info, proofs)
     }
 
-    /// To NetworkEvent::SectionInfo event
+    /// To AccumulatingEvent::SectionInfo event
     pub fn into_network_event(self) -> NetworkEvent {
-        NetworkEvent::SectionInfo(self, None)
+        AccumulatingEvent::SectionInfo(self).into_network_event()
     }
 
     #[cfg(any(test, feature = "mock_base"))]

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -190,7 +190,7 @@ impl SharedState {
             .map(|(sec_info, _)| sec_info)
     }
 
-    /// Returns `true` if we have accumulated self `NetworkEvent::OurMerge`.
+    /// Returns `true` if we have accumulated self `AccumulatingEvent::OurMerge`.
     pub(super) fn is_self_merge_ready(&self) -> bool {
         self.merging.contains(self.our_info().hash())
     }
@@ -525,10 +525,12 @@ impl SectionKeyInfo {
 
     pub fn serialise_for_signature(&self) -> Option<Vec<u8>> {
         let payload_for_signature: parsec::Observation<NetworkEvent, PublicId> =
-            parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(
-                self.key_info_holder.internal_section_info().clone(),
-                None,
-            ));
+            parsec::Observation::OpaquePayload(
+                self.key_info_holder
+                    .internal_section_info()
+                    .clone()
+                    .into_network_event(),
+            );
         serialisation::serialise(&payload_for_signature).ok()
     }
 }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -527,6 +527,7 @@ impl SectionKeyInfo {
         let payload_for_signature: parsec::Observation<NetworkEvent, PublicId> =
             parsec::Observation::OpaquePayload(NetworkEvent::SectionInfo(
                 self.key_info_holder.internal_section_info().clone(),
+                None,
             ));
         serialisation::serialise(&payload_for_signature).ok()
     }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -9,8 +9,8 @@
 use super::Relocated;
 use crate::{
     chain::{
-        AccumulatingEvent, Chain, ExpectCandidatePayload, NetworkEvent, OnlinePayload, Proof,
-        ProofSet, SectionInfo, SectionKeyInfo, SendAckMessagePayload,
+        AccumulatingEvent, Chain, ExpectCandidatePayload, OnlinePayload, Proof, ProofSet,
+        SectionInfo, SectionKeyInfo, SendAckMessagePayload,
     },
     error::RoutingError,
     id::PublicId,
@@ -179,16 +179,17 @@ pub trait Approved: Relocated {
                     peer_id,
                     related_info,
                 } => {
-                    let event = NetworkEvent::AddElder(
+                    let event = AccumulatingEvent::AddElder(
                         *peer_id,
                         serialisation::deserialise(&related_info)?,
-                    );
+                    )
+                    .into_network_event();
                     let proof_set = to_proof_set(&block);
                     trace!("{} Parsec Add {}: - {}", self, parsec_version, peer_id);
                     self.chain_mut().handle_churn_event(&event, proof_set)?;
                 }
                 Observation::Remove { peer_id, .. } => {
-                    let event = NetworkEvent::RemoveElder(*peer_id);
+                    let event = AccumulatingEvent::RemoveElder(*peer_id).into_network_event();
                     let proof_set = to_proof_set(&block);
                     trace!("{} Parsec Remove {}: - {}", self, parsec_version, peer_id);
                     self.chain_mut().handle_churn_event(&event, proof_set)?;

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -258,14 +258,10 @@ impl Elder {
 
         // We have just become established. Now we can supply our votes for all latest neighbour
         // infos that have accumulated so far.
-        let neighbour_info_events = self
-            .chain
-            .neighbour_infos()
-            .map(|info| info.clone().into_network_event())
-            .collect_vec();
+        let neighbour_infos = self.chain.neighbour_infos().cloned().collect_vec();
 
-        neighbour_info_events.into_iter().for_each(|event| {
-            self.vote_for_event(event);
+        neighbour_infos.into_iter().for_each(|info| {
+            self.vote_for_section_info(info);
         });
 
         // Send `Event::Connected` first and then any backlogged events from previous states.
@@ -311,9 +307,9 @@ impl Elder {
             }
         }
         if let Some(merged_info) = self.chain.try_merge()? {
-            self.vote_for_event(NetworkEvent::SectionInfo(merged_info, None));
+            self.vote_for_section_info(merged_info);
         } else if self.chain.should_vote_for_merge() && !self.chain.is_self_merge_ready() {
-            self.vote_for_event(NetworkEvent::OurMerge);
+            self.vote_for_event(AccumulatingEvent::OurMerge);
         }
         Ok(())
     }
@@ -382,7 +378,9 @@ impl Elder {
 
         for obs in drained_obs {
             let event = match obs {
-                parsec::Observation::Remove { peer_id, .. } => NetworkEvent::Offline(peer_id),
+                parsec::Observation::Remove { peer_id, .. } => {
+                    AccumulatingEvent::Offline(peer_id).into_network_event()
+                }
                 parsec::Observation::OpaquePayload(event) => event.clone(),
 
                 parsec::Observation::Genesis { .. }
@@ -398,39 +396,38 @@ impl Elder {
 
         cached_events
             .iter()
-            .filter(|event| match **event {
+            .filter(|event| match event.payload {
                 // Only re-vote not yet accumulated events and still relevant to our new prefix.
-                NetworkEvent::Offline(pub_id) => {
-                    let (event, _sig) = AccumulatingEvent::from_network_event((*event).clone());
-                    our_pfx.matches(pub_id.name()) && !completed_events.contains(&event)
+                AccumulatingEvent::Offline(pub_id) => {
+                    our_pfx.matches(pub_id.name()) && !completed_events.contains(&event.payload)
                 }
 
                 // Drop candidates that have not completed:
                 // Called peer_manager.remove_candidate reset the candidate so it can be shared by
                 // all nodes: Because new node may not have voted for it, Forget the votes in
                 // flight as well.
-                NetworkEvent::AddElder(_, _)
-                | NetworkEvent::RemoveElder(_)
-                | NetworkEvent::Online(_)
-                | NetworkEvent::ExpectCandidate(_)
-                | NetworkEvent::PurgeCandidate(_) => false,
+                AccumulatingEvent::AddElder(_, _)
+                | AccumulatingEvent::RemoveElder(_)
+                | AccumulatingEvent::Online(_)
+                | AccumulatingEvent::ExpectCandidate(_)
+                | AccumulatingEvent::PurgeCandidate(_) => false,
 
                 // Keep: Additional signatures for neighbours for sec-msg-relay.
-                NetworkEvent::SectionInfo(ref sec_info, _) => {
+                AccumulatingEvent::SectionInfo(ref sec_info) => {
                     our_pfx.is_neighbour(sec_info.prefix())
                 }
 
                 // Drop: condition may have changed.
-                NetworkEvent::OurMerge => false,
+                AccumulatingEvent::OurMerge => false,
 
                 // Keep: Still relevant after prefix change.
-                NetworkEvent::NeighbourMerge(_)
-                | NetworkEvent::TheirKeyInfo(_)
-                | NetworkEvent::AckMessage(_)
-                | NetworkEvent::SendAckMessage(_) => true,
+                AccumulatingEvent::NeighbourMerge(_)
+                | AccumulatingEvent::TheirKeyInfo(_)
+                | AccumulatingEvent::AckMessage(_)
+                | AccumulatingEvent::SendAckMessage(_) => true,
             })
             .for_each(|event| {
-                self.vote_for_event(event.clone());
+                self.vote_for_network_event(event.clone());
             });
 
         Ok(())
@@ -638,7 +635,7 @@ impl Elder {
     ) -> Result<(), RoutingError> {
         // Prefix doesn't need to match, as we may get an ack for the section where we were before
         // splitting.
-        self.vote_for_event(NetworkEvent::AckMessage(AckMessagePayload {
+        self.vote_for_event(AccumulatingEvent::AckMessage(AckMessagePayload {
             src_prefix,
             ack_version,
         }));
@@ -651,7 +648,7 @@ impl Elder {
         });
 
         if has_their_keys {
-            self.vote_for_event(NetworkEvent::SendAckMessage(ack_payload));
+            self.vote_for_event(AccumulatingEvent::SendAckMessage(ack_payload));
         }
     }
 
@@ -1028,7 +1025,7 @@ impl Elder {
         dst_name: XorName,
         message_id: MessageId,
     ) -> Result<(), RoutingError> {
-        self.vote_for_event(NetworkEvent::ExpectCandidate(ExpectCandidatePayload {
+        self.vote_for_event(AccumulatingEvent::ExpectCandidate(ExpectCandidatePayload {
             old_public_id,
             old_client_auth,
             dst_name,
@@ -1139,19 +1136,19 @@ impl Elder {
         });
 
         if new_key_info {
-            self.vote_for_event(NetworkEvent::TheirKeyInfo(key_info.clone()));
+            self.vote_for_event(AccumulatingEvent::TheirKeyInfo(key_info.clone()));
         }
     }
 
     fn handle_neighbour_info(&mut self, sec_info: SectionInfo) -> Result<(), RoutingError> {
         if self.chain.is_new_neighbour(&sec_info) {
-            self.vote_for_event(sec_info.into_network_event());
+            self.vote_for_section_info(sec_info);
         }
         Ok(())
     }
 
     fn handle_merge(&mut self, digest: Digest256) -> Result<(), RoutingError> {
-        self.vote_for_event(NetworkEvent::NeighbourMerge(digest));
+        self.vote_for_event(AccumulatingEvent::NeighbourMerge(digest));
         Ok(())
     }
 
@@ -1205,10 +1202,18 @@ impl Elder {
                 self.our_prefix()
             );
         }
-        self.vote_for_event(NetworkEvent::Online(online_payload));
+        self.vote_for_event(AccumulatingEvent::Online(online_payload));
     }
 
-    fn vote_for_event(&mut self, event: NetworkEvent) {
+    fn vote_for_event(&mut self, event: AccumulatingEvent) {
+        self.vote_for_network_event(event.into_network_event())
+    }
+
+    fn vote_for_section_info(&mut self, info: SectionInfo) {
+        self.vote_for_network_event(info.into_network_event())
+    }
+
+    fn vote_for_network_event(&mut self, event: NetworkEvent) {
         trace!("{} Vote for Event {:?}", self, event);
         self.parsec_map.vote_for(event, &self.log_ident())
     }
@@ -1412,7 +1417,7 @@ impl Elder {
             outbox.send_event(Event::NodeLost(*pub_id.name()));
 
             if self.chain.our_info().members().contains(&pub_id) {
-                self.vote_for_event(NetworkEvent::Offline(pub_id));
+                self.vote_for_event(AccumulatingEvent::Offline(pub_id));
             }
         }
 
@@ -1452,7 +1457,7 @@ impl Elder {
     fn remove_expired_peers(&mut self) {
         if self.peer_mgr.expired_candidate_once() {
             if let Some(expired_id) = self.chain.candidate_old_public_id().cloned() {
-                self.vote_for_event(NetworkEvent::PurgeCandidate(expired_id));
+                self.vote_for_event(AccumulatingEvent::PurgeCandidate(expired_id));
             }
         }
 
@@ -1462,7 +1467,7 @@ impl Elder {
             // expired peers.
             self.disconnect_peer(&pub_id);
             if self.chain.our_info().members().contains(&pub_id) {
-                self.vote_for_event(NetworkEvent::Offline(pub_id));
+                self.vote_for_event(AccumulatingEvent::Offline(pub_id));
             }
         }
     }
@@ -1905,8 +1910,7 @@ impl Approved for Elder {
 
         to_vote_infos
             .into_iter()
-            .map(|info| NetworkEvent::SectionInfo(info, None))
-            .for_each(|sec_info| self.vote_for_event(sec_info));
+            .for_each(|sec_info| self.vote_for_section_info(sec_info));
 
         Ok(())
     }
@@ -1917,7 +1921,7 @@ impl Approved for Elder {
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
         let self_info = self.chain.remove_member(pub_id)?;
-        self.vote_for_event(NetworkEvent::SectionInfo(self_info, None));
+        self.vote_for_section_info(self_info);
         if let Some(&pub_id) = self.peer_mgr.get_pub_id(pub_id.name()) {
             let _ = self.dropped_peer(pub_id, outbox, false);
             self.disconnect_peer(&pub_id);
@@ -1942,7 +1946,7 @@ impl Approved for Elder {
 
             // TODO: vote for StartDkg and only when that gets consensused, vote for AddElder.
 
-            self.vote_for_event(NetworkEvent::AddElder(
+            self.vote_for_event(AccumulatingEvent::AddElder(
                 online_payload.new_public_id,
                 online_payload.client_auth,
             ));
@@ -1951,7 +1955,7 @@ impl Approved for Elder {
     }
 
     fn handle_offline_event(&mut self, pub_id: PublicId) -> Result<(), RoutingError> {
-        self.vote_for_event(NetworkEvent::RemoveElder(pub_id));
+        self.vote_for_event(AccumulatingEvent::RemoveElder(pub_id));
         Ok(())
     }
 
@@ -2031,7 +2035,7 @@ impl Approved for Elder {
         } else {
             // Vote for neighbour update if we haven't done so already.
             // vote_for_event is expected to only generate a new vote if required.
-            self.vote_for_event(sec_info.clone().into_network_event());
+            self.vote_for_section_info(sec_info);
         }
 
         let _ = self.merge_if_necessary();

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -221,7 +221,7 @@ impl ElderUnderTest {
     fn accumulate_section_info_if_vote(&mut self, section_info_payload: SectionInfo) {
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
-            &[&NetworkEvent::SectionInfo(section_info_payload)],
+            &[&NetworkEvent::SectionInfo(section_info_payload, None)],
         );
     }
 

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -139,12 +139,14 @@ impl ElderUnderTest {
         unwrap!(self.machine.current().elder_state())
     }
 
-    fn n_vote_for(&mut self, count: usize, events: &[&NetworkEvent]) {
+    fn n_vote_for(&mut self, count: usize, events: &[&AccumulatingEvent]) {
         for event in events {
             self.other_parsec_map
                 .iter_mut()
                 .take(count)
-                .for_each(|parsec| parsec.vote_for((*event).clone(), &LogIdent::new(&0)));
+                .for_each(|parsec| {
+                    parsec.vote_for((*event).clone().into_network_event(), &LogIdent::new(&0))
+                });
         }
     }
 
@@ -157,7 +159,7 @@ impl ElderUnderTest {
     fn n_vote_for_gossipped(
         &mut self,
         count: usize,
-        events: &[&NetworkEvent],
+        events: &[&AccumulatingEvent],
     ) -> Result<(), RoutingError> {
         self.n_vote_for(count, events);
         self.create_gossip()
@@ -190,28 +192,28 @@ impl ElderUnderTest {
     ) {
         let _ = self.n_vote_for_gossipped(
             count,
-            &[&NetworkEvent::ExpectCandidate(payload_expect.clone())],
+            &[&AccumulatingEvent::ExpectCandidate(payload_expect.clone())],
         );
     }
 
     fn accumulate_purge_candidate(&mut self, purge_payload: PublicId) {
         let _ = self.n_vote_for_gossipped(
             ACCUMULATE_VOTE_COUNT,
-            &[&NetworkEvent::PurgeCandidate(purge_payload)],
+            &[&AccumulatingEvent::PurgeCandidate(purge_payload)],
         );
     }
 
     fn accumulate_online(&mut self, online_payload: OnlinePayload) {
         let _ = self.n_vote_for_gossipped(
             ACCUMULATE_VOTE_COUNT,
-            &[&NetworkEvent::Online(online_payload)],
+            &[&AccumulatingEvent::Online(online_payload)],
         );
     }
 
     fn accumulate_add_elder_if_vote(&mut self, online_payload: OnlinePayload) {
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
-            &[&NetworkEvent::AddElder(
+            &[&AccumulatingEvent::AddElder(
                 online_payload.new_public_id,
                 online_payload.client_auth,
             )],
@@ -221,21 +223,21 @@ impl ElderUnderTest {
     fn accumulate_section_info_if_vote(&mut self, section_info_payload: SectionInfo) {
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
-            &[&NetworkEvent::SectionInfo(section_info_payload, None)],
+            &[&AccumulatingEvent::SectionInfo(section_info_payload)],
         );
     }
 
     fn accumulate_offline(&mut self, offline_payload: PublicId) {
         let _ = self.n_vote_for_gossipped(
             ACCUMULATE_VOTE_COUNT,
-            &[&NetworkEvent::Offline(offline_payload)],
+            &[&AccumulatingEvent::Offline(offline_payload)],
         );
     }
 
     fn accumulate_remove_elder_if_vote(&mut self, offline_payload: PublicId) {
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
-            &[&NetworkEvent::RemoveElder(offline_payload)],
+            &[&AccumulatingEvent::RemoveElder(offline_payload)],
         );
     }
 


### PR DESCRIPTION
In order to support BLS, we need to be able to add a different signature share for each of the votes for a new SectionInfo.

This PR allow this to still accumulate based only on the SectionInfo part of the Parsec payload.
This first commit setup the test as a stepping stone using a different type.
The second commit refactor the code to be able to re-use the enum.