### PR TITLE
Re-apply 1/3 DKG threshold

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -13,9 +13,14 @@ use super::ProofSet;
 use crate::{
     crypto,
     id::{FullId, PublicId},
-    QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
 };
 use std::{collections::BTreeMap, fmt};
+
+/// The BLS scheme will require more than `THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR`
+/// shares in order to construct a full key or signature.
+pub const THRESHOLD_NUMERATOR: usize = 1;
+/// See `THRESHOLD_NUMERATOR`.
+pub const THRESHOLD_DENOMINATOR: usize = 3;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeySet {
@@ -65,7 +70,7 @@ impl PublicKeyShare {
 
 impl PublicKeySet {
     pub fn from_elders_info(elders_info: EldersInfo) -> Self {
-        let threshold = elders_info.members().len() * QUORUM_NUMERATOR / QUORUM_DENOMINATOR;
+        let threshold = elders_info.members().len() * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
         Self {
             threshold,
             elders_info,
@@ -172,7 +177,7 @@ mod test {
     #[test]
     fn test_signature() {
         let section_size = 10;
-        let min_sigs = section_size * QUORUM_NUMERATOR / QUORUM_DENOMINATOR + 1;
+        let min_sigs = section_size * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR + 1;
 
         let (pk_set, sk_shares) = gen_section(section_size);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,9 @@ pub mod test_consts {
     pub use crate::states::{BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT};
 }
 
+#[cfg(feature = "mock_base")]
+pub use self::chain::bls_emu::{THRESHOLD_DENOMINATOR, THRESHOLD_NUMERATOR};
+
 #[cfg(test)]
 mod tests {
     use super::{QUORUM_DENOMINATOR, QUORUM_NUMERATOR};

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -9,8 +9,8 @@
 use super::{create_connected_nodes, gen_bytes, poll_all, sort_nodes_by_distance_to, TestNode};
 use rand::Rng;
 use routing::{
-    mock::Network, Authority, Event, EventStream, NetworkParams, XorName, QUORUM_DENOMINATOR,
-    QUORUM_NUMERATOR,
+    mock::Network, Authority, Event, EventStream, NetworkParams, XorName, THRESHOLD_DENOMINATOR,
+    THRESHOLD_NUMERATOR,
 };
 
 #[test]
@@ -37,7 +37,7 @@ fn messages_accumulate_with_quorum() {
     let content = gen_bytes(&mut rng, 8);
 
     // The smallest number such that `quorum * QUORUM_DENOMINATOR > section_size * QUORUM_NUMERATOR`:
-    let quorum = 1 + (section_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
+    let quorum = 1 + section_size * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
 
     // Send a message from the section `src` to the node `dst`.
     // Only the `quorum`-th sender should cause accumulation and a


### PR DESCRIPTION
This reverts the commit 194ae9a7e8ec6efe46b7bdb4a9faa734a92cf18f, which means this re-applies the change to 1/3 DKG threshold.

Closes #1770 again.