### PR TITLE
Revert PR #1785

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -8,14 +8,11 @@
 
 //! Types emulating the BLS functionality until proper BLS lands
 use super::{ProofSet, SectionInfo};
-use crate::id::{FullId, PublicId};
+use crate::{
+    id::{FullId, PublicId},
+    QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
+};
 use std::{collections::BTreeMap, fmt};
-
-/// The BLS scheme will require more than `THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR`
-/// shares in order to construct a full key or signature.
-pub const THRESHOLD_NUMERATOR: usize = 1;
-/// See `THRESHOLD_NUMERATOR`.
-pub const THRESHOLD_DENOMINATOR: usize = 3;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {
@@ -66,7 +63,7 @@ impl PublicKeyShare {
 
 impl PublicKeySet {
     pub fn from_section_info(sec_info: SectionInfo) -> Self {
-        let threshold = sec_info.members().len() * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
+        let threshold = sec_info.members().len() * QUORUM_NUMERATOR / QUORUM_DENOMINATOR;
         Self {
             threshold,
             sec_info,
@@ -164,7 +161,7 @@ mod test {
     #[test]
     fn test_signature() {
         let section_size = 10;
-        let min_sigs = section_size * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR + 1;
+        let min_sigs = section_size * QUORUM_NUMERATOR / QUORUM_DENOMINATOR + 1;
 
         let (pk_set, sk_shares) = gen_section(section_size);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,9 +207,6 @@ pub(crate) use self::{
     quic_p2p::{Event as NetworkEvent, Peer as ConnectionInfo, QuicP2p},
 };
 
-#[cfg(feature = "mock_base")]
-pub use self::chain::bls_emu::{THRESHOLD_DENOMINATOR, THRESHOLD_NUMERATOR};
-
 #[cfg(test)]
 mod tests {
     use super::{QUORUM_DENOMINATOR, QUORUM_NUMERATOR};

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -9,8 +9,7 @@
 use super::{create_connected_nodes, gen_bytes, poll_all, sort_nodes_by_distance_to, TestNode};
 use rand::Rng;
 use routing::{
-    mock::Network, Authority, Event, EventStream, XorName, THRESHOLD_DENOMINATOR,
-    THRESHOLD_NUMERATOR,
+    mock::Network, Authority, Event, EventStream, XorName, QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
 };
 
 #[test]
@@ -31,7 +30,7 @@ fn messages_accumulate_with_quorum() {
     let content = gen_bytes(&mut rng, 8);
 
     // The smallest number such that `quorum * QUORUM_DENOMINATOR > section_size * QUORUM_NUMERATOR`:
-    let quorum = 1 + section_size * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
+    let quorum = 1 + (section_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
 
     // Send a message from the section `src` to the node `dst`.
     // Only the `quorum`-th sender should cause accumulation and a


### PR DESCRIPTION
PR #1785, which changed the emulated BLS threshold to 1/3 of the section instead of 2/3, broke the node joining process when tested with production PARSEC. Since the joining process will be significantly modified soon (when #1811 is done), we decide not to look for a proper fix, but revert the changes instead and reapply them after #1811 lands (and fix then if still necessary).