### PR TITLE
Remove ConnectionRequest/Response - Part 3

### DIFF
--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -43,9 +43,6 @@ pub enum DirectMessage {
     /// `BootstrapResponse::Join` to its `BootstrapRequest`.
     /// If the peer is being relocated, contains `RelocatePayload`. Otherwise contains `None`.
     JoinRequest(Option<RelocatePayload>),
-    /// Sent from members of a section to a joining node in response to `ConnectionRequest` (which is
-    /// a routing message)
-    ConnectionResponse,
     /// Poke a node to send us the first gossip request
     ParsecPoke(u64),
     /// Parsec request message
@@ -87,7 +84,6 @@ impl Debug for DirectMessage {
                     .as_ref()
                     .map(|payload| payload.details.content())
             ),
-            ConnectionResponse => write!(formatter, "ConnectionResponse"),
             ParsecRequest(v, _) => write!(formatter, "ParsecRequest({}, _)", v),
             ParsecResponse(v, _) => write!(formatter, "ParsecResponse({}, _)", v),
             ParsecPoke(v) => write!(formatter, "ParsecPoke({})", v),
@@ -112,7 +108,6 @@ impl Hash for DirectMessage {
             BootstrapRequest(name) => name.hash(state),
             BootstrapResponse(response) => response.hash(state),
             JoinRequest(payload) => payload.hash(state),
-            ConnectionResponse => (),
             ParsecPoke(version) => version.hash(state),
             ParsecRequest(version, request) => {
                 version.hash(state);

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -15,9 +15,8 @@ use crate::{
     error::{Result, RoutingError},
     id::{FullId, PublicId},
     routing_table::{Authority, Prefix},
-    types::MessageId,
     xor_name::XorName,
-    BlsPublicKeySet, BlsSecretKeyShare, BlsSignature, BlsSignatureShare, ConnectionInfo,
+    BlsPublicKeySet, BlsSecretKeyShare, BlsSignature, BlsSignatureShare,
 };
 use log::LogLevel;
 use maidsafe_utilities::serialisation::serialise;
@@ -518,15 +517,6 @@ impl RoutingMessage {
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
 pub enum MessageContent {
-    /// Send a request containing our connection info to a member of a section to connect to us.
-    ConnectionRequest {
-        /// The sender's public ID.
-        pub_id: PublicId,
-        /// Sender's connection info.
-        conn_info: ConnectionInfo,
-        /// The message's unique identifier.
-        msg_id: MessageId,
-    },
     /// Inform neighbours about our new section.
     NeighbourInfo(EldersInfo),
     /// User-facing message
@@ -568,11 +558,6 @@ impl Debug for MessageContent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         use self::MessageContent::*;
         match self {
-            ConnectionRequest { pub_id, msg_id, .. } => write!(
-                formatter,
-                "ConnectionRequest({:?}, {:?}, ..)",
-                pub_id, msg_id
-            ),
             NeighbourInfo(info) => write!(formatter, "NeighbourInfo({:?})", info),
             UserMessage(content) => write!(formatter, "UserMessage({:?})", content,),
             NodeApproval(gen_info) => write!(formatter, "NodeApproval({:?})", gen_info),
@@ -594,6 +579,7 @@ mod tests {
         rng,
         routing_table::{Authority, Prefix},
         xor_name::XorName,
+        ConnectionInfo,
     };
     use rand;
     use std::collections::BTreeMap;

--- a/src/network_service/mod.rs
+++ b/src/network_service/mod.rs
@@ -115,7 +115,7 @@ impl NetworkBuilder {
             quic_p2p: self.quic_p2p.build()?,
             cache: Default::default(),
             next_msg_token: 0,
-            peer_map: PeerMap::new(),
+            peer_map: Default::default(),
         })
     }
 }

--- a/src/peer_map.rs
+++ b/src/peer_map.rs
@@ -17,10 +17,6 @@ pub struct PeerMap {
 }
 
 impl PeerMap {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     // Marks the connection as established at the network layer.
     pub fn connect(&mut self, conn_info: ConnectionInfo) {
         let _ = self.connections.insert(conn_info.peer_addr, conn_info);

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -174,10 +174,7 @@ impl BootstrappingPeer {
     }
 
     fn reconnect_to_new_section(&mut self, new_conn_infos: Vec<ConnectionInfo>) {
-        let old_conn_infos: Vec<_> = self.peer_map_mut().remove_all().collect();
-        for conn_info in old_conn_infos {
-            self.disconnect_from(conn_info.peer_addr);
-        }
+        self.network_service_mut().remove_and_disconnect_all();
 
         self.pending_requests.clear();
         self.timeout_tokens.clear();

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -268,14 +268,6 @@ impl Base for BootstrappingPeer {
         Transition::Terminate
     }
 
-    fn handle_connected_to(
-        &mut self,
-        _conn_info: ConnectionInfo,
-        _outbox: &mut dyn EventBox,
-    ) -> Transition {
-        Transition::Stay
-    }
-
     fn handle_connection_failure(
         &mut self,
         peer_addr: SocketAddr,

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -415,7 +415,6 @@ pub trait Approved: Base {
             self, their_pub_id
         );
 
-        self.peer_map_mut().connect(their_conn_info.clone());
         self.send_direct_message(&their_conn_info, DirectMessage::ConnectionResponse);
 
         Ok(())

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -15,14 +15,13 @@ use crate::{
     error::RoutingError,
     event::Event,
     id::{P2pNode, PublicId},
-    messages::{DirectMessage, MessageContent, RoutingMessage},
     outbox::EventBox,
     parsec::{self, Block, DkgResultWrapper, Observation, ParsecMap},
     relocation::RelocateDetails,
-    routing_table::{Authority, Prefix},
+    routing_table::Prefix,
     state_machine::Transition,
     xor_name::XorName,
-    BlsSignature, ConnectionInfo,
+    BlsSignature,
 };
 use log::LogLevel;
 use rand::Rng;
@@ -348,76 +347,6 @@ pub trait Approved: Base {
                 &log_indent,
             );
         }
-    }
-
-    fn send_connection_request(
-        &mut self,
-        their_pub_id: PublicId,
-        src: Authority<XorName>,
-        dst: Authority<XorName>,
-        _: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        if their_pub_id == *self.id() {
-            trace!("{} - Not sending connection request to ourselves.", self);
-            return Ok(());
-        }
-
-        if let Some(p2p_node) = self.chain().get_p2p_node(their_pub_id.name()) {
-            if self.peer_map().has(p2p_node.peer_addr()) {
-                trace!(
-                    "{} - Not sending connection request to {} - already connected.",
-                    self,
-                    their_pub_id
-                );
-                return Ok(());
-            }
-        }
-
-        let msg_id = self.rng().gen();
-        let content = MessageContent::ConnectionRequest {
-            conn_info: self.our_connection_info()?,
-            pub_id: *self.full_id().public_id(),
-            msg_id,
-        };
-
-        trace!("{} - Sending connection request to {}.", self, their_pub_id);
-
-        self.send_routing_message(RoutingMessage { src, dst, content })
-            .map_err(|err| {
-                debug!(
-                    "{} - Failed to send connection request to {}: {:?}.",
-                    self, their_pub_id, err
-                );
-                err
-            })
-    }
-
-    fn handle_connection_request(
-        &mut self,
-        their_conn_info: ConnectionInfo,
-        their_pub_id: PublicId,
-        src: Authority<XorName>,
-        dst: Authority<XorName>,
-        _: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        if src.single_signing_name() != Some(their_pub_id.name()) {
-            // Connection request not from the source node.
-            return Err(RoutingError::InvalidSource);
-        }
-
-        if dst.single_signing_name() != Some(self.name()) {
-            // Connection request not for us.
-            return Err(RoutingError::InvalidDestination);
-        }
-
-        debug!(
-            "{} - Received connection request from {:?}.",
-            self, their_pub_id
-        );
-
-        self.send_direct_message(&their_conn_info, DirectMessage::ConnectionResponse);
-
-        Ok(())
     }
 
     fn disconnect_by_id_lookup(&mut self, pub_id: &PublicId) {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -364,7 +364,6 @@ impl Elder {
 
     fn establish_connection(&mut self, node: P2pNode) {
         self.send_direct_message(node.connection_info(), DirectMessage::ConnectionResponse);
-        self.peer_map_mut().connect(node.connection_info().clone())
     }
 
     fn reset_parsec_with_data(&mut self, reset_data: ParsecResetData) -> Result<(), RoutingError> {
@@ -635,8 +634,6 @@ impl Elder {
                 self,
                 p2p_node
             );
-            self.peer_map_mut()
-                .connect(p2p_node.connection_info().clone());
             self.send_direct_message(
                 p2p_node.connection_info(),
                 DirectMessage::ConnectionResponse,

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -144,14 +144,6 @@ impl JoiningPeer {
                 src: Authority::PrefixSection(_),
                 dst: Authority::Node { .. },
             } => Ok(self.handle_node_approval(gen_info)),
-            RoutingMessage {
-                content: MessageContent::ConnectionRequest { conn_info, .. },
-                src: Authority::Node(_),
-                dst: Authority::Node(_),
-            } => {
-                self.send_direct_message(&conn_info, DirectMessage::ConnectionResponse);
-                Ok(Transition::Stay)
-            }
             _ => {
                 debug!(
                     "{} - Unhandled routing message, adding to backlog: {:?}",
@@ -245,7 +237,7 @@ impl Base for JoiningPeer {
         _outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
         match msg {
-            DirectMessage::ConnectionResponse | DirectMessage::BootstrapResponse(_) => (),
+            DirectMessage::BootstrapResponse(_) => (),
             _ => {
                 debug!(
                     "{} Unhandled direct message from {}, adding to backlog: {:?}",

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -149,7 +149,6 @@ impl JoiningPeer {
                 src: Authority::Node(_),
                 dst: Authority::Node(_),
             } => {
-                self.peer_map_mut().connect(conn_info.clone());
                 self.send_direct_message(&conn_info, DirectMessage::ConnectionResponse);
                 Ok(Transition::Stay)
             }


### PR DESCRIPTION
Work in progress.

This is the third part and final part of #1865, and currently depends on disconnection handling #1880.
Immediate follow up from #1914 and #1908.

Removes all traces of `ConnectionRequest`/`Response`.