### PR TITLE
sign SectionInfo with share

### DIFF
--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -161,7 +161,7 @@ pub struct RemainingEvents {
 mod test {
     use super::super::SectionInfo;
     use super::*;
-    use crate::{id::FullId, BlsPublicKeySet, BlsPublicKeyShare};
+    use crate::{id::FullId, BlsPublicKeyShare};
     use parsec::SecretId;
     use std::iter;
     use unwrap::unwrap;
@@ -192,8 +192,8 @@ mod test {
     fn random_section_info_sig_payload() -> SectionInfoSigPayload {
         let (id, first_proof) = random_ids_and_proof();
         SectionInfoSigPayload {
-            share: (BlsPublicKeyShare(*id.public_id()), first_proof.sig),
-            pk_set: BlsPublicKeySet::from_section_info(empty_section_info()),
+            pub_key_share: BlsPublicKeyShare(*id.public_id()),
+            sig_share: first_proof.sig,
         }
     }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -23,6 +23,7 @@ mod test_utils;
 pub use self::test_utils::verify_chain_invariant;
 pub use self::{
     chain::{delivery_group_size, Chain, PrefixChangeOutcome},
+    chain_accumulator::AccumulatingProof,
     network_event::{
         AccumulatingEvent, AckMessagePayload, ExpectCandidatePayload, NetworkEvent, OnlinePayload,
         SectionInfoSigPayload, SendAckMessagePayload,

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{SectionInfo, SectionKeyInfo};
-use crate::id::PublicId;
+use super::{Proof, SectionInfo, SectionKeyInfo};
+use crate::id::{FullId, PublicId};
 use crate::parsec;
 use crate::routing_table::Prefix;
 use crate::sha3::Digest256;
@@ -61,6 +61,20 @@ pub struct SectionInfoSigPayload {
     pub pub_key_share: BlsPublicKeyShare,
     /// The signature share signing the SectionInfo.
     pub sig_share: BlsSignatureShare,
+}
+
+impl SectionInfoSigPayload {
+    pub fn new(
+        info: &SectionInfo,
+        full_id: &FullId,
+    ) -> Result<SectionInfoSigPayload, RoutingError> {
+        let proof = Proof::new(*full_id.public_id(), full_id.signing_private_key(), &info)?;
+
+        Ok(SectionInfoSigPayload {
+            pub_key_share: BlsPublicKeyShare(proof.pub_id),
+            sig_share: proof.sig,
+        })
+    }
 }
 
 /// Routing Network events

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -12,9 +12,7 @@ use crate::parsec;
 use crate::routing_table::Prefix;
 use crate::sha3::Digest256;
 use crate::types::MessageId;
-use crate::{
-    Authority, BlsPublicKeySet, BlsPublicKeyShare, BlsSignatureShare, RoutingError, XorName,
-};
+use crate::{Authority, BlsPublicKeyShare, BlsSignatureShare, RoutingError, XorName};
 use hex_fmt::HexFmt;
 use maidsafe_utilities::serialisation::serialise;
 use std::fmt::{self, Debug, Formatter};
@@ -59,10 +57,10 @@ pub struct SendAckMessagePayload {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct SectionInfoSigPayload {
+    /// The public key share for that signature share
+    pub pub_key_share: BlsPublicKeyShare,
     /// The signature share signing the SectionInfo.
-    pub share: (BlsPublicKeyShare, BlsSignatureShare),
-    /// The key set to combine shares.
-    pub pk_set: BlsPublicKeySet,
+    pub sig_share: BlsSignatureShare,
 }
 
 /// Routing Network events

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -9,7 +9,6 @@
 use super::{AccumulatingEvent, NetworkEvent, ProofSet};
 use crate::error::RoutingError;
 use crate::id::PublicId;
-use crate::parsec;
 use crate::routing_table::Prefix;
 use crate::sha3::Digest256;
 use crate::XorName;
@@ -121,20 +120,6 @@ impl SectionInfo {
     /// Returns `true` if `self` is a successor of `other_info`, according to its hash.
     pub fn is_successor_of(&self, other_info: &SectionInfo) -> bool {
         self.prev_hash.contains(&other_info.hash)
-    }
-
-    /// Returns `true` if the `proofs` are a quorum of `self` and valid signatures of
-    /// `other_event`.
-    pub fn proves(&self, other_info: &SectionInfo, proofs: &ProofSet) -> bool {
-        let other_event: parsec::Observation<NetworkEvent, PublicId> =
-            parsec::Observation::OpaquePayload(other_info.clone().into_network_event());
-        self.is_quorum(proofs) && proofs.validate_signatures(&other_event)
-    }
-
-    /// Returns `true` if the `proofs` are a quorum of `self` and valid signatures of
-    /// `other_event`, and if `other_info` is a valid successor of `self`.
-    pub fn proves_successor(&self, other_info: &SectionInfo, proofs: &ProofSet) -> bool {
-        other_info.is_successor_of(self) && self.proves(other_info, proofs)
     }
 
     /// To AccumulatingEvent::SectionInfo event

--- a/src/chain/section_info.rs
+++ b/src/chain/section_info.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{AccumulatingEvent, NetworkEvent, ProofSet};
+use super::{AccumulatingEvent, NetworkEvent, ProofSet, SectionInfoSigPayload};
 use crate::error::RoutingError;
 use crate::id::PublicId;
 use crate::routing_table::Prefix;
@@ -123,8 +123,8 @@ impl SectionInfo {
     }
 
     /// To AccumulatingEvent::SectionInfo event
-    pub fn into_network_event(self) -> NetworkEvent {
-        AccumulatingEvent::SectionInfo(self).into_network_event()
+    pub fn into_network_event_with(self, signature: Option<SectionInfoSigPayload>) -> NetworkEvent {
+        AccumulatingEvent::SectionInfo(self).into_network_event_with(signature)
     }
 
     #[cfg(any(test, feature = "mock_base"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,6 +149,8 @@ pub enum RoutingError {
     UntrustedMessage,
     /// Crypto related error.
     Crypto(safe_crypto::Error),
+    /// A new SectionInfo is invalid.
+    InvalidNewSectionInfo,
 }
 
 impl From<RoutingTableError> for RoutingError {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -246,14 +246,6 @@ impl Elder {
             self.chain.prefixes()
         );
 
-        // We have just become established. Now we can supply our votes for all latest neighbour
-        // infos that have accumulated so far.
-        let neighbour_infos = self.chain.neighbour_infos().cloned().collect_vec();
-
-        neighbour_infos.into_iter().for_each(|info| {
-            self.vote_for_section_info(info);
-        });
-
         // Send `Event::Connected` first and then any backlogged events from previous states.
         for event in iter::once(Event::Connected).chain(event_backlog) {
             self.send_event(event, outbox);
@@ -1870,10 +1862,6 @@ impl Approved for Elder {
             });
 
             self.send_neighbour_infos();
-        } else {
-            // Vote for neighbour update if we haven't done so already.
-            // vote_for_event is expected to only generate a new vote if required.
-            self.vote_for_section_info(sec_info);
         }
 
         let _ = self.merge_if_necessary();

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -143,9 +143,16 @@ impl ElderUnderTest {
         for event in events {
             self.other_parsec_map
                 .iter_mut()
+                .zip(self.other_full_ids.iter())
                 .take(count)
-                .for_each(|parsec| {
-                    parsec.vote_for((*event).clone().into_network_event(), &LogIdent::new(&0))
+                .for_each(|(parsec, full_id)| {
+                    let sig_event = event
+                        .section_info()
+                        .map(|sec_info| unwrap!(SectionInfoSigPayload::new(sec_info, &full_id)));
+                    parsec.vote_for(
+                        (*event).clone().into_network_event_with(sig_event),
+                        &LogIdent::new(&0),
+                    )
                 });
         }
     }


### PR DESCRIPTION
Closes #1769 

Building on PR #1802 , we are now adding a signature share to the parsec payload containing the SectionInfo. When ready, we will be able to also/instead sign the SectionKeyInfo when we add it as a result of the DKG (i.e `NetworkEvent(SectionInfo,SectionKeyInfo)).

The initial commits clean up code that was no longer used.