### PR TITLE
track node responsiveness through votes

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -277,8 +277,10 @@ impl Chain {
                 .find(|(event, proofs)| self.is_valid_transition(event, proofs.parsec_proof_set()))
                 .map(|(event, _)| event.clone());
 
-            let opt_event_proofs =
-                opt_event.and_then(|event| self.chain_accumulator.poll_event(event));
+            let opt_event_proofs = opt_event.and_then(|event| {
+                self.chain_accumulator
+                    .poll_event(event, self.our_info().members().clone())
+            });
 
             match opt_event_proofs {
                 None => return Ok(None),
@@ -740,6 +742,12 @@ impl Chain {
     pub fn prove(&self, target: &Authority<XorName>) -> SectionProofChain {
         let first_index = self.proving_index(target);
         self.state.our_history.slice_from(first_index as usize)
+    }
+
+    /// Check which nodes are unresponsive.
+    pub fn check_vote_status(&mut self) -> BTreeSet<PublicId> {
+        let members = self.our_info().members().clone();
+        self.chain_accumulator.check_vote_status(&members)
     }
 
     /// Returns `true` if the given `NetworkEvent` is already accumulated and can be skipped.

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -501,6 +501,10 @@ impl Chain {
         let p2p_node = P2pNode::new(pub_id, connection_info);
         let _ = elders.remove(&p2p_node);
 
+        if self.our_id() == &pub_id {
+            self.is_elder = false;
+        }
+
         self.state.new_info = EldersInfo::new(
             elders,
             *self.state.new_info.prefix(),

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -17,6 +17,8 @@ mod network_event;
 mod proof;
 mod shared_state;
 
+#[cfg(feature = "mock_base")]
+pub use self::chain_accumulator::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW};
 pub use self::{
     chain::{delivery_group_size, Chain, EldersChange, NetworkParams, PrefixChangeOutcome},
     chain_accumulator::AccumulatingProof,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ pub(crate) use self::mock::crypto;
 #[cfg(feature = "mock_base")]
 #[doc(hidden)]
 pub mod test_consts {
+    pub use crate::chain::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW};
     pub use crate::states::{ADD_TIMEOUT, BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT};
 }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -247,6 +247,8 @@ pub trait Approved: Base {
             }
         }
 
+        self.check_voting_status();
+
         Ok(Transition::Stay)
     }
 
@@ -305,6 +307,18 @@ pub trait Approved: Base {
         }
 
         Ok(Transition::Stay)
+    }
+
+    // Checking members vote status and vote to remove those non-resposive nodes.
+    fn check_voting_status(&mut self) {
+        let unresponsive_nodes = self.chain_mut().check_vote_status();
+        let log_indent = self.log_ident();
+        for pub_id in unresponsive_nodes.iter() {
+            self.parsec_map_mut().vote_for(
+                AccumulatingEvent::Offline(*pub_id).into_network_event(),
+                &log_indent,
+            );
+        }
     }
 
     fn send_connection_request(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -403,7 +403,7 @@ impl Elder {
         for obs in drained_obs {
             let event = match obs {
                 parsec::Observation::Remove { peer_id, .. } => {
-                    AccumulatingEvent::Offline(peer_id).into_network_event()
+                    AccumulatingEvent::RemoveElder(peer_id).into_network_event()
                 }
                 parsec::Observation::OpaquePayload(event) => event,
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1396,6 +1396,9 @@ impl Elder {
     }
 
     pub fn has_unpolled_observations(&self) -> bool {
+        if !self.chain.is_self_elder() {
+            return false;
+        }
         self.parsec_map.has_unpolled_observations()
     }
 


### PR DESCRIPTION
Closes #1849 

This PR contains the work of enable routing checking responsiveness.

The current ChainAccumulator is utilised that each time there is a completed event, the snapshot of members becomes expected voters (with those provided proof removed from the list).
For incoming proofs, the provider will be removed from the list (if has its name).

For the nodes appeart too many times, it will be considered as non-responsive. A vote of `Offline` will then be casted against it. 