### PR TITLE
Fix SectionProofChain comparison

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -31,7 +31,7 @@ pub struct SecretKeyShare(FullId);
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Hash, Serialize, Deserialize, Debug)]
 pub struct PublicKeyShare(pub PublicId);
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct Signature {
     sigs: BTreeMap<PublicId, SignatureShare>,
 }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -17,6 +17,7 @@ use crate::{
     error::RoutingError,
     id::PublicId,
     routing_table::{Authority, Error},
+    utils::LogIdent,
     BlsPublicKeySet, Prefix, XorName, Xorable,
 };
 use itertools::Itertools;
@@ -106,7 +107,8 @@ impl Chain {
         _group: &BTreeSet<PublicId>,
         related_info: &[u8],
     ) -> Result<(), RoutingError> {
-        self.state.update_with_genesis_related_info(related_info)
+        self.state
+            .update_with_genesis_related_info(related_info, &LogIdent::new(self))
     }
 
     /// Get the serialized shared state that will be the starting point when processing

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -64,7 +64,7 @@ impl HopMessage {
 /// Metadata needed for verification of the sender.
 /// Contain shares of the section signature before combining into a BLS signature
 /// and into a FullSecurityMetadata.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PartialSecurityMetadata {
     proof: SectionProofChain,
     shares: BTreeMap<BlsPublicKeyShare, BlsSignatureShare>,
@@ -83,7 +83,7 @@ impl Debug for PartialSecurityMetadata {
 }
 
 /// Metadata needed for verification of the sender.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct FullSecurityMetadata {
     proof: SectionProofChain,
     signature: BlsSignature,
@@ -141,7 +141,7 @@ impl Debug for SingleSrcSecurityMetadata {
     }
 }
 
-#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum SecurityMetadata {
     None,

--- a/src/node.rs
+++ b/src/node.rs
@@ -327,12 +327,8 @@ impl Node {
     /// Prefix must be either our prefix or of one of our neighbours. Returns empty set otherwise.
     pub fn section_members(&self, prefix: &Prefix<XorName>) -> BTreeSet<XorName> {
         self.chain()
-            .and_then(|chain| {
-                chain
-                    .all_sections()
-                    .find(|(sec_prefix, _)| prefix == *sec_prefix)
-                    .map(|(_, elder_info)| elder_info.member_names())
-            })
+            .and_then(|chain| chain.get_section(prefix))
+            .map(|info| info.member_names())
             .unwrap_or_default()
     }
 


### PR DESCRIPTION
It now takes into account that two emulated-BLS signatures might not be equal according to their `Eq` impl even though they are each created from threshold + 1 signature shares from the same set of nodes. This would possibly not be the case with real BLS.

Also modifies the simultaneous_joining_nodes test to stop polling once relevant conditions are met instead of waiting until all nodes become idle which might not always happen before the max number of poll iterations is exhausted.
