### PR TITLE
Make elder_size and safe_section_size only configurable with mocks

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -18,7 +18,7 @@ mod proof;
 mod shared_state;
 
 pub use self::{
-    chain::{delivery_group_size, Chain, EldersChange, PrefixChangeOutcome},
+    chain::{delivery_group_size, Chain, EldersChange, NetworkParams, PrefixChangeOutcome},
     chain_accumulator::AccumulatingProof,
     elders_info::EldersInfo,
     member_info::{AgeCounter, MemberInfo, MemberPersona, MemberState, MIN_AGE, MIN_AGE_COUNTER},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ use crate::mock::quic_p2p;
 pub use crate::{
     chain::{
         bls_key_set_from_elders_info, delivery_group_size, elders_info_for_test,
-        section_proof_chain_from_elders_info,
+        section_proof_chain_from_elders_info, NetworkParams,
     },
     messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
 };

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -13,8 +13,6 @@ use fxhash::FxHashSet;
 use std::{iter, net::SocketAddr};
 use unwrap::unwrap;
 
-const MIN_SECTION_SIZE: usize = 4;
-
 // Assert that the expression matches the expected pattern.
 macro_rules! assert_match {
     ($e:expr, $p:pat => $arm:expr) => {
@@ -31,7 +29,7 @@ macro_rules! assert_match {
 
 #[test]
 fn successful_bootstrap_node_to_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let a = Agent::node();
     let b = Agent::bootstrapped_node(&network, a.addr());
     a.expect_connected_to_node(&b.addr());
@@ -39,7 +37,7 @@ fn successful_bootstrap_node_to_node() {
 
 #[test]
 fn successful_bootstrap_client_to_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let a = Agent::node();
     let b = Agent::bootstrapped_client(&network, a.addr());
     a.expect_connected_to_client(&b.addr());
@@ -47,7 +45,7 @@ fn successful_bootstrap_client_to_node() {
 
 #[test]
 fn bootstrap_to_nonexisting_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let a_addr = network.gen_addr();
 
     let config = Config::node().with_hard_coded_contacts(iter::once(a_addr));
@@ -60,7 +58,7 @@ fn bootstrap_to_nonexisting_node() {
 
 #[test]
 fn bootstrap_to_multiple_nodes() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let bootstrappers: Vec<_> = (0..3).map(|_| Agent::node()).collect();
 
@@ -91,7 +89,7 @@ fn bootstrap_to_multiple_nodes() {
 
 #[test]
 fn bootstrap_using_bootstrap_cache() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     // Address of a bootstrap node that is currently offline.
     let a_addr = network.gen_addr();
@@ -117,7 +115,7 @@ fn bootstrap_using_bootstrap_cache() {
 
 #[test]
 fn successful_connect_node_to_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::node();
     let mut b = Agent::node();
 
@@ -126,7 +124,7 @@ fn successful_connect_node_to_node() {
 
 #[test]
 fn successful_connect_client_to_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::client();
     let mut b = Agent::node();
 
@@ -135,7 +133,7 @@ fn successful_connect_client_to_node() {
 
 #[test]
 fn connect_to_nonexisting_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::node();
     let b_addr = network.gen_addr();
 
@@ -147,7 +145,7 @@ fn connect_to_nonexisting_node() {
 
 #[test]
 fn connect_to_already_connected_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::node();
     let mut b = Agent::node();
 
@@ -162,7 +160,7 @@ fn connect_to_already_connected_node() {
 
 #[test]
 fn disconnect_incoming_bootstrap_connection() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let a = Agent::node();
     let mut b = Agent::bootstrapped_node(&network, a.addr());
@@ -177,7 +175,7 @@ fn disconnect_incoming_bootstrap_connection() {
 
 #[test]
 fn disconnect_outgoing_bootstrap_connection() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let b = Agent::bootstrapped_node(&network, a.addr());
@@ -192,7 +190,7 @@ fn disconnect_outgoing_bootstrap_connection() {
 
 #[test]
 fn disconnect_outgoing_connection() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let mut b = Agent::node();
@@ -208,7 +206,7 @@ fn disconnect_outgoing_connection() {
 
 #[test]
 fn disconnect_incoming_connection() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let mut b = Agent::node();
@@ -224,7 +222,7 @@ fn disconnect_incoming_connection() {
 
 #[test]
 fn send_to_connected_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let mut b = Agent::node();
@@ -241,7 +239,7 @@ fn send_to_connected_node() {
 
 #[test]
 fn send_to_disconnecting_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::node();
     let mut b = Agent::node();
 
@@ -259,7 +257,7 @@ fn send_to_disconnecting_node() {
 
 #[test]
 fn send_to_nonexisting_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let b_addr = network.gen_addr();
@@ -276,7 +274,7 @@ fn send_to_nonexisting_node() {
 
 #[test]
 fn send_without_connecting_first() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::node();
     let b = Agent::node();
 
@@ -293,7 +291,7 @@ fn send_without_connecting_first() {
 
 #[test]
 fn send_multiple_messages_without_connecting_first() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
     let mut a = Agent::node();
     let b = Agent::node();
 
@@ -318,7 +316,7 @@ fn send_multiple_messages_without_connecting_first() {
 
 #[test]
 fn our_connection_info_of_node() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let (tx, _) = mpmc::unbounded();
 
@@ -336,7 +334,7 @@ fn our_connection_info_of_node() {
 
 #[test]
 fn our_connection_info_of_client() {
-    let _network = Network::new(MIN_SECTION_SIZE, None);
+    let _network = Network::new(Default::default(), None);
 
     let (tx, _) = mpmc::unbounded();
     let mut client = unwrap!(Builder::new(tx).with_config(Config::client()).build());
@@ -346,7 +344,7 @@ fn our_connection_info_of_client() {
 
 #[test]
 fn bootstrap_cache() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let mut b = Agent::node();
@@ -365,7 +363,7 @@ fn bootstrap_cache() {
 
 #[test]
 fn drop_disconnects() {
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(Default::default(), None);
 
     let mut a = Agent::node();
     let a_addr = a.addr();

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -39,7 +39,6 @@ pub trait Base: Display {
     fn network_service_mut(&mut self) -> &mut NetworkService;
     fn full_id(&self) -> &FullId;
     fn in_authority(&self, auth: &Authority<XorName>) -> bool;
-    fn min_section_size(&self) -> usize;
     fn peer_map(&self) -> &PeerMap;
     fn peer_map_mut(&mut self) -> &mut PeerMap;
     fn timer(&mut self) -> &mut Timer;

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -9,13 +9,20 @@
 use super::{create_connected_nodes, gen_bytes, poll_all, sort_nodes_by_distance_to, TestNode};
 use rand::Rng;
 use routing::{
-    mock::Network, Authority, Event, EventStream, XorName, QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
+    mock::Network, Authority, Event, EventStream, NetworkParams, XorName, QUORUM_DENOMINATOR,
+    QUORUM_NUMERATOR,
 };
 
 #[test]
 fn messages_accumulate_with_quorum() {
     let section_size = 15;
-    let network = Network::new(8, None);
+    let network = Network::new(
+        NetworkParams {
+            elder_size: 8,
+            safe_section_size: 8,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes(&network, section_size);
 

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -10,7 +10,7 @@ use super::{
     create_connected_nodes, poll_all, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
 };
 use rand::Rng;
-use routing::{mock::Network, Event, EventStream};
+use routing::{mock::Network, Event, EventStream, NetworkParams};
 
 // Drop node at index and verify its own section detected it.
 fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {
@@ -31,9 +31,16 @@ fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {
 
 #[test]
 fn node_drops() {
-    let min_section_size = 8;
-    let network = Network::new(min_section_size, None);
-    let mut nodes = create_connected_nodes(&network, min_section_size + 2);
+    let elder_size = 8;
+    let safe_section_size = 8;
+    let network = Network::new(
+        NetworkParams {
+            elder_size,
+            safe_section_size,
+        },
+        None,
+    );
+    let mut nodes = create_connected_nodes(&network, elder_size + 2);
     drop_node(&mut nodes, 0);
 
     // Trigger poll_and_resend to allow remaining nodes to gossip and
@@ -46,10 +53,17 @@ fn node_drops() {
 fn node_restart() {
     // Idea of test: if a node disconnects from all other nodes, it should restart
     // (with the exception of the first node which is special).
-    let min_section_size = 5;
-    let network = Network::new(min_section_size, None);
+    let elder_size = 5;
+    let safe_section_size = 5;
+    let network = Network::new(
+        NetworkParams {
+            elder_size,
+            safe_section_size,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, min_section_size);
+    let mut nodes = create_connected_nodes(&network, elder_size);
 
     // Drop all but last node in random order:
     while nodes.len() > 1 {

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -8,15 +8,25 @@
 
 use super::{create_connected_nodes, poll_all};
 use rand::Rng;
-use routing::{mock::Network, Authority, Event, EventStream, QUORUM_DENOMINATOR, QUORUM_NUMERATOR};
+use routing::{
+    mock::Network, Authority, Event, EventStream, NetworkParams, QUORUM_DENOMINATOR,
+    QUORUM_NUMERATOR,
+};
 
 #[test]
 fn send() {
-    let min_section_size = 8;
-    let quorum = 1 + (min_section_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
-    let network = Network::new(min_section_size, None);
+    let elder_size = 8;
+    let safe_section_size = 8;
+    let quorum = 1 + (elder_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
+    let network = Network::new(
+        NetworkParams {
+            elder_size,
+            safe_section_size,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, min_section_size + 1);
+    let mut nodes = create_connected_nodes(&network, elder_size + 1);
 
     let sender_index = rng.gen_range(0, nodes.len());
     let src = Authority::Node(nodes[sender_index].name());
@@ -53,11 +63,18 @@ fn send() {
 
 #[test]
 fn send_and_receive() {
-    let min_section_size = 8;
-    let quorum = 1 + (min_section_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
-    let network = Network::new(min_section_size, None);
+    let elder_size = 8;
+    let safe_section_size = 8;
+    let quorum = 1 + (elder_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
+    let network = Network::new(
+        NetworkParams {
+            elder_size,
+            safe_section_size,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes(&network, min_section_size + 1);
+    let mut nodes = create_connected_nodes(&network, elder_size + 1);
 
     let sender_index = rng.gen_range(0, nodes.len());
     let src = Authority::Node(nodes[sender_index].name());

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -8,17 +8,23 @@
 
 use super::{
     add_connected_nodes_until_one_away_from_split, create_connected_nodes_until_split,
-    current_sections, poll_and_resend_with_options, PollOptions, TestNode, MIN_SECTION_SIZE,
+    current_sections, poll_and_resend_with_options, PollOptions, TestNode, LOWERED_ELDER_SIZE,
 };
 use rand::Rng;
-use routing::{mock::Network, FullId, NetworkConfig, Prefix, XorName};
+use routing::{mock::Network, FullId, NetworkConfig, NetworkParams, Prefix, XorName};
 use std::{iter, slice};
 
 #[test]
 fn relocate_without_split() {
     // Create a network of two sections, then trigger relocation of a random node from one section
     // into the other section.
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(
+        NetworkParams {
+            elder_size: LOWERED_ELDER_SIZE,
+            safe_section_size: LOWERED_ELDER_SIZE,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
 
@@ -56,7 +62,13 @@ fn relocate_causing_split() {
     // Create a network with at least two sections. Pick two sections: source and destination. Add
     // enough nodes to the destination section so it is one node shy of split. Then relocate a
     // random node from the source section to the destination section.
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(
+        NetworkParams {
+            elder_size: LOWERED_ELDER_SIZE,
+            safe_section_size: LOWERED_ELDER_SIZE,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
 
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
@@ -107,7 +119,13 @@ fn relocate_during_split() {
     // Create a network with at least two sections. Pick two sections: source and destination. Add
     // enough nodes to the destination section so it is one node shy of split. Then add one more
     // node to it and simultaneously relocate another random node from the source section to it.
-    let network = Network::new(MIN_SECTION_SIZE, None);
+    let network = Network::new(
+        NetworkParams {
+            elder_size: LOWERED_ELDER_SIZE,
+            safe_section_size: LOWERED_ELDER_SIZE,
+        },
+        None,
+    );
     let mut rng = network.new_rng();
 
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -10,7 +10,7 @@ use super::{create_connected_nodes_until_split, poll_all, Nodes, TestNode};
 use routing::{
     bls_key_set_from_elders_info, elders_info_for_test, mock::Network,
     section_proof_chain_from_elders_info, Authority, FullId, HopMessage, Message, MessageContent,
-    Prefix, RoutingMessage, SignedRoutingMessage, XorName,
+    NetworkParams, Prefix, RoutingMessage, SignedRoutingMessage, XorName,
 };
 use std::collections::BTreeSet;
 use std::iter;
@@ -44,8 +44,15 @@ fn message_with_invalid_security(fail_type: FailType) {
     //
     // Arrange
     //
-    let min_section_size = 3;
-    let network = Network::new(min_section_size, None);
+    let elder_size = 3;
+    let safe_section_size = 3;
+    let network = Network::new(
+        NetworkParams {
+            elder_size,
+            safe_section_size,
+        },
+        None,
+    );
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
 
     let their_node_pos = 0;


### PR DESCRIPTION
The ELDER_SIZE and SAFE_SECTION_SIZE constants will be used in production code; in mock tests, they will be available for setting like `min_section_size` was before.