### PR TITLE
handle disconnection only via unresponsiveness track

### DIFF
--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -156,7 +156,6 @@ impl ChainAccumulator {
     pub fn reset_accumulator(&mut self, our_id: &PublicId) -> RemainingEvents {
         let completed_events = mem::replace(&mut self.completed_events, Default::default());
         let chain_acc = mem::replace(&mut self.chain_accumulator, Default::default());
-        self.vote_statuses = Default::default();
 
         RemainingEvents {
             cached_events: chain_acc

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -134,11 +134,6 @@ impl PeerMap {
         self.forward.get(name.as_ref())
     }
 
-    // Returns an iterator over the public IDs of connected peers
-    pub fn connected_ids(&self) -> impl Iterator<Item = &PublicId> {
-        self.reverse.values().flatten()
-    }
-
     // Returns `true` if we have the connection info for a given public ID
     pub fn has<N: AsRef<XorName>>(&self, name: N) -> bool {
         self.forward.contains_key(name.as_ref())

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -353,11 +353,6 @@ impl Base for Adult {
         Transition::Stay
     }
 
-    fn handle_peer_lost(&mut self, pub_id: PublicId, _: &mut dyn EventBox) -> Transition {
-        debug!("{} - Lost peer {}", self, pub_id);
-        Transition::Stay
-    }
-
     fn handle_direct_message(
         &mut self,
         msg: DirectMessage,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -589,6 +589,10 @@ impl Approved for Adult {
         Ok(())
     }
 
+    fn check_vote_status(&mut self) {
+        debug!("{} - Not Required CheckVotingStatus For Adult", self);
+    }
+
     fn handle_their_key_info_event(
         &mut self,
         _key_info: SectionKeyInfo,

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -75,6 +75,9 @@ pub trait Approved: Base {
         neighbour_change: EldersChange,
     ) -> Result<(), RoutingError>;
 
+    /// Checks peers voting status to detect unresponsive nodes.
+    fn check_vote_status(&mut self);
+
     /// Handle an accumulated `TheirKeyInfo` event
     fn handle_their_key_info_event(&mut self, key_info: SectionKeyInfo)
         -> Result<(), RoutingError>;
@@ -279,7 +282,7 @@ pub trait Approved: Base {
             }
         }
 
-        self.check_voting_status();
+        self.check_vote_status();
 
         Ok(Transition::Stay)
     }
@@ -336,18 +339,6 @@ pub trait Approved: Base {
         }
 
         Ok(Transition::Stay)
-    }
-
-    // Checking members vote status and vote to remove those non-resposive nodes.
-    fn check_voting_status(&mut self) {
-        let unresponsive_nodes = self.chain_mut().check_vote_status();
-        let log_indent = self.log_ident();
-        for pub_id in unresponsive_nodes.iter() {
-            self.parsec_map_mut().vote_for(
-                AccumulatingEvent::Offline(*pub_id).into_network_event(),
-                &log_indent,
-            );
-        }
     }
 
     fn send_connection_request(

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -48,10 +48,6 @@ pub trait Base: Display {
         LogIdent::new(self)
     }
 
-    fn handle_peer_lost(&mut self, _pub_id: PublicId, _outbox: &mut dyn EventBox) -> Transition {
-        Transition::Stay
-    }
-
     fn handle_direct_message(
         &mut self,
         msg: DirectMessage,
@@ -237,23 +233,10 @@ pub trait Base: Display {
     fn handle_connection_failure(
         &mut self,
         peer_addr: SocketAddr,
-        outbox: &mut dyn EventBox,
+        _outbox: &mut dyn EventBox,
     ) -> Transition {
         trace!("{} - ConnectionFailure from {}", self, peer_addr);
-
-        let mut transition = Transition::Stay;
-
-        let pub_ids = self.peer_map_mut().disconnect(peer_addr);
-        for pub_id in pub_ids {
-            trace!("{} - ConnectionFailure from {}", self, pub_id);
-            let other_transition = self.handle_peer_lost(pub_id, outbox);
-
-            if let Transition::Stay = transition {
-                transition = other_transition
-            }
-        }
-
-        transition
+        Transition::Stay
     }
 
     fn handle_new_message(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1056,29 +1056,6 @@ impl Elder {
         Ok((targets.into_iter().cloned().collect(), dg_size))
     }
 
-    // Check whether we are connected to any elders. If this node loses all elder connections,
-    // it must be restarted.
-    fn check_elder_connections(&mut self, outbox: &mut dyn EventBox) -> bool {
-        if self
-            .peer_map()
-            .connected_ids()
-            .filter(|id| self.chain.our_id() != *id)
-            .any(|id| self.chain.is_peer_our_elder(id))
-        {
-            true
-        } else {
-            debug!("{} - Lost all elder connections.", self);
-
-            // Except network startup, restart in other cases.
-            if self.chain.our_info().version() > 0 {
-                outbox.send_event(Event::RestartRequired);
-                false
-            } else {
-                true
-            }
-        }
-    }
-
     fn check_signed_message_trust(&self, msg: &SignedRoutingMessage) -> Result<(), RoutingError> {
         if msg.check_trust(&self.chain) {
             Ok(())
@@ -1272,35 +1249,6 @@ impl Base for Elder {
         self.network_service
             .service_mut()
             .disconnect_from(conn_info.peer_addr);
-        Transition::Stay
-    }
-
-    fn handle_peer_lost(&mut self, pub_id: PublicId, outbox: &mut dyn EventBox) -> Transition {
-        debug!("{} - Lost peer {}", self, pub_id);
-
-        if !self.check_elder_connections(outbox) {
-            return Transition::Terminate;
-        }
-
-        if self.chain.is_peer_our_member(&pub_id) {
-            self.vote_for_event(AccumulatingEvent::Offline(pub_id));
-        }
-
-        if self.chain.is_peer_elder(&pub_id) {
-            debug!(
-                "{} - Sending connection request to {} due to lost peer.",
-                self, pub_id
-            );
-
-            let our_name = *self.name();
-            let _ = self.send_connection_request(
-                pub_id,
-                Authority::Node(our_name),
-                Authority::Node(*pub_id.name()),
-                outbox,
-            );
-        }
-
         Transition::Stay
     }
 


### PR DESCRIPTION
This PR contains the work of handling disconnection via responsiveness tracking.
The main idea is that when a disconnection of peer is detected, we now don't need to do anything.
Just leave it to the `responsive tracking` to report that peer as unresponsive and remove it later on.

Closes #1875 