### PR TITLE
chore: remove redundant semicolon to fix build on nightly

### DIFF
--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -998,7 +998,7 @@ impl Elder {
         // we remove self in targets info and can do same by not
         // chaining us to conn_peer list here?
         let conn_peers = self.connected_peers();
-        let (targets, dg_size) = self.chain.targets(&routing_msg.dst, &conn_peers)?;;
+        let (targets, dg_size) = self.chain.targets(&routing_msg.dst, &conn_peers)?;
         Ok((
             targets
                 .into_iter()


### PR DESCRIPTION
The redundant semicolon warning exists on rust nightly, and so the build
fails due to `#![forbid(warnings)]`.