### PR TITLE
refactor/node: refactor Node API to be used by Vaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 bytes = "~0.4.12"
 config_file_handler = "~0.11.0"
-crossbeam-channel = "~0.3.8"
+crossbeam-channel = "~0.3.9"
 fake_clock = "~0.3.0"
 fxhash = "~0.2.1"
 hex = "~0.2.0"

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -17,7 +17,7 @@ use super::*;
 use crate::{
     messages::DirectMessage,
     mock::Network,
-    outbox::{EventBox, EventBuf},
+    outbox::EventBox,
     state_machine::{State, StateMachine, Transition},
     utils::LogIdent,
     NetworkConfig, NetworkService,
@@ -58,7 +58,6 @@ struct ElderUnderTest {
     pub full_id: FullId,
     pub other_full_ids: Vec<FullId>,
     pub other_parsec_map: Vec<ParsecMap>,
-    pub ev_buffer: EventBuf,
     pub elders_info: EldersInfo,
     pub candidate_id: PublicId,
 }
@@ -72,7 +71,6 @@ impl ElderUnderTest {
         let full_ids = (0..NO_SINGLE_VETO_VOTE_COUNT)
             .map(|_| FullId::new())
             .collect_vec();
-        let mut ev_buffer = EventBuf::new();
 
         let prefix = Prefix::<XorName>::default();
         let elders_info = unwrap!(EldersInfo::new(
@@ -93,7 +91,7 @@ impl ElderUnderTest {
         };
 
         let full_id = full_ids[0].clone();
-        let machine = make_state_machine(&full_id, &gen_pfx_info, min_section_size, &mut ev_buffer);
+        let machine = make_state_machine(&full_id, &gen_pfx_info, min_section_size, &mut ());
 
         let other_full_ids = full_ids[1..].iter().cloned().collect_vec();
         let other_parsec_map = other_full_ids
@@ -106,7 +104,6 @@ impl ElderUnderTest {
             full_id,
             other_full_ids,
             other_parsec_map,
-            ev_buffer,
             elders_info,
             candidate_id: *FullId::new().public_id(),
         };
@@ -241,11 +238,10 @@ impl ElderUnderTest {
         &mut self,
         msg: (DirectMessage, PublicId),
     ) -> Result<(), RoutingError> {
-        let _ = self.machine.elder_state_mut().handle_direct_message(
-            msg.0,
-            msg.1,
-            &mut self.ev_buffer,
-        )?;
+        let _ = self
+            .machine
+            .elder_state_mut()
+            .handle_direct_message(msg.0, msg.1, &mut ())?;
         Ok(())
     }
 
@@ -253,7 +249,7 @@ impl ElderUnderTest {
         match self
             .machine
             .elder_state_mut()
-            .handle_connected_to(conn_info, &mut self.ev_buffer)
+            .handle_connected_to(conn_info, &mut ())
         {
             Transition::Stay => (),
             _ => panic!("Unexpected transition"),

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -102,7 +102,7 @@ impl TestNode {
 
     pub fn resume(network: &Network, state: PausedState) -> Self {
         Self {
-            inner: Node::resume(state),
+            inner: Node::resume(state).0,
             network: network.clone(),
         }
     }
@@ -172,7 +172,7 @@ impl<'a> TestNodeBuilder<'a> {
     }
 
     pub fn create(self) -> TestNode {
-        let inner = unwrap!(self
+        let (inner, _node_rx) = unwrap!(self
             .inner
             .min_section_size(self.network.min_section_size())
             .create());


### PR DESCRIPTION
This change makes `StateMachine::step` non-blocking and consequently allows `Node` to process routing events in a non-blocking fashion.

As a result of this refactoring, we can now process arbitrary events within the scope of the Routing event loop, allowing us to confine the user code (e.g. Vaults) to the same thread as Routing.

This is achieved by using the `crossbeam_channel::Select` abstraction which allows to register multiple event receivers and listen on all of them at the same time.

Closes https://github.com/maidsafe/safe_vault/issues/878