### PR TITLE
Remove ConnectionRequest/Response - Part 2

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -663,6 +663,28 @@ impl Chain {
             .map(|member_info| member_info.p2p_node.connection_info())
     }
 
+    /// Returns a section member `P2pNode`
+    pub fn get_member_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
+        self.state
+            .our_members
+            .get(name)
+            .map(|member_info| &member_info.p2p_node)
+    }
+
+    /// Returns a neighbour `P2pNode`
+    pub fn get_neighbour_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
+        self.state
+            .neighbour_infos
+            .iter()
+            .find(|(pfx, _)| pfx.matches(name))
+            .and_then(|(_, elders_info)| elders_info.member_map().get(name))
+    }
+
+    pub fn get_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
+        self.get_member_p2p_node(name)
+            .or_else(|| self.get_neighbour_p2p_node(name))
+    }
+
     /// Returns a set of elders we should be connected to.
     pub fn elders(&self) -> impl Iterator<Item = &P2pNode> {
         self.neighbour_infos()

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -671,6 +671,14 @@ impl Chain {
             .map(|member_info| &member_info.p2p_node)
     }
 
+    /// Returns an old section member `P2pNode`
+    fn get_post_split_sibling_member_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
+        self.state
+            .post_split_sibling_members
+            .get(name)
+            .map(|member_info| &member_info.p2p_node)
+    }
+
     pub fn get_our_info_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
         self.state.our_info().member_map().get(name)
     }
@@ -688,6 +696,7 @@ impl Chain {
         self.get_member_p2p_node(name)
             .or_else(|| self.get_our_info_p2p_node(name))
             .or_else(|| self.get_neighbour_p2p_node(name))
+            .or_else(|| self.get_post_split_sibling_member_p2p_node(name))
     }
 
     /// Returns a set of elders we should be connected to.

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -701,6 +701,22 @@ impl Chain {
         self.neighbour_infos().flat_map(EldersInfo::member_nodes)
     }
 
+    /// Returns the elders for a neighbour section.
+    /// Returns None if the `Prefix` provided wasn't our own section or a neigbour.
+    pub fn get_section_elders(
+        &self,
+        names: &Prefix<XorName>,
+    ) -> Option<&BTreeMap<XorName, P2pNode>> {
+        if self.our_prefix() == names {
+            Some(self.our_info().member_map())
+        } else {
+            self.state
+                .neighbour_infos
+                .get(names)
+                .map(|elders_info| elders_info.member_map())
+        }
+    }
+
     /// Return the keys we know
     pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
         self.state.get_their_keys_info()

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -691,6 +691,7 @@ impl Chain {
     }
 
     /// Returns a set of elders we should be connected to.
+    // WIP: should we remove potential duplicates?
     pub fn elders(&self) -> impl Iterator<Item = &P2pNode> {
         self.neighbour_infos()
             .chain(iter::once(self.state.our_info()))

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -671,6 +671,10 @@ impl Chain {
             .map(|member_info| &member_info.p2p_node)
     }
 
+    pub fn get_our_info_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
+        self.state.our_info().member_map().get(name)
+    }
+
     /// Returns a neighbour `P2pNode`
     pub fn get_neighbour_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
         self.state
@@ -682,6 +686,7 @@ impl Chain {
 
     pub fn get_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
         self.get_member_p2p_node(name)
+            .or_else(|| self.get_our_info_p2p_node(name))
             .or_else(|| self.get_neighbour_p2p_node(name))
     }
 

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::ConnectionInfo;
+use crate::P2pNode;
 
 /// The type for counting the churn events experienced by a node
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
@@ -53,16 +53,16 @@ const MAX_INFANT_AGE: u32 = MIN_AGE as u32;
 pub struct MemberInfo {
     pub age_counter: AgeCounter,
     pub state: MemberState,
-    pub connection_info: ConnectionInfo,
+    pub p2p_node: P2pNode,
 }
 
 impl MemberInfo {
     /// Create new `MemberInfo` in the `Joined` state.
-    pub fn new(age: u8, connection_info: ConnectionInfo) -> Self {
+    pub fn new(age: u8, p2p_node: P2pNode) -> Self {
         Self {
             age_counter: AgeCounter::from_age(age),
             state: MemberState::Joined,
-            connection_info,
+            p2p_node,
         }
     }
 

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -134,17 +134,6 @@ impl PeerMap {
         self.forward.get(name.as_ref())
     }
 
-    // Get connection infos of the peers with the given names. Ignores unknown names.
-    pub fn get_connection_infos<I>(&self, names: I) -> impl Iterator<Item = &ConnectionInfo>
-    where
-        I: IntoIterator,
-        I::Item: AsRef<XorName>,
-    {
-        names
-            .into_iter()
-            .filter_map(move |name| self.get_connection_info(name))
-    }
-
     // Get PublicId for XorName
     pub fn get_id(&self, name: &XorName) -> Option<&PublicId> {
         self.forward

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -134,14 +134,6 @@ impl PeerMap {
         self.forward.get(name.as_ref())
     }
 
-    // Get PublicId for XorName
-    pub fn get_id(&self, name: &XorName) -> Option<&PublicId> {
-        self.forward
-            .get(name)
-            .and_then(|conn_info| self.reverse.get(&conn_info.peer_addr))
-            .and_then(|pub_ids| pub_ids.iter().find(|pub_id| pub_id.name() == name))
-    }
-
     // Returns an iterator over the public IDs of connected peers
     pub fn connected_ids(&self) -> impl Iterator<Item = &PublicId> {
         self.reverse.values().flatten()

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -424,14 +424,14 @@ impl Base for Adult {
             .cloned()
             .collect_vec();
 
-        for p2p_node in target_nodes {
+        for p2p_node in &target_nodes {
             if self
                 .routing_msg_filter
                 .filter_outgoing(signed_msg.routing_message(), p2p_node.public_id())
                 .is_new()
             {
                 let message = self.to_hop_message(signed_msg.clone())?;
-                self.send_message(&p2p_node, message);
+                self.send_message(p2p_node, message);
             }
         }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -417,8 +417,7 @@ pub trait Approved: Base {
 
         self.peer_map_mut()
             .insert(their_pub_id, their_conn_info.clone());
-        let their_p2p_node = P2pNode::new(their_pub_id, their_conn_info);
-        self.send_direct_message(&their_p2p_node, DirectMessage::ConnectionResponse);
+        self.send_direct_message(&their_conn_info, DirectMessage::ConnectionResponse);
 
         Ok(())
     }

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -390,7 +390,7 @@ pub trait Base: Display {
     ) {
         let conn_infos: Vec<_> = dst_targets
             .iter()
-            .filter_map(|dst| dst.resolve(self.peer_map()).cloned())
+            .filter_map(|dst| dst.resolve().cloned())
             .collect();
 
         if conn_infos.len() < dg_size {
@@ -401,7 +401,7 @@ pub trait Base: Display {
                 dst_targets,
                 dst_targets
                     .iter()
-                    .filter(|dst| dst.resolve(self.peer_map()).is_some())
+                    .filter(|dst| dst.resolve().is_some())
                     .format(", "),
                 message
             );
@@ -512,24 +512,18 @@ pub fn from_network_bytes(data: NetworkBytes) -> Result<Message, RoutingError> {
 
 /// A trait for types used to identify recipients of messages.
 pub trait MessageRecipient: Debug {
-    /// Resolve this recipient to a ConnectionInfo using the given PeerMap.
-    fn resolve<'a>(&'a self, peer_map: &'a PeerMap) -> Option<&'a ConnectionInfo>;
-}
-
-impl MessageRecipient for PublicId {
-    fn resolve<'a>(&'a self, peer_map: &'a PeerMap) -> Option<&'a ConnectionInfo> {
-        peer_map.get_connection_info(self)
-    }
-}
-
-impl MessageRecipient for XorName {
-    fn resolve<'a>(&'a self, peer_map: &'a PeerMap) -> Option<&'a ConnectionInfo> {
-        peer_map.get_connection_info(self)
-    }
+    /// Resolve this recipient to a ConnectionInfo.
+    fn resolve(&self) -> Option<&ConnectionInfo>;
 }
 
 impl MessageRecipient for ConnectionInfo {
-    fn resolve(&self, _: &PeerMap) -> Option<&ConnectionInfo> {
+    fn resolve(&self) -> Option<&ConnectionInfo> {
         Some(self)
+    }
+}
+
+impl MessageRecipient for P2pNode {
+    fn resolve(&self) -> Option<&ConnectionInfo> {
+        Some(self.connection_info())
     }
 }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -954,18 +954,13 @@ impl Elder {
         // If the message is to a single node and we have the connection info for this node, don't
         // go through the routing table
         let single_target = if let Authority::Node(node_name) = dst {
-            // WIP: remove calls to peer_map
-            self.peer_map.get_id(&node_name).and_then(|public_id| {
-                self.peer_map
-                    .get_connection_info(public_id)
-                    .map(|connection_info| P2pNode::new(*public_id, connection_info.clone()))
-            })
+            self.chain.get_p2p_node(&node_name)
         } else {
             None
         };
 
         let (target_p2p_nodes, dg_size) = if let Some(target) = single_target {
-            (vec![target], 1)
+            (vec![target.clone()], 1)
         } else {
             // WIP: neet to get targets without using the peer_map (get_targets uses peer_map
             // internally)

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1054,18 +1054,6 @@ impl Elder {
         ))
     }
 
-    // TODO: Once `Chain::targets` uses the ideal state instead of the actually connected peers,
-    // this should be removed.
-    /// Returns all peers we are currently connected to, according to the peer manager, including
-    /// ourselves.
-    fn connected_peers(&self) -> Vec<&XorName> {
-        self.peer_map
-            .connected_ids()
-            .map(|pub_id| pub_id.name())
-            .chain(iter::once(self.name()))
-            .collect()
-    }
-
     // Check whether we are connected to any elders. If this node loses all elder connections,
     // it must be restarted.
     fn check_elder_connections(&mut self, outbox: &mut dyn EventBox) -> bool {
@@ -1181,7 +1169,9 @@ impl Base for Elder {
     }
 
     fn close_group(&self, name: XorName, count: usize) -> Option<Vec<XorName>> {
-        let conn_peers = self.connected_peers();
+        let mut conn_peers: Vec<_> = self.chain.elders().map(P2pNode::name).collect();
+        conn_peers.sort_unstable();
+        conn_peers.dedup();
         self.chain.closest_names(&name, count, &conn_peers)
     }
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1042,16 +1042,8 @@ impl Elder {
         &self,
         routing_msg: &RoutingMessage,
     ) -> Result<(Vec<P2pNode>, usize), RoutingError> {
-        let conn_peers: Vec<_> = self.chain.elders().map(P2pNode::name).collect();
-        let (targets, dg_size) = self.chain.targets(&routing_msg.dst, &conn_peers)?;
-        Ok((
-            targets
-                .into_iter()
-                .filter_map(|name| self.chain.get_p2p_node(&name))
-                .cloned()
-                .collect(),
-            dg_size,
-        ))
+        let (targets, dg_size) = self.chain.targets(&routing_msg.dst)?;
+        Ok((targets.into_iter().cloned().collect(), dg_size))
     }
 
     // Check whether we are connected to any elders. If this node loses all elder connections,

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1416,21 +1416,18 @@ impl Base for Elder {
                         self.send_signed_message(&mut msg)?;
                     }
                 }
-            } else if let Some(&pub_id) = self.peer_map.get_id(&target) {
+            } else if let Some(p2p_node) = self.chain.get_p2p_node(&target) {
                 trace!(
                     "{} Sending a signature for message {:?} to {:?}",
                     self,
                     signed_msg.routing_message(),
                     target
                 );
-                // WIP: remove using peer_map (and the unwra
-                if let Some(connection_info) = self.peer_map.get_connection_info(&pub_id) {
-                    let p2p_node = P2pNode::new(pub_id, connection_info.clone());
-                    self.send_direct_message(
-                        &p2p_node,
-                        DirectMessage::MessageSignature(signed_msg.clone()),
-                    );
-                }
+                let p2p_node = p2p_node.clone();
+                self.send_direct_message(
+                    &p2p_node,
+                    DirectMessage::MessageSignature(signed_msg.clone()),
+                );
             } else {
                 error!(
                     "{} Failed to resolve signature target {:?} for message {:?}",

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -838,10 +838,12 @@ impl Elder {
             return Transition::Stay;
         }
 
-        let names = self.chain.closest_section(&details.content().destination).1;
-        let conn_infos = self
-            .peer_map
-            .get_connection_infos(&names)
+        let closest_section = self.chain.closest_section(&details.content().destination).0;
+        let conn_infos: Vec<_> = self
+            .chain
+            .get_section_elders(&closest_section)
+            .iter()
+            .flat_map(|nodes| nodes.values().map(P2pNode::connection_info))
             .cloned()
             .collect();
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -738,11 +738,12 @@ impl Elder {
                 p2p_nodes: self.chain.our_elders().cloned().collect(),
             }
         } else {
-            let names = self.chain.closest_section(name).1;
-            let conn_infos = self
-                .peer_map
-                .get_connection_infos(&names)
-                .cloned()
+            let closest_section = self.chain.closest_section(name).0;
+            let conn_infos: Vec<_> = self
+                .chain
+                .get_section_elders(&closest_section)
+                .iter()
+                .flat_map(|p2p_nodes| p2p_nodes.values().map(P2pNode::connection_info).cloned())
                 .collect();
             debug!(
                 "{} - Sending BootstrapResponse::Rebootstrap to {}",

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -318,8 +318,8 @@ impl Elder {
         self.chain.public_key_set()
     }
 
-    fn handle_parsec_poke(&mut self, msg_version: u64, pub_id: PublicId) {
-        self.send_parsec_gossip(Some((msg_version, pub_id)))
+    fn handle_parsec_poke(&mut self, msg_version: u64, p2p_node: P2pNode) {
+        self.send_parsec_gossip(Some((msg_version, p2p_node)))
     }
 
     /// Votes for `Merge` if necessary, or for the merged `SectionInfo` if both siblings have
@@ -363,7 +363,7 @@ impl Elder {
             if !self.peer_map.has(&pub_id) {
                 self.peer_map
                     .insert(pub_id, p2p_node.connection_info().clone());
-                self.send_direct_message(&pub_id, DirectMessage::ConnectionResponse);
+                self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
             };
         }
 
@@ -378,7 +378,7 @@ impl Elder {
             let pub_id = p2p_node.public_id();
             self.peer_map
                 .insert(*pub_id, p2p_node.connection_info().clone());
-            self.send_direct_message(pub_id, DirectMessage::ConnectionResponse);
+            self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
         }
     }
 
@@ -651,7 +651,7 @@ impl Elder {
             );
             self.peer_map
                 .insert(pub_id, p2p_node.connection_info().clone());
-            self.send_direct_message(&pub_id, DirectMessage::ConnectionResponse);
+            self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
         };
 
         let trimmed_info = GenesisPfxInfo {
@@ -680,14 +680,15 @@ impl Elder {
     // If this returns an error, the peer will be dropped.
     fn handle_bootstrap_request(
         &mut self,
-        pub_id: PublicId,
+        p2p_node: P2pNode,
         name: XorName,
     ) -> Result<(), RoutingError> {
         debug!(
             "{} - Received BootstrapRequest to section at {} from {:?}.",
-            self, name, pub_id
+            self, name, p2p_node
         );
 
+        let pub_id = *p2p_node.public_id();
         if !self.peer_map.has(&pub_id) {
             log_or_panic!(
                 LogLevel::Error,
@@ -715,7 +716,7 @@ impl Elder {
                 self.chain.elder_size() - 1
             );
             self.send_direct_message(
-                &pub_id,
+                &p2p_node,
                 DirectMessage::BootstrapResponse(BootstrapResponse::Error(
                     BootstrapResponseError::TooFewPeers,
                 )),
@@ -724,15 +725,14 @@ impl Elder {
             return Ok(());
         }
 
-        self.respond_to_bootstrap_request(&pub_id, &name);
+        self.respond_to_bootstrap_request(&p2p_node, &name);
 
         Ok(())
     }
 
-    fn respond_to_bootstrap_request(&mut self, pub_id: &PublicId, name: &XorName) {
+    fn respond_to_bootstrap_request(&mut self, p2p_node: &P2pNode, name: &XorName) {
         let response = if self.our_prefix().matches(name) {
-            debug!("{} - Sending BootstrapResponse::Join to {}", self, pub_id);
-
+            debug!("{} - Sending BootstrapResponse::Join to {}", self, p2p_node);
             BootstrapResponse::Join {
                 prefix: *self.chain.our_prefix(),
                 p2p_nodes: self.chain.our_elders().cloned().collect(),
@@ -746,11 +746,11 @@ impl Elder {
                 .collect();
             debug!(
                 "{} - Sending BootstrapResponse::Rebootstrap to {}",
-                self, pub_id
+                self, p2p_node
             );
             BootstrapResponse::Rebootstrap(conn_infos)
         };
-        self.send_direct_message(pub_id, DirectMessage::BootstrapResponse(response));
+        self.send_direct_message(p2p_node, DirectMessage::BootstrapResponse(response));
     }
 
     fn handle_connection_response(&mut self, pub_id: PublicId, _: &mut dyn EventBox) {
@@ -816,7 +816,7 @@ impl Elder {
             MIN_AGE
         };
 
-        self.send_direct_message(&pub_id, DirectMessage::ConnectionResponse);
+        self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
         self.vote_for_event(AccumulatingEvent::Online(OnlinePayload { p2p_node, age }))
     }
 
@@ -953,29 +953,47 @@ impl Elder {
         // If the message is to a single node and we have the connection info for this node, don't
         // go through the routing table
         let single_target = if let Authority::Node(node_name) = dst {
-            self.peer_map.get_id(&node_name)
+            // WIP: remove calls to peer_map
+            self.peer_map.get_id(&node_name).and_then(|public_id| {
+                self.peer_map
+                    .get_connection_info(public_id)
+                    .map(|connection_info| P2pNode::new(*public_id, connection_info.clone()))
+            })
         } else {
             None
         };
 
-        let (target_pub_ids, dg_size) = if let Some(target) = single_target {
-            (vec![*target], 1)
+        let (target_p2p_nodes, dg_size) = if let Some(target) = single_target {
+            (vec![target], 1)
         } else {
-            self.get_targets(signed_msg.routing_message())?
+            // WIP: neet to get targets without using the peer_map (get_targets uses peer_map
+            // internally)
+            let (targets, dg_size) = self.get_targets(signed_msg.routing_message())?;
+            (
+                targets
+                    .into_iter()
+                    .filter_map(|public_id| {
+                        self.peer_map
+                            .get_connection_info(&public_id)
+                            .map(|conn_info| P2pNode::new(public_id, conn_info.clone()))
+                    })
+                    .collect(),
+                dg_size,
+            )
         };
 
         trace!(
             "{}: Sending message {:?} via targets {:?}",
             self,
             signed_msg,
-            target_pub_ids
+            target_p2p_nodes
         );
 
-        let targets: Vec<_> = target_pub_ids
+        let targets: Vec<_> = target_p2p_nodes
             .into_iter()
-            .filter(|pub_id| {
+            .filter(|p2p_node| {
                 self.routing_msg_filter
-                    .filter_outgoing(signed_msg.routing_message(), pub_id)
+                    .filter_outgoing(signed_msg.routing_message(), p2p_node.public_id())
                     .is_new()
             })
             .collect();
@@ -1320,11 +1338,12 @@ impl Base for Elder {
         outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
         let pub_id = *p2p_node.public_id();
+
         use crate::messages::DirectMessage::*;
         match msg {
             MessageSignature(msg) => self.handle_message_signature(msg, pub_id)?,
             BootstrapRequest(name) => {
-                if let Err(error) = self.handle_bootstrap_request(pub_id, name) {
+                if let Err(error) = self.handle_bootstrap_request(p2p_node, name) {
                     warn!(
                         "{} Invalid BootstrapRequest received from {} ({:?}).",
                         self, pub_id, error,
@@ -1333,9 +1352,9 @@ impl Base for Elder {
             }
             ConnectionResponse => self.handle_connection_response(pub_id, outbox),
             JoinRequest(payload) => self.handle_join_request(p2p_node, payload),
-            ParsecPoke(version) => self.handle_parsec_poke(version, pub_id),
+            ParsecPoke(version) => self.handle_parsec_poke(version, p2p_node),
             ParsecRequest(version, par_request) => {
-                return self.handle_parsec_request(version, par_request, pub_id, outbox);
+                return self.handle_parsec_request(version, par_request, p2p_node, outbox);
             }
             ParsecResponse(version, par_response) => {
                 return self.handle_parsec_response(version, par_response, pub_id, outbox);
@@ -1408,10 +1427,14 @@ impl Base for Elder {
                     signed_msg.routing_message(),
                     target
                 );
-                self.send_direct_message(
-                    &pub_id,
-                    DirectMessage::MessageSignature(signed_msg.clone()),
-                );
+                // WIP: remove using peer_map (and the unwra
+                if let Some(connection_info) = self.peer_map.get_connection_info(&pub_id) {
+                    let p2p_node = P2pNode::new(pub_id, connection_info.clone());
+                    self.send_direct_message(
+                        &p2p_node,
+                        DirectMessage::MessageSignature(signed_msg.clone()),
+                    );
+                }
             } else {
                 error!(
                     "{} Failed to resolve signature target {:?} for message {:?}",
@@ -1453,7 +1476,7 @@ impl Elder {
 
     pub fn send_msg_to_targets(
         &mut self,
-        dst_targets: &[PublicId],
+        dst_targets: &[P2pNode],
         dg_size: usize,
         message: Message,
     ) {

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -289,14 +289,14 @@ impl ElderUnderTest {
     fn handle_bootstrap_request(&mut self, pub_id: PublicId, conn_info: ConnectionInfo) {
         let peer_addr = conn_info.peer_addr;
 
-        self.handle_connected_to(conn_info);
+        self.handle_connected_to(conn_info.clone());
         self.machine
             .elder_state_mut()
             .identify_connection(pub_id, peer_addr);
         unwrap!(self
             .machine
             .elder_state_mut()
-            .handle_bootstrap_request(pub_id, *pub_id.name()));
+            .handle_bootstrap_request(P2pNode::new(pub_id, conn_info), *pub_id.name()));
     }
 
     fn is_connected(&self, pub_id: &PublicId) -> bool {

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -145,8 +145,9 @@ impl JoiningPeer {
                 src: Authority::Node(_),
                 dst: Authority::Node(_),
             } => {
-                self.peer_map_mut().insert(pub_id, conn_info);
-                self.send_direct_message(&pub_id, DirectMessage::ConnectionResponse);
+                self.peer_map_mut().insert(pub_id, conn_info.clone());
+                let p2p_node = P2pNode::new(pub_id, conn_info);
+                self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
                 Ok(Transition::Stay)
             }
             _ => {

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -146,8 +146,7 @@ impl JoiningPeer {
                 dst: Authority::Node(_),
             } => {
                 self.peer_map_mut().insert(pub_id, conn_info.clone());
-                let p2p_node = P2pNode::new(pub_id, conn_info);
-                self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
+                self.send_direct_message(&conn_info, DirectMessage::ConnectionResponse);
                 Ok(Transition::Stay)
             }
             _ => {

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -25,7 +25,11 @@ fn get_position_with_other_prefix(nodes: &Nodes, prefix: &Prefix<XorName>) -> us
 }
 
 fn send_message(nodes: &mut Nodes, src: usize, dst: usize, message: Message) {
-    let targets = vec![unwrap!(nodes[dst].inner.id())];
+    let public_id = unwrap!(nodes[dst].inner.id());
+    let connection_info = unwrap!(nodes[dst].inner.our_connection_info());
+    let p2p_node = P2pNode::new(public_id, connection_info);
+    let targets = vec![p2p_node];
+
     let _ = nodes[src]
         .inner
         .elder_state_mut()


### PR DESCRIPTION
This is the second part of #1865 and removes most calls to `PeerMap`.