### PR TITLE
fix/states: remove timeout for Adult to transition to Elder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub(crate) use self::mock::crypto;
 #[doc(hidden)]
 pub mod test_consts {
     pub use crate::chain::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW};
-    pub use crate::states::{ADD_TIMEOUT, BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT};
+    pub use crate::states::{BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT};
 }
 
 #[cfg(test)]

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -17,9 +17,7 @@ pub use self::{
 };
 
 #[cfg(feature = "mock_base")]
-pub use self::{
-    adult::ADD_TIMEOUT, bootstrapping_peer::BOOTSTRAP_TIMEOUT, joining_peer::JOIN_TIMEOUT,
-};
+pub use self::{bootstrapping_peer::BOOTSTRAP_TIMEOUT, joining_peer::JOIN_TIMEOUT};
 
 //
 // # The state machine

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -299,7 +299,6 @@ pub fn poll_and_resend_with_options(nodes: &mut [TestNode], mut options: PollOpt
             FakeClock::advance_time(
                 test_consts::BOOTSTRAP_TIMEOUT
                     .max(test_consts::JOIN_TIMEOUT)
-                    .max(test_consts::ADD_TIMEOUT)
                     .as_secs()
                     * 1000
                     + 1,


### PR DESCRIPTION
This failed with Seed Some([2536718493, 1108160782, 926471325, 1679426090])
on check_section_info_ack with features=mock_base.

The problem is that this did not leave enough iteration for Parsec to
reach consensus on both AddElder and the new SectionInfo.

This timeout does also not make sense in the context of node ageing
since most Adult will stay adults and not transition to Elder.

Test:
Clippy + Soak test + mock_base with seed passing.