### PR TITLE
Tune prune limit for real PARSEC

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -394,9 +394,7 @@ impl SignedRoutingMessage {
     // valid).
     fn find_invalid_sigs(&self, signed_bytes: &[u8]) -> Vec<BlsPublicKeyShare> {
         match self.security_metadata {
-            SecurityMetadata::None | SecurityMetadata::Full(_) | SecurityMetadata::Single(_) => {
-                vec![]
-            }
+            SecurityMetadata::None | SecurityMetadata::Full(_) | SecurityMetadata::Single(_) => vec![],
             SecurityMetadata::Partial(ref partial) => {
                 let invalid: Vec<_> = partial
                     .shares


### PR DESCRIPTION
Fixes the vote_prune test when runnig with `mock_base` or `mock_serialise`.

NOTE: test still fails for unrelated reasons until #1813 is merged

Resolves #1815 