### PR TITLE
fix/routing: correctly identify messages as non client

### DIFF
--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -30,11 +30,10 @@ use crate::{
     time::Duration,
     timer::Timer,
     xor_name::XorName,
-    InterfaceError, NetworkService,
+    NetworkService,
 };
 use itertools::Itertools;
 use std::fmt::{self, Display, Formatter};
-use std::net::SocketAddr;
 
 const POKE_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -284,11 +283,6 @@ impl Base for Adult {
 
     fn timer(&mut self) -> &mut Timer {
         &mut self.timer
-    }
-
-    fn handle_disconnect_client(&mut self, peer_addr: SocketAddr) -> Result<(), InterfaceError> {
-        self.disconnect_from(peer_addr);
-        Ok(())
     }
 
     fn handle_timeout(&mut self, token: u64, _: &mut dyn EventBox) -> Transition {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     crypto::Digest256,
     error::{BootstrapResponseError, InterfaceError, RoutingError},
-    event::{ClientEvent, Event},
+    event::Event,
     id::{FullId, PublicId},
     messages::{
         BootstrapResponse, DirectMessage, HopMessage, MessageContent, RoutingMessage,
@@ -38,11 +38,11 @@ use crate::{
     timer::Timer,
     utils::XorTargetInterval,
     xor_name::XorName,
-    BlsPublicKeySet, ConnectionInfo, NetworkBytes, NetworkService,
+    BlsPublicKeySet, ConnectionInfo, NetworkService,
 };
 use itertools::Itertools;
 use log::LogLevel;
-use quic_p2p::Token;
+#[cfg(feature = "mock_base")]
 use std::net::SocketAddr;
 use std::{
     cmp,
@@ -961,26 +961,6 @@ impl Base for Elder {
 
     fn timer(&mut self) -> &mut Timer {
         &mut self.timer
-    }
-
-    fn handle_connected_to_client(&mut self, peer_addr: SocketAddr, outbox: &mut dyn EventBox) {
-        let client_event = ClientEvent::ConnectedToClient { peer_addr };
-        outbox.send_event(From::from(client_event));
-    }
-
-    fn handle_disconnect_client(&mut self, peer_addr: SocketAddr) -> Result<(), InterfaceError> {
-        self.disconnect_from(peer_addr);
-        Ok(())
-    }
-
-    fn handle_send_msg_to_client(
-        &mut self,
-        peer_addr: SocketAddr,
-        msg: NetworkBytes,
-        token: Token,
-    ) -> Result<(), InterfaceError> {
-        self.send_msg_to_client(peer_addr, msg, token);
-        Ok(())
     }
 
     fn handle_send_message(


### PR DESCRIPTION
Fix easy to reproduce failure in messages_during_churn:
-When connection is dropped by the destination because of split for
 example, we get a quic_p2p error and we need to resend the message.
-Unfortunatly, we detected that message as from a client because we
 dropped the node information before getting this error.

 => Use a straightforward client detection by storing all client address
    in hash map. There may be many client but we can optimize as needed.

Also clean up interface: We were half delegating client handling to
vault and half handling it depending on our state.
=> Always delegate client handling to Vault regardless of state.
   Vault can decide what to do as an adult.

Test:
Soak tests pass
Clippy pass