### PR TITLE
fix out of order neighbour info

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -282,7 +282,8 @@ impl Chain {
         };
 
         match event {
-            AccumulatingEvent::SectionInfo(ref info) => {
+            AccumulatingEvent::SectionInfo(ref info)
+            | AccumulatingEvent::NeighbourInfo(ref info) => {
                 let old_neighbours: BTreeSet<_> = self.neighbour_elders_p2p().cloned().collect();
                 self.add_elders_info(info.clone(), proofs)?;
                 let new_neighbours: BTreeSet<_> = self.neighbour_elders_p2p().cloned().collect();
@@ -753,7 +754,7 @@ impl Chain {
     fn should_skip_accumulator(&self, event: &NetworkEvent) -> bool {
         // FIXME: may also need to handle non SI votes to not get handled multiple times
         let si = match event.payload {
-            AccumulatingEvent::SectionInfo(ref si) => si,
+            AccumulatingEvent::SectionInfo(ref si) | AccumulatingEvent::NeighbourInfo(ref si) => si,
             _ => return false,
         };
 
@@ -781,7 +782,8 @@ impl Chain {
     /// Returns `true` for other types of `NetworkEvent`.
     fn is_valid_transition(&self, network_event: &AccumulatingEvent, proofs: &ProofSet) -> bool {
         match *network_event {
-            AccumulatingEvent::SectionInfo(ref info) => {
+            AccumulatingEvent::SectionInfo(ref info)
+            | AccumulatingEvent::NeighbourInfo(ref info) => {
                 // Reject any info we have a newer compatible info for.
                 let is_newer = |i: &EldersInfo| {
                     info.prefix().is_compatible(i.prefix()) && i.version() >= info.version()
@@ -843,7 +845,8 @@ impl Chain {
             (PrefixChange::None, _)
             | (PrefixChange::Merging, AccumulatingEvent::OurMerge)
             | (PrefixChange::Merging, AccumulatingEvent::NeighbourMerge(_)) => true,
-            (_, AccumulatingEvent::SectionInfo(elders_info)) => {
+            (_, AccumulatingEvent::SectionInfo(elders_info))
+            | (_, AccumulatingEvent::NeighbourInfo(elders_info)) => {
                 if elders_info.prefix().is_compatible(self.our_prefix())
                     && elders_info.version() > self.state.new_info.version()
                 {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -784,15 +784,15 @@ impl Chain {
         match *network_event {
             AccumulatingEvent::SectionInfo(ref info)
             | AccumulatingEvent::NeighbourInfo(ref info) => {
-                // Reject any info we have a newer compatible info for.
-                let is_newer = |i: &EldersInfo| {
-                    info.prefix().is_compatible(i.prefix()) && i.version() >= info.version()
+                // Do not process yet any version that is not the immediate follower of the one we have.
+                let not_follow = |i: &EldersInfo| {
+                    info.prefix().is_compatible(i.prefix()) && *info.version() != (i.version() + 1)
                 };
                 if self
                     .compatible_neighbour_info(info)
                     .into_iter()
                     .chain(iter::once(self.our_info()))
-                    .any(is_newer)
+                    .any(not_follow)
                 {
                     return false;
                 }

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -124,11 +124,6 @@ impl AccumulatingProof {
         new_share && new_proof
     }
 
-    /// Returns whether the set contains a signature by that ID.
-    pub fn contains_id(&self, id: &PublicId) -> bool {
-        self.parsec_proofs.contains_id(id)
-    }
-
     pub fn parsec_proof_set(&self) -> &ProofSet {
         &self.parsec_proofs
     }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -120,15 +120,6 @@ impl AccumulatingEvent {
             signature,
         }
     }
-
-    pub fn elders_info(&self) -> Option<&EldersInfo> {
-        match self {
-            AccumulatingEvent::SectionInfo(info) | AccumulatingEvent::NeighbourInfo(info) => {
-                Some(info)
-            }
-            _ => None,
-        }
-    }
 }
 
 impl Debug for AccumulatingEvent {
@@ -169,12 +160,6 @@ pub struct NetworkEvent {
 }
 
 impl NetworkEvent {
-    /// Returns the payload if this is a `SectionInfo` event.
-    #[cfg(feature = "mock_base")]
-    pub fn elders_info(&self) -> Option<&EldersInfo> {
-        self.payload.elders_info()
-    }
-
     /// Convert `NetworkEvent` into a Parsec Observation
     pub fn into_obs(self) -> Result<parsec::Observation<NetworkEvent, PublicId>, RoutingError> {
         Ok(match self {

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -78,7 +78,10 @@ pub enum AccumulatingEvent {
     NeighbourMerge(Digest256),
     SectionInfo(EldersInfo),
 
-    // Voted for received message with keys to we can update their_keys
+    // Voted for received message with info to update neighbour_info.
+    NeighbourInfo(EldersInfo),
+
+    // Voted for received message with keys to update their_keys
     TheirKeyInfo(SectionKeyInfo),
 
     // Voted for received AckMessage to update their_knowledge
@@ -120,7 +123,9 @@ impl AccumulatingEvent {
 
     pub fn elders_info(&self) -> Option<&EldersInfo> {
         match self {
-            AccumulatingEvent::SectionInfo(info) => Some(info),
+            AccumulatingEvent::SectionInfo(info) | AccumulatingEvent::NeighbourInfo(info) => {
+                Some(info)
+            }
             _ => None,
         }
     }
@@ -138,6 +143,9 @@ impl Debug for AccumulatingEvent {
                 write!(formatter, "NeighbourMerge({:.14?})", HexFmt(digest))
             }
             AccumulatingEvent::SectionInfo(info) => write!(formatter, "SectionInfo({:?})", info),
+            AccumulatingEvent::NeighbourInfo(info) => {
+                write!(formatter, "NeighbourInfo({:?})", info)
+            }
             AccumulatingEvent::TheirKeyInfo(payload) => {
                 write!(formatter, "TheirKeyInfo({:?})", payload)
             }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -270,7 +270,8 @@ pub trait Approved: Base {
                 }
                 AccumulatingEvent::OurMerge => self.handle_our_merge_event()?,
                 AccumulatingEvent::NeighbourMerge(_) => self.handle_neighbour_merge_event()?,
-                AccumulatingEvent::SectionInfo(elders_info) => {
+                AccumulatingEvent::SectionInfo(elders_info)
+                | AccumulatingEvent::NeighbourInfo(elders_info) => {
                     match self.handle_section_info_event(
                         elders_info,
                         our_pfx,

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -436,7 +436,8 @@ impl Elder {
                 | AccumulatingEvent::Relocate(_) => false,
 
                 // Keep: Additional signatures for neighbours for sec-msg-relay.
-                AccumulatingEvent::SectionInfo(ref elders_info) => {
+                AccumulatingEvent::SectionInfo(ref elders_info)
+                | AccumulatingEvent::NeighbourInfo(ref elders_info) => {
                     our_pfx.is_neighbour(elders_info.prefix())
                 }
 
@@ -891,7 +892,7 @@ impl Elder {
 
     fn handle_neighbour_info(&mut self, elders_info: EldersInfo) -> Result<(), RoutingError> {
         if self.chain.is_new_neighbour(&elders_info) {
-            self.vote_for_section_info(elders_info)?;
+            self.vote_for_event(AccumulatingEvent::NeighbourInfo(elders_info));
         }
         Ok(())
     }

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -132,9 +132,11 @@ impl ElderUnderTest {
                 .zip(self.other_full_ids.iter())
                 .take(count)
                 .for_each(|(parsec, full_id)| {
-                    let sig_event = event
-                        .elders_info()
-                        .map(|info| unwrap!(SectionInfoSigPayload::new(info, &full_id)));
+                    let sig_event = if let AccumulatingEvent::SectionInfo(ref info) = event {
+                        Some(unwrap!(SectionInfoSigPayload::new(info, &full_id)))
+                    } else {
+                        None
+                    };
                     parsec.vote_for(
                         event.clone().into_network_event_with(sig_event),
                         &LogIdent::new(&0),


### PR DESCRIPTION
Closes #1870 

The core of the solution is to ensure
 1- We do not process a NeighbourInfo before we processed its parent section.
 2 - We do not ignore NeighbourInfo because we voted for a follow up one (still needed for quorum).

Additionally, start isolating the NeighbourInfo Parsec event, as it is not the same as a SectionInfo.
Additional work was not required to fix this issue and can be done as needed or in other PRs.