### PR TITLE
fix/routing: connect joining node on Join

### DIFF
--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -710,6 +710,7 @@ impl Elder {
             return;
         }
 
+        self.send_direct_message(&pub_id, DirectMessage::ConnectionResponse);
         self.vote_for_event(AccumulatingEvent::Online(pub_id));
     }
 


### PR DESCRIPTION
An error was triggered since commit:
`Remove most of PeerManager` (186772748d42de2957ad97bd61afee354588eca0)
`ERROR 13:05:46.985250496 [routing::states::elder mod.rs:1158] Elder(29937b..(00)) Failed to resolve signature target 0b038a..`

This is stopping newly joining node (elder) from sending direct messages
to other elder in the same section. This happens because the connection
is no longer established before the node is accepted.

My understanding, is Joining node use NodeInfo for sending the
JoinRequest, but this is not setting it up as connected. Before the
Joining node would have send ConnectionRequest and received
ConnectionResponse.

In order to fix that in a way that seem in line with new design, on
JoinRequest, the Elder send back a ConnectionResponse.

This eliminate the Error from the log file.
Additionally, it fixes the seed
`Some([4136990831, 3409479545, 2308001771, 3144967737])`
with the additional commit for
`Revert "Revert "Merge pull request #1785 from fizyk20/bls_epic_2""`
though it might be that the seed is no longer valid.

Test:
Verify the test no longer show the error.
Run test once.