### PR TITLE
Fix indeterminism in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "~0.4.12"
 config_file_handler = "~0.11.0"
 crossbeam-channel = "~0.3.8"
 fake_clock = "~0.3.0"
-fxhash = { version = "~0.2.1", optional = true }
+fxhash = "~0.2.1"
 hex = "~0.2.0"
 hex_fmt = "~0.1.0"
 itertools = "~0.6.1"
@@ -46,7 +46,7 @@ libc = "~0.2.29"
 serde_json = "~1.0.8"
 
 [features]
-mock_base = ["lru_time_cache/fake_clock", "parsec/mock", "parsec/malice-detection", "fxhash"]
+mock_base = ["lru_time_cache/fake_clock", "parsec/mock", "parsec/malice-detection"]
 mock_crypto = ["mock_base"]
 mock_parsec = ["mock_base"]
 mock_serialise = ["mock_base"]

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -7,7 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{id::PublicId, quic_p2p::NodeInfo, ConnectionInfo};
-use std::{collections::HashMap, net::SocketAddr};
+use fxhash::FxHashMap;
+use std::net::SocketAddr;
 
 /// This structure holds the bi-directional association between peers public id and their network
 /// connection info. This association can be create in two ways:
@@ -20,9 +21,9 @@ use std::{collections::HashMap, net::SocketAddr};
 ///    public id.
 #[derive(Default)]
 pub struct PeerMap {
-    forward: HashMap<PublicId, ConnectionInfo>,
-    reverse: HashMap<SocketAddr, PublicId>,
-    pending: HashMap<SocketAddr, PendingConnection>,
+    forward: FxHashMap<PublicId, ConnectionInfo>,
+    reverse: FxHashMap<SocketAddr, PublicId>,
+    pending: FxHashMap<SocketAddr, PendingConnection>,
 }
 
 // TODO (quic-p2p): correctly handle these pathological scenarios:


### PR DESCRIPTION
The `PeerMap` contained fields that were `HashMap`s and were being iterated over. This changes the fields to `FxHashMap`s, which provide the same order of iteration in different runs.

Note that it wasn't possible to use `BTreeMap`s because `SocketAddr` doesn't implement `Ord`.