### PR TITLE
inform vaults (users) about client events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -9,8 +9,11 @@
 use crate::routing_table::Authority;
 use crate::routing_table::Prefix;
 use crate::xor_name::XorName;
+use crate::NetworkBytes;
 use hex_fmt::HexFmt;
+use quic_p2p::Token;
 use std::fmt::{self, Debug, Formatter};
+use std::net::SocketAddr;
 
 /// An Event raised by a `Node` or `Client` via its event sender.
 ///
@@ -23,6 +26,43 @@ use std::fmt::{self, Debug, Formatter};
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
 pub enum Event {
+    // =========== Client Events - Routing won't handle these ===========
+    /// Inform the user (library) that we are connected to a client
+    ConnectedToClient {
+        /// Client's endpoint
+        peer_addr: SocketAddr,
+    },
+    /// Inform the user (library) that we are disconnected from a client
+    ConnectionFailureToClient {
+        /// Client's endpoint
+        peer_addr: SocketAddr,
+    },
+    /// Inform the user (library) that we have a new message from a client
+    NewMessageFromClient {
+        /// Client's endpoint
+        peer_addr: SocketAddr,
+        /// Client's message
+        msg: NetworkBytes,
+    },
+    /// Inform the user (library) that we couldn't send this message to a client
+    UnsentUserMsgToClient {
+        /// Client's endpoint
+        peer_addr: SocketAddr,
+        /// Message we had tried to send to the client
+        msg: NetworkBytes,
+        /// Token that we had used to identify this message
+        token: Token,
+    },
+    /// Inform the user (library) that we have successfully sent this message to a client
+    SentUserMsgToClient {
+        /// Client's endpoint
+        peer_addr: SocketAddr,
+        /// Message we had tried to send to the client
+        msg: NetworkBytes,
+        /// Token that we had used to identify this message
+        token: Token,
+    },
+    // ==================================================================
     /// Received a message.
     MessageReceived {
         /// The content of the message.
@@ -57,6 +97,29 @@ pub enum Event {
 impl Debug for Event {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
+            Event::ConnectedToClient { peer_addr } => {
+                write!(formatter, "Event::ConnectedToClient - {}", peer_addr)
+            }
+            Event::ConnectionFailureToClient { peer_addr } => {
+                write!(formatter, "Event::ConnectionFailureToClient: {}", peer_addr)
+            }
+            Event::NewMessageFromClient { peer_addr, .. } => {
+                write!(formatter, "Event::NewMessageFromClient: {}", peer_addr)
+            }
+            Event::UnsentUserMsgToClient {
+                peer_addr, token, ..
+            } => write!(
+                formatter,
+                "Event::UnsentUserMsgToClient: {} with Token: {}",
+                peer_addr, token
+            ),
+            Event::SentUserMsgToClient {
+                peer_addr, token, ..
+            } => write!(
+                formatter,
+                "Event::SentUserMsgToClient: {} with Token: {}",
+                peer_addr, token
+            ),
             Event::MessageReceived {
                 ref content,
                 ref src,

--- a/src/event.rs
+++ b/src/event.rs
@@ -57,12 +57,6 @@ pub enum ClientEvent {
     },
 }
 
-impl Into<Event> for ClientEvent {
-    fn into(self) -> Event {
-        Event::ClientEvent(self)
-    }
-}
-
 /// An Event raised by a `Node` or `Client` via its event sender.
 ///
 /// These are sent by routing to the library's user. It allows the user to handle requests and
@@ -105,6 +99,12 @@ pub enum Event {
     TimerTicked,
     /// Consensus on a custom event.
     Consensus(Vec<u8>),
+}
+
+impl From<ClientEvent> for Event {
+    fn from(client_event: ClientEvent) -> Event {
+        Event::ClientEvent(client_event)
+    }
 }
 
 impl Debug for Event {

--- a/src/event.rs
+++ b/src/event.rs
@@ -110,7 +110,9 @@ impl From<ClientEvent> for Event {
 impl Debug for Event {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
-            Event::ClientEvent(ref client_event) => write!(formatter, "{:?}", client_event),
+            Event::ClientEvent(ref client_event) => {
+                write!(formatter, "Event::ClientEvent({:?})", client_event)
+            }
             Event::MessageReceived {
                 ref content,
                 ref src,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ use crate::mock::quic_p2p;
 pub use crate::{
     chain::Chain,
     error::{InterfaceError, RoutingError},
-    event::Event,
+    event::{ClientEvent, Event},
     event_stream::EventStream,
     id::{FullId, PublicId},
     node::{Node, NodeBuilder},

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,12 +25,12 @@ use crate::{
 use crate::{utils::XorTargetInterval, Chain, ConnectionInfo, Prefix};
 use crossbeam_channel as mpmc;
 use quic_p2p::Token;
+use std::net::SocketAddr;
 use std::sync::mpsc;
 #[cfg(feature = "mock_base")]
 use std::{
     collections::BTreeSet,
     fmt::{self, Display, Formatter},
-    net::SocketAddr,
 };
 #[cfg(feature = "mock_base")]
 use unwrap::unwrap;

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,16 +19,18 @@ use crate::{
     state_machine::{State, StateMachine},
     states::{self, BootstrappingPeer},
     xor_name::XorName,
-    NetworkConfig, MIN_SECTION_SIZE,
+    NetworkBytes, NetworkConfig, MIN_SECTION_SIZE,
 };
 #[cfg(feature = "mock_base")]
 use crate::{utils::XorTargetInterval, Chain, ConnectionInfo, Prefix};
 use crossbeam_channel as mpmc;
+use quic_p2p::Token;
 use std::sync::mpsc;
 #[cfg(feature = "mock_base")]
 use std::{
     collections::BTreeSet,
     fmt::{self, Display, Formatter},
+    net::SocketAddr,
 };
 #[cfg(feature = "mock_base")]
 use unwrap::unwrap;
@@ -208,6 +210,43 @@ impl Node {
             result_tx: self.interface_result_tx.clone(),
         };
 
+        self.perform_action(action)
+    }
+
+    /// Send a message to a client peer
+    pub fn send_message_to_client(
+        &mut self,
+        peer_addr: SocketAddr,
+        msg: NetworkBytes,
+        token: Token,
+    ) -> Result<(), InterfaceError> {
+        // Make sure the state machine has processed any outstanding network events.
+        let _ = self.poll();
+
+        let action = Action::SendMessageToClient {
+            peer_addr,
+            msg,
+            token,
+            result_tx: self.interface_result_tx.clone(),
+        };
+
+        self.perform_action(action)
+    }
+
+    /// Disconnect form a client peer
+    pub fn disconnect_from_client(&mut self, peer_addr: SocketAddr) -> Result<(), InterfaceError> {
+        // Make sure the state machine has processed any outstanding network events.
+        let _ = self.poll();
+
+        let action = Action::DisconnectClient {
+            peer_addr,
+            result_tx: self.interface_result_tx.clone(),
+        };
+
+        self.perform_action(action)
+    }
+
+    fn perform_action(&mut self, action: Action) -> Result<(), InterfaceError> {
         let transition = self
             .machine
             .current_mut()

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -131,8 +131,9 @@ impl PeerMap {
     }
 
     // If we don't have any information about this peer when this query is made then in certain
-    // context it could mean it's likely a client
-    pub fn is_peer_known_to_routing(&self, peer_addr: &SocketAddr) -> bool {
+    // context it could mean it's likely a client. If we have the info then the peer definitely
+    // wanted to join us as a node.
+    pub fn is_node(&self, peer_addr: &SocketAddr) -> bool {
         self.reverse.contains_key(peer_addr) || self.pending.contains_key(peer_addr)
     }
 }

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -129,6 +129,12 @@ impl PeerMap {
     pub fn has<N: AsRef<XorName>>(&self, name: N) -> bool {
         self.forward.contains_key(name.as_ref())
     }
+
+    // If we don't have any information about this peer when this query is made then in certain
+    // context it could mean it's likely a client
+    pub fn is_peer_known_to_routing(&self, peer_addr: &SocketAddr) -> bool {
+        self.reverse.contains_key(peer_addr) || self.pending.contains_key(peer_addr)
+    }
 }
 
 struct PendingConnection {

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -30,10 +30,11 @@ use crate::{
     time::Duration,
     timer::Timer,
     xor_name::XorName,
-    NetworkService,
+    InterfaceError, NetworkService,
 };
 use itertools::Itertools;
 use std::fmt::{self, Display, Formatter};
+use std::net::SocketAddr;
 
 const POKE_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -283,6 +284,11 @@ impl Base for Adult {
 
     fn timer(&mut self) -> &mut Timer {
         &mut self.timer
+    }
+
+    fn handle_disconnect_client(&mut self, peer_addr: SocketAddr) -> Result<(), InterfaceError> {
+        self.disconnect_from(peer_addr);
+        Ok(())
     }
 
     fn handle_timeout(&mut self, token: u64, _: &mut dyn EventBox) -> Transition {

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -154,8 +154,7 @@ pub trait Base: Display {
             ConnectedTo {
                 peer: Peer::Client { peer_addr },
             } => {
-                let client_event = ClientEvent::ConnectedToClient { peer_addr };
-                outbox.send_event(client_event.into());
+                self.handle_connected_to_client(peer_addr, outbox);
                 Transition::Stay
             }
             ConnectionFailure { peer_addr, .. } => {
@@ -237,6 +236,12 @@ pub trait Base: Display {
     ) -> Transition {
         self.peer_map_mut().connect(conn_info);
         Transition::Stay
+    }
+
+    fn handle_connected_to_client(&mut self, peer_addr: SocketAddr, _outbox: &mut dyn EventBox) {
+        // By default we immediately disconnect from a client.
+        // Only elders override it to pass it on to the vaults
+        self.disconnect_from(peer_addr);
     }
 
     fn handle_connection_failure(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     crypto::Digest256,
     error::{BootstrapResponseError, InterfaceError, RoutingError},
-    event::Event,
+    event::{ClientEvent, Event},
     id::{FullId, PublicId},
     messages::{
         BootstrapResponse, DirectMessage, HopMessage, MessageContent, RoutingMessage,
@@ -43,7 +43,6 @@ use crate::{
 use itertools::Itertools;
 use log::LogLevel;
 use quic_p2p::Token;
-#[cfg(feature = "mock_base")]
 use std::net::SocketAddr;
 use std::{
     cmp,
@@ -957,6 +956,11 @@ impl Base for Elder {
 
     fn timer(&mut self) -> &mut Timer {
         &mut self.timer
+    }
+
+    fn handle_connected_to_client(&mut self, peer_addr: SocketAddr, outbox: &mut dyn EventBox) {
+        let client_event = ClientEvent::ConnectedToClient { peer_addr };
+        outbox.send_event(From::from(client_event));
     }
 
     fn handle_disconnect_client(&mut self, peer_addr: SocketAddr) -> Result<(), InterfaceError> {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -38,10 +38,11 @@ use crate::{
     timer::Timer,
     utils::XorTargetInterval,
     xor_name::XorName,
-    BlsPublicKeySet, ConnectionInfo, NetworkService,
+    BlsPublicKeySet, ConnectionInfo, NetworkBytes, NetworkService,
 };
 use itertools::Itertools;
 use log::LogLevel;
+use quic_p2p::Token;
 #[cfg(feature = "mock_base")]
 use std::net::SocketAddr;
 use std::{
@@ -956,6 +957,21 @@ impl Base for Elder {
 
     fn timer(&mut self) -> &mut Timer {
         &mut self.timer
+    }
+
+    fn handle_disconnect_client(&mut self, peer_addr: SocketAddr) -> Result<(), InterfaceError> {
+        self.disconnect_from(peer_addr);
+        Ok(())
+    }
+
+    fn handle_send_msg_to_client(
+        &mut self,
+        peer_addr: SocketAddr,
+        msg: NetworkBytes,
+        token: Token,
+    ) -> Result<(), InterfaceError> {
+        self.send_msg_to_client(peer_addr, msg, token);
+        Ok(())
     }
 
     fn handle_send_message(

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -369,6 +369,7 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
                 Event::NodeLost(..)
                 | Event::SectionSplit(..)
                 | Event::RestartRequired
+                | Event::ClientEvent(..)
                 | Event::TimerTicked => (),
                 event => panic!("Got unexpected event: {:?}", event),
             }
@@ -481,6 +482,7 @@ pub fn add_connected_nodes_until_split(
         Event::NodeAdded(..)
         | Event::NodeLost(..)
         | Event::TimerTicked
+        | Event::ClientEvent(..)
         | Event::SectionSplit(..) => (),
         event => panic!("Got unexpected event: {:?}", event),
     });


### PR DESCRIPTION
Routing doesn't handle these. Simply off-load to vaults.