### PR TITLE
Replace member container in `EldersInfo` and fix order trait impl

### DIFF
--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -163,7 +163,7 @@ mod test {
             .enumerate()
             .map(|(index, full_id)| {
                 (
-                    *full_id.public_id(),
+                    *full_id.public_id().name(),
                     P2pNode::new(
                         *full_id.public_id(),
                         ConnectionInfo {

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -162,12 +162,15 @@ mod test {
             .iter()
             .enumerate()
             .map(|(index, full_id)| {
-                P2pNode::new(
+                (
                     *full_id.public_id(),
-                    ConnectionInfo {
-                        peer_addr: ([127, 0, 0, 1], (index + 9000) as u16).into(),
-                        peer_cert_der: vec![],
-                    },
+                    P2pNode::new(
+                        *full_id.public_id(),
+                        ConnectionInfo {
+                            peer_addr: ([127, 0, 0, 1], (index + 9000) as u16).into(),
+                            peer_cert_der: vec![],
+                        },
+                    ),
                 )
             })
             .collect();

--- a/src/chain/bls_emu.rs
+++ b/src/chain/bls_emu.rs
@@ -70,7 +70,7 @@ impl PublicKeyShare {
 
 impl PublicKeySet {
     pub fn from_elders_info(elders_info: EldersInfo) -> Self {
-        let threshold = elders_info.members().len() * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
+        let threshold = elders_info.len() * THRESHOLD_NUMERATOR / THRESHOLD_DENOMINATOR;
         Self {
             threshold,
             elders_info,
@@ -87,7 +87,7 @@ impl PublicKeySet {
     {
         let sigs: BTreeMap<_, _> = shares
             .into_iter()
-            .filter(|(pk, _ss)| self.elders_info.members().contains(&pk.0))
+            .filter(|(pk, _ss)| self.elders_info.is_member(&pk.0))
             .map(|(pk, ss)| (pk.0, *ss))
             .collect();
         // In the BLS scheme, more than `threshold` valid signatures are needed to obtain a
@@ -114,8 +114,7 @@ impl PublicKey {
         sig.sigs
             .iter()
             .filter(|&(pk, ss)| {
-                self.0.elders_info.members().contains(pk)
-                    && PublicKeyShare(*pk).verify(ss, msg.as_ref())
+                self.0.elders_info.is_member(pk) && PublicKeyShare(*pk).verify(ss, msg.as_ref())
             })
             .count()
             > self.0.threshold

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -184,9 +184,11 @@ impl ChainAccumulator {
             .add_expectation(event, non_voted, &all_voters);
     }
 
-    pub fn check_vote_status(&mut self, members: &BTreeSet<PublicId>) -> BTreeSet<PublicId> {
+    pub fn check_vote_status<'a>(
+        &self,
+        members: impl Iterator<Item = &'a PublicId>,
+    ) -> BTreeSet<PublicId> {
         members
-            .iter()
             .filter(|peer_id| self.vote_statuses.is_unresponsive(peer_id))
             .cloned()
             .collect()
@@ -588,7 +590,7 @@ mod test {
         }
 
         let expected: BTreeSet<_> = iter::once(unresponsive_node).collect();
-        let detected = acc.check_vote_status(&members);
+        let detected = acc.check_vote_status(members.iter());
         assert_eq!(detected, expected);
     }
 }

--- a/src/chain/elders_info.rs
+++ b/src/chain/elders_info.rs
@@ -94,9 +94,7 @@ impl EldersInfo {
         self.members.keys().copied().collect()
     }
 
-    // WIP: remove me?
-    // WIP: rename to member_map?
-    pub fn p2p_members(&self) -> &BTreeMap<PublicId, P2pNode> {
+    pub fn member_map(&self) -> &BTreeMap<PublicId, P2pNode> {
         &self.members
     }
 
@@ -127,7 +125,7 @@ impl EldersInfo {
 
     /// Returns `true` if the proofs are from a quorum of this section.
     pub fn is_quorum(&self, proofs: &ProofSet) -> bool {
-        if proofs.len() * QUORUM_DENOMINATOR <= self.p2p_members().len() * QUORUM_NUMERATOR {
+        if proofs.len() * QUORUM_DENOMINATOR <= self.member_map().len() * QUORUM_NUMERATOR {
             return false;
         }
 
@@ -139,7 +137,7 @@ impl EldersInfo {
 
     /// Returns `true` if the proofs are from all members of this section.
     pub fn is_total_consensus(&self, proofs: &ProofSet) -> bool {
-        if proofs.len() < self.p2p_members().len() {
+        if proofs.len() < self.member_map().len() {
             return false;
         }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -37,8 +37,6 @@ use crate::PublicId;
 #[cfg(feature = "mock_base")]
 use crate::{error::RoutingError, id::P2pNode, BlsPublicKeySet, Prefix, XorName};
 use std::collections::BTreeMap;
-#[cfg(feature = "mock_base")]
-use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Formatter};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
@@ -76,7 +74,7 @@ pub fn bls_key_set_from_elders_info(elders_info: EldersInfo) -> BlsPublicKeySet 
 #[cfg(feature = "mock_base")]
 /// Test helper to create arbitrary elders nfo.
 pub fn elders_info_for_test(
-    members: BTreeSet<P2pNode>,
+    members: BTreeMap<PublicId, P2pNode>,
     prefix: Prefix<XorName>,
     version: u64,
 ) -> Result<EldersInfo, RoutingError> {

--- a/src/chain/proof.rs
+++ b/src/chain/proof.rs
@@ -105,11 +105,6 @@ impl ProofSet {
         self.sigs.keys()
     }
 
-    /// Returns the number of signatures.
-    pub fn len(&self) -> usize {
-        self.sigs.len()
-    }
-
     /// Removes the node's signature. Returns `false` if it already didn't exist.
     #[cfg(feature = "mock_base")]
     pub fn remove(&mut self, id: &PublicId) -> bool {

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -260,7 +260,7 @@ impl SharedState {
     /// Returns the current persona corresponding to the given PublicId or `None` if such a member
     /// doesn't exist
     pub fn get_persona(&self, pub_id: &PublicId) -> Option<MemberPersona> {
-        if self.our_info().members().contains(pub_id) {
+        if self.our_info().is_member(pub_id) {
             Some(MemberPersona::Elder)
         } else {
             self.our_members.get(pub_id).map(|member| {
@@ -320,13 +320,13 @@ impl SharedState {
             return false;
         }
 
-        if self.our_info().members().len() < min_section_size {
+        if self.our_info().len() < min_section_size {
             return true;
         }
 
         let needs_merge = |si: &EldersInfo| {
             pfx.is_compatible(&si.prefix().sibling())
-                && (si.members().len() < min_section_size || self.merging.contains(si.hash()))
+                && (si.len() < min_section_size || self.merging.contains(si.hash()))
         };
 
         neighbour_infos.into_iter().any(needs_merge)

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -616,7 +616,7 @@ mod tests {
             P2pNode::new(*full_id_2.public_id(), connection_info.clone()),
         ]
         .into_iter()
-        .map(|p2p_node| (*p2p_node.public_id(), p2p_node))
+        .map(|p2p_node| (*p2p_node.public_id().name(), p2p_node))
         .collect();
         let dummy_elders_info = unwrap!(EldersInfo::new(pub_ids, prefix, None));
         let dummy_pk_set = BlsPublicKeySet::from_elders_info(dummy_elders_info.clone());
@@ -678,7 +678,7 @@ mod tests {
         let src_section = unwrap!(EldersInfo::new(
             src_section_nodes
                 .into_iter()
-                .map(|node| (*node.public_id(), node))
+                .map(|node| (*node.public_id().name(), node))
                 .collect(),
             prefix,
             None,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -597,7 +597,7 @@ mod tests {
         xor_name::XorName,
     };
     use rand;
-    use std::collections::BTreeSet;
+    use std::collections::BTreeMap;
     use std::net::SocketAddr;
     use unwrap::unwrap;
 
@@ -611,11 +611,12 @@ mod tests {
             peer_cert_der: vec![],
         };
         let prefix = Prefix::new(0, *full_id.public_id().name());
-        let pub_ids: BTreeSet<_> = vec![
+        let pub_ids: BTreeMap<_, _> = vec![
             P2pNode::new(*full_id.public_id(), connection_info.clone()),
             P2pNode::new(*full_id_2.public_id(), connection_info.clone()),
         ]
         .into_iter()
+        .map(|p2p_node| (*p2p_node.public_id(), p2p_node))
         .collect();
         let dummy_elders_info = unwrap!(EldersInfo::new(pub_ids, prefix, None));
         let dummy_pk_set = BlsPublicKeySet::from_elders_info(dummy_elders_info.clone());
@@ -675,7 +676,10 @@ mod tests {
             P2pNode::new(*full_id_3.public_id(), connection_info.clone()),
         ];
         let src_section = unwrap!(EldersInfo::new(
-            src_section_nodes.into_iter().collect(),
+            src_section_nodes
+                .into_iter()
+                .map(|node| (*node.public_id(), node))
+                .collect(),
             prefix,
             None,
         ));

--- a/src/node.rs
+++ b/src/node.rs
@@ -377,7 +377,7 @@ impl Node {
     pub fn section_elders(&self, prefix: &Prefix<XorName>) -> BTreeSet<XorName> {
         self.chain()
             .and_then(|chain| chain.get_section(prefix))
-            .map(|info| info.member_names())
+            .map(|info| info.member_names().copied().collect())
             .unwrap_or_default()
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,7 +26,7 @@ use std::{net::SocketAddr, sync::mpsc};
 
 #[cfg(feature = "mock_base")]
 use {
-    crate::{chain::SectionProofChain, utils::XorTargetInterval, Chain, Prefix},
+    crate::{chain::SectionProofChain, id::P2pNode, utils::XorTargetInterval, Chain, Prefix},
     std::{
         collections::{BTreeMap, BTreeSet},
         fmt::{self, Display, Formatter},
@@ -383,7 +383,10 @@ impl Node {
 
     /// Returns a set of elders we should be connected to.
     pub fn elders(&self) -> impl Iterator<Item = &PublicId> {
-        self.chain().into_iter().flat_map(Chain::elders)
+        self.chain()
+            .into_iter()
+            .flat_map(Chain::elders)
+            .map(P2pNode::public_id)
     }
 
     /// Returns whether the given `PublicId` is a member of our section.

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -334,11 +334,16 @@ mod tests {
     }
 
     fn create_gen_pfx_info(full_ids: Vec<FullId>, version: u64) -> GenesisPfxInfo {
-        let socket_addr: SocketAddr = unwrap!("127.0.0.1:9999".parse());
+        let socket_addr: SocketAddr = ([127, 0, 0, 1], 9999).into();
         let connection_info = ConnectionInfo::from(socket_addr);
         let members = full_ids
             .iter()
-            .map(|id| P2pNode::new(*id.public_id(), connection_info.clone()))
+            .map(|id| {
+                (
+                    *id.public_id(),
+                    P2pNode::new(*id.public_id(), connection_info.clone()),
+                )
+            })
             .collect();
         let elders_info = unwrap!(EldersInfo::new_for_test(
             members,

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -274,16 +274,12 @@ impl ParsecMap {
 fn create(full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
     let rng = Box::new(utils::new_rng());
 
-    if gen_pfx_info
-        .first_info
-        .members()
-        .contains(full_id.public_id())
-    {
+    if gen_pfx_info.first_info.is_member(full_id.public_id()) {
         Parsec::from_genesis(
             #[cfg(feature = "mock_parsec")]
             *gen_pfx_info.first_info.hash(),
             full_id,
-            &gen_pfx_info.first_info.members(),
+            &gen_pfx_info.first_info.member_ids().copied().collect(),
             gen_pfx_info.first_state_serialized.clone(),
             ConsensusMode::Single,
             rng,
@@ -293,8 +289,8 @@ fn create(full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
             #[cfg(feature = "mock_parsec")]
             *gen_pfx_info.first_info.hash(),
             full_id,
-            &gen_pfx_info.first_info.members(),
-            &gen_pfx_info.latest_info.members(),
+            &gen_pfx_info.first_info.member_ids().copied().collect(),
+            &gen_pfx_info.latest_info.member_ids().copied().collect(),
             ConsensusMode::Single,
             rng,
         )
@@ -351,8 +347,7 @@ mod tests {
             version
         ));
         let first_ages = elders_info
-            .members()
-            .iter()
+            .member_ids()
             .map(|pub_id| (*pub_id, MIN_AGE_COUNTER))
             .collect();
         GenesisPfxInfo {

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -204,8 +204,7 @@ impl Adult {
         let recipients = self
             .gen_pfx_info
             .latest_info
-            .members()
-            .iter()
+            .member_ids()
             .filter(|pub_id| self.peer_map.has(pub_id))
             .copied()
             .collect_vec();

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -288,7 +288,7 @@ impl Elder {
 
         // Handle the SectionInfo event which triggered us becoming established node.
         let neighbour_change = EldersChange {
-            added: self.chain.neighbour_elders_p2p().cloned().collect(),
+            added: self.chain.neighbour_elder_nodes().cloned().collect(),
             removed: Default::default(),
         };
         let _ = self.handle_section_info_event(elders_info, old_pfx, neighbour_change, outbox)?;
@@ -1696,12 +1696,8 @@ impl Display for Elder {
 // Create `EldersInfo` for the first node.
 fn create_first_elders_info(p2p_node: P2pNode) -> Result<EldersInfo, RoutingError> {
     let name = *p2p_node.name();
-    EldersInfo::new(
-        iter::once(p2p_node).collect(),
-        Prefix::default(),
-        iter::empty(),
-    )
-    .map_err(|err| {
+    let node = (*p2p_node.public_id(), p2p_node);
+    EldersInfo::new(iter::once(node).collect(), Prefix::default(), iter::empty()).map_err(|err| {
         error!(
             "FirstNode({:?}) - Failed to create first EldersInfo: {:?}",
             name, err

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1696,7 +1696,7 @@ impl Display for Elder {
 // Create `EldersInfo` for the first node.
 fn create_first_elders_info(p2p_node: P2pNode) -> Result<EldersInfo, RoutingError> {
     let name = *p2p_node.name();
-    let node = (*p2p_node.public_id(), p2p_node);
+    let node = (name, p2p_node);
     EldersInfo::new(iter::once(node).collect(), Prefix::default(), iter::empty()).map_err(|err| {
         error!(
             "FirstNode({:?}) - Failed to create first EldersInfo: {:?}",

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1007,11 +1007,13 @@ impl Elder {
             // calculation. This even when going via RT would have only allowed route-0 to succeed
             // as by ack-failure, the new node would have been accepted to the RT.
             // Need a better network startup separation.
-            Authority::PrefixSection(pfx) => {
-                Iterator::flatten(self.chain.all_sections().map(|(_, si)| si.member_names()))
-                    .filter(|name| pfx.matches(name))
-                    .sorted_by(|lhs, rhs| src.name().cmp_distance(lhs, rhs))
-            }
+            Authority::PrefixSection(pfx) => self
+                .chain
+                .all_sections()
+                .flat_map(|(_, si)| si.member_names())
+                .filter(|name| pfx.matches(name))
+                .copied()
+                .sorted_by(|lhs, rhs| src.name().cmp_distance(lhs, rhs)),
             Authority::Node(_) => {
                 let mut result = BTreeSet::new();
                 let _ = result.insert(*self.name());
@@ -1132,7 +1134,7 @@ impl Elder {
         self.print_rt_size();
 
         for info in to_vote_infos {
-            let participants = info.members();
+            let participants: BTreeSet<_> = info.member_ids().copied().collect();
             let _ = self.dkg_cache.insert(participants.clone(), info);
             self.vote_for_event(AccumulatingEvent::StartDkg(participants));
         }
@@ -1147,7 +1149,7 @@ impl Elder {
     ) -> Result<(), RoutingError> {
         let self_info = self.chain.remove_elder(pub_id)?;
 
-        let participants = self_info.members();
+        let participants: BTreeSet<_> = self_info.member_ids().copied().collect();
         let _ = self.dkg_cache.insert(participants.clone(), self_info);
         self.vote_for_event(AccumulatingEvent::StartDkg(participants));
 
@@ -1250,7 +1252,7 @@ impl Base for Elder {
             self.gossip_timer_token = self.timer.schedule(GOSSIP_TIMEOUT);
 
             // If we're the only node then invoke parsec_poll directly
-            if self.chain.our_info().members().len() == 1 {
+            if self.chain.our_info().len() == 1 {
                 let _ = self.parsec_poll(outbox);
             }
 

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -73,7 +73,10 @@ impl ElderUnderTest {
         let elders_info = unwrap!(EldersInfo::new(
             full_ids
                 .iter()
-                .map(|id| P2pNode::new(*id.public_id(), connection_info.clone()))
+                .map(|id| (
+                    *id.public_id(),
+                    P2pNode::new(*id.public_id(), connection_info.clone())
+                ))
                 .collect(),
             prefix,
             iter::empty()
@@ -223,10 +226,9 @@ impl ElderUnderTest {
     fn new_elders_info_with_candidate(&self) -> EldersInfo {
         unwrap!(EldersInfo::new(
             self.elders_info
-                .p2p_members()
-                .iter()
+                .member_nodes()
                 .chain(iter::once(&self.candidate))
-                .cloned()
+                .map(|node| (*node.public_id(), node.clone()))
                 .collect(),
             *self.elders_info.prefix(),
             Some(&self.elders_info)

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -74,7 +74,7 @@ impl ElderUnderTest {
             full_ids
                 .iter()
                 .map(|id| (
-                    *id.public_id(),
+                    *id.public_id().name(),
                     P2pNode::new(*id.public_id(), connection_info.clone())
                 ))
                 .collect(),
@@ -228,7 +228,7 @@ impl ElderUnderTest {
             self.elders_info
                 .member_nodes()
                 .chain(iter::once(&self.candidate))
-                .map(|node| (*node.public_id(), node.clone()))
+                .map(|node| (*node.public_id().name(), node.clone()))
                 .collect(),
             *self.elders_info.prefix(),
             Some(&self.elders_info)

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -264,8 +264,7 @@ impl ElderUnderTest {
         self.elder_state()
             .chain()
             .our_info()
-            .members()
-            .contains(self.candidate.public_id())
+            .is_member(self.candidate.public_id())
     }
 
     fn handle_direct_message(&mut self, msg: (DirectMessage, P2pNode)) -> Result<(), RoutingError> {

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -238,7 +238,7 @@ impl ElderUnderTest {
     fn new_elders_info_without_candidate(&self) -> EldersInfo {
         let old_info = self.new_elders_info_with_candidate();
         unwrap!(EldersInfo::new(
-            self.elders_info.p2p_members().clone(),
+            self.elders_info.member_map().clone(),
             *old_info.prefix(),
             Some(&old_info)
         ))

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -12,7 +12,7 @@ use routing::{
     section_proof_chain_from_elders_info, Authority, ConnectionInfo, FullId, HopMessage, Message,
     MessageContent, NetworkParams, P2pNode, Prefix, RoutingMessage, SignedRoutingMessage, XorName,
 };
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::iter;
 use std::net::SocketAddr;
 
@@ -65,8 +65,11 @@ fn message_with_invalid_security(fail_type: FailType) {
     let fake_full = FullId::new();
     let socket_addr: SocketAddr = unwrap!("127.0.0.1:9999".parse());
     let connection_info = ConnectionInfo::from(socket_addr);
-    let members: BTreeSet<_> =
-        iter::once(P2pNode::new(*fake_full.public_id(), connection_info)).collect();
+    let members: BTreeMap<_, _> = iter::once((
+        *fake_full.public_id(),
+        P2pNode::new(*fake_full.public_id(), connection_info),
+    ))
+    .collect();
     let new_info = unwrap!(elders_info_for_test(members, our_prefix, 10001,));
 
     let routing_msg = RoutingMessage {


### PR DESCRIPTION
- Replace member container set with map in `EldersInfo`.
- Implement order traits correctly for `P2pNode`.
- Improve performance by not unnecessarily clone and collect into sets and maps in `EldersInfo` methods. The `churn` tests show a ~10% improvement for me locally on average.

These things were pointed out during the review of #1868 