### PR TITLE
DKG on top of parsec reset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "~0.3.8"
 lru_time_cache = "~0.8.1"
 maidsafe_utilities = "~0.18.0"
 num-bigint = "~0.1.40"
-parsec = { git = "https://github.com/maidsafe/parsec", rev = "fbefc42d" }
+parsec = { git = "https://github.com/maidsafe/parsec", rev = "b96e6016" }
 # quic-p2p = "~0.2.0"
 quic-p2p = { git = "https://github.com/maidsafe/quic-p2p" }
 quick-error = "~1.2.0"

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -292,6 +292,7 @@ impl Chain {
             }
             AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
+            | AccumulatingEvent::StartDkg(_)
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::SendAckMessage(_)
             | AccumulatingEvent::Relocate(_) => (),
@@ -779,6 +780,13 @@ impl Chain {
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::Relocate(_) => {
                 self.state.change == PrefixChange::None && self.our_info().is_quorum(proofs)
+            }
+            AccumulatingEvent::StartDkg(_) => {
+                log_or_panic!(
+                    LogLevel::Error,
+                    "StartDkg present in the chain accumulator - should never happen!"
+                );
+                false
             }
             AccumulatingEvent::SendAckMessage(_) => {
                 // We may not reach consensus if malicious peer, but when we do we know all our

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -120,6 +120,14 @@ where
         Ok(())
     }
 
+    pub fn vote_for_as(&mut self, observation: Observation<T, S::PublicId>, vote_id: &S) {
+        state::with(self.section_hash, |state| {
+            let holder =
+                ObservationHolder::new(observation, vote_id.public_id(), self.consensus_mode);
+            state.vote(vote_id, holder);
+        });
+    }
+
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &S::PublicId> {
         let iter = if self.peer_list.contains(self.our_id.public_id()) {
             Some(

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -172,6 +172,18 @@ impl ParsecMap {
         }
     }
 
+    // Enable test to simulate other members voting
+    #[cfg(feature = "mock_parsec")]
+    pub fn vote_for_as(
+        &mut self,
+        obs: Observation<chain::NetworkEvent, id::PublicId>,
+        vote_id: &FullId,
+    ) {
+        if let Some(ref mut parsec) = self.map.values_mut().last() {
+            parsec.vote_for_as(obs, vote_id)
+        }
+    }
+
     pub fn last_version(&self) -> u64 {
         if let Some(version) = self.map.keys().last() {
             *version

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -34,6 +34,7 @@ pub type Block = inner::Block<chain::NetworkEvent, id::PublicId>;
 pub type Parsec = inner::Parsec<chain::NetworkEvent, FullId>;
 pub type Request = inner::Request<chain::NetworkEvent, id::PublicId>;
 pub type Response = inner::Response<chain::NetworkEvent, id::PublicId>;
+pub use inner::DkgResultWrapper;
 
 // The maximum number of parsec instances to store.
 const MAX_PARSECS: usize = 10;

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -24,7 +24,7 @@ use crate::{
         SignedRoutingMessage,
     },
     outbox::EventBox,
-    parsec::ParsecMap,
+    parsec::{DkgResultWrapper, ParsecMap},
     peer_map::PeerMap,
     routing_message_filter::RoutingMessageFilter,
     routing_table::{Authority, Prefix},
@@ -36,6 +36,7 @@ use crate::{
 };
 use itertools::Itertools;
 use std::{
+    collections::BTreeSet,
     fmt::{self, Display, Formatter},
     mem,
 };
@@ -476,7 +477,15 @@ impl Approved for Adult {
         let _ = self.chain.remove_elder(pub_id)?;
         self.disconnect(&pub_id);
         self.send_event(Event::NodeLost(*pub_id.name()), outbox);
+        Ok(())
+    }
 
+    fn handle_dkg_result_event(
+        &mut self,
+        _participants: &BTreeSet<PublicId>,
+        _dkg_result: &DkgResultWrapper,
+    ) -> Result<(), RoutingError> {
+        // TODO
         Ok(())
     }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -271,6 +271,12 @@ pub trait Approved: Base {
             trace!("{} Handle accumulated event: {:?}", self, event);
 
             match event {
+                AccumulatingEvent::StartDkg(_) => {
+                    log_or_panic!(
+                        LogLevel::Error,
+                        "StartDkg came out of Parsec - this shouldn't happen"
+                    );
+                }
                 AccumulatingEvent::Online(payload) => {
                     self.handle_online_event(payload, outbox)?;
                 }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -31,7 +31,7 @@ use crate::{
         SignedRoutingMessage,
     },
     outbox::EventBox,
-    parsec::{self, ParsecMap},
+    parsec::{self, DkgResultWrapper, ParsecMap},
     pause::PausedState,
     peer_map::PeerMap,
     routing_message_filter::RoutingMessageFilter,
@@ -1529,6 +1529,15 @@ impl Approved for Elder {
         info!("{} - handle Offline: {}.", self, pub_id);
         self.remove_member(pub_id, DisconnectTime::Now, outbox)?;
 
+        Ok(())
+    }
+
+    fn handle_dkg_result_event(
+        &mut self,
+        _participants: &BTreeSet<PublicId>,
+        _dkg_result: &DkgResultWrapper,
+    ) -> Result<(), RoutingError> {
+        // TODO
         Ok(())
     }
 

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -19,7 +19,6 @@ use crate::{
     mock::Network,
     outbox::EventBox,
     state_machine::{State, StateMachine, Transition},
-    utils::LogIdent,
     NetworkConfig, NetworkParams, NetworkService, ELDER_SIZE,
 };
 use std::{iter, net::SocketAddr};
@@ -56,7 +55,6 @@ struct ElderUnderTest {
     pub machine: StateMachine,
     pub full_id: FullId,
     pub other_full_ids: Vec<FullId>,
-    pub other_parsec_map: Vec<ParsecMap>,
     pub elders_info: EldersInfo,
     pub candidate: P2pNode,
 }
@@ -96,10 +94,6 @@ impl ElderUnderTest {
         let machine = make_state_machine(&full_id, &gen_pfx_info, &mut ());
 
         let other_full_ids = full_ids[1..].iter().cloned().collect_vec();
-        let other_parsec_map = other_full_ids
-            .iter()
-            .map(|full_id| ParsecMap::new(full_id.clone(), &gen_pfx_info))
-            .collect_vec();
 
         let candidate_addr: SocketAddr = unwrap!("127.0.0.2:9999".parse());
         let candidate = P2pNode::new(
@@ -111,12 +105,12 @@ impl ElderUnderTest {
             machine,
             full_id,
             other_full_ids,
-            other_parsec_map,
             elders_info,
             candidate,
         };
 
-        // Process initial unpolled event
+        // Process initial unpolled event including genesis
+        elder_test.n_vote_for_unconsensused_events(elder_test.other_full_ids.len());
         unwrap!(elder_test.create_gossip());
         elder_test
     }
@@ -126,22 +120,36 @@ impl ElderUnderTest {
     }
 
     fn n_vote_for(&mut self, count: usize, events: impl IntoIterator<Item = AccumulatingEvent>) {
+        let parsec = unwrap!(self.machine.current_mut().elder_state_mut()).parsec_map_mut();
         for event in events {
-            self.other_parsec_map
-                .iter_mut()
-                .zip(self.other_full_ids.iter())
-                .take(count)
-                .for_each(|(parsec, full_id)| {
-                    let sig_event = if let AccumulatingEvent::SectionInfo(ref info) = event {
-                        Some(unwrap!(SectionInfoSigPayload::new(info, &full_id)))
-                    } else {
-                        None
-                    };
-                    parsec.vote_for(
-                        event.clone().into_network_event_with(sig_event),
-                        &LogIdent::new(&0),
-                    )
-                });
+            self.other_full_ids.iter().take(count).for_each(|full_id| {
+                let sig_event = if let AccumulatingEvent::SectionInfo(ref info) = event {
+                    Some(unwrap!(SectionInfoSigPayload::new(info, &full_id)))
+                } else {
+                    None
+                };
+
+                info!("Vote as {:?} for event {:?}", full_id.public_id(), event);
+                parsec.vote_for_as(
+                    event.clone().into_network_event_with(sig_event).into_obs(),
+                    &full_id,
+                );
+            });
+        }
+    }
+
+    fn n_vote_for_unconsensused_events(&mut self, count: usize) {
+        let parsec = unwrap!(self.machine.current_mut().elder_state_mut()).parsec_map_mut();
+        let events = parsec.our_unpolled_observations().cloned().collect_vec();
+        for event in events.into_iter() {
+            self.other_full_ids.iter().take(count).for_each(|full_id| {
+                info!(
+                    "Vote as {:?} for unconsensused event {:?}",
+                    full_id.public_id(),
+                    event
+                );
+                parsec.vote_for_as(event.clone(), &full_id);
+            });
         }
     }
 
@@ -149,7 +157,9 @@ impl ElderUnderTest {
         let other_pub_id = *self.other_full_ids[0].public_id();
         let addr: SocketAddr = unwrap!("127.0.0.3:9999".parse());
         let connection_info = ConnectionInfo::from(addr);
-        let message = unwrap!(self.other_parsec_map[0].create_gossip(0, self.full_id.public_id()));
+        let parsec = unwrap!(self.machine.current_mut().elder_state_mut()).parsec_map_mut();
+        let parsec_version = parsec.last_version();
+        let message = unwrap!(parsec.create_gossip(parsec_version, self.full_id.public_id()));
         self.handle_direct_message((message, P2pNode::new(other_pub_id, connection_info)))
     }
 

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -189,11 +189,35 @@ impl ElderUnderTest {
         );
     }
 
+    fn accumulate_voted_unconsensused_events(&mut self) {
+        self.n_vote_for_unconsensused_events(ACCUMULATE_VOTE_COUNT);
+        let _ = self.create_gossip();
+    }
+
     fn accumulate_offline(&mut self, offline_payload: PublicId) {
         let _ = self.n_vote_for_gossipped(
             ACCUMULATE_VOTE_COUNT,
             iter::once(AccumulatingEvent::Offline(offline_payload)),
         );
+    }
+
+    fn get_participants(&self) -> BTreeSet<PublicId> {
+        iter::once(*self.full_id.public_id())
+            .chain(self.other_full_ids.iter().map(|f_id| *f_id.public_id()))
+            .collect()
+    }
+
+    fn accumulate_start_dkg(&mut self, participants: BTreeSet<PublicId>) {
+        let _ = self.n_vote_for_gossipped(
+            ACCUMULATE_VOTE_COUNT,
+            iter::once(AccumulatingEvent::StartDkg(participants)),
+        );
+    }
+
+    fn accumulate_start_dkg_with(&mut self, added: PublicId) {
+        let mut participants = self.get_participants();
+        let _ = participants.insert(added);
+        self.accumulate_start_dkg(participants);
     }
 
     fn new_elders_info_with_candidate(&self) -> EldersInfo {
@@ -362,6 +386,7 @@ fn construct() {
 fn when_accumulate_online_then_node_is_added_to_our_members() {
     let mut elder_test = ElderUnderTest::new();
     elder_test.accumulate_online(elder_test.candidate.clone());
+    elder_test.accumulate_start_dkg_with(*elder_test.candidate.public_id());
 
     assert!(!elder_test.has_unpolled_observations());
     assert!(elder_test.is_candidate_member());
@@ -370,13 +395,14 @@ fn when_accumulate_online_then_node_is_added_to_our_members() {
 }
 
 #[test]
-#[ignore] // Will need to update for a Parsec reset
 fn when_accumulate_online_and_accumulate_section_info_then_node_is_added_to_our_elders_info() {
     let mut elder_test = ElderUnderTest::new();
     elder_test.accumulate_online(elder_test.candidate.clone());
+    elder_test.accumulate_start_dkg_with(*elder_test.candidate.public_id());
 
     let new_elders_info = elder_test.new_elders_info_with_candidate();
     elder_test.accumulate_section_info_if_vote(new_elders_info);
+    elder_test.accumulate_voted_unconsensused_events();
 
     assert!(!elder_test.has_unpolled_observations());
     assert!(elder_test.is_candidate_member());
@@ -385,29 +411,34 @@ fn when_accumulate_online_and_accumulate_section_info_then_node_is_added_to_our_
 }
 
 #[test]
-#[ignore] // Will need to update for a Parsec reset
 fn when_accumulate_offline_then_node_is_removed_from_our_members() {
     let mut elder_test = ElderUnderTest::new();
     elder_test.accumulate_online(elder_test.candidate.clone());
+    elder_test.accumulate_start_dkg_with(*elder_test.candidate.public_id());
     elder_test.accumulate_section_info_if_vote(elder_test.new_elders_info_with_candidate());
+    elder_test.accumulate_voted_unconsensused_events();
 
     elder_test.accumulate_offline(*elder_test.candidate.public_id());
+    elder_test.accumulate_start_dkg(elder_test.get_participants());
 
     assert!(!elder_test.has_unpolled_observations());
     assert!(!elder_test.is_candidate_member());
-    assert!(!elder_test.is_candidate_elder());
+    assert!(elder_test.is_candidate_elder());
     assert!(elder_test.is_candidate_in_our_elders_info());
 }
 
 #[test]
-#[ignore] // Will need to update for a Parsec reset
 fn when_accumulate_offline_and_accumulate_section_info_then_node_is_removed_from_our_elders_info() {
     let mut elder_test = ElderUnderTest::new();
     elder_test.accumulate_online(elder_test.candidate.clone());
+    elder_test.accumulate_start_dkg_with(*elder_test.candidate.public_id());
     elder_test.accumulate_section_info_if_vote(elder_test.new_elders_info_with_candidate());
+    elder_test.accumulate_voted_unconsensused_events();
 
     elder_test.accumulate_offline(*elder_test.candidate.public_id());
+    elder_test.accumulate_start_dkg(elder_test.get_participants());
     elder_test.accumulate_section_info_if_vote(elder_test.new_elders_info_without_candidate());
+    elder_test.accumulate_voted_unconsensused_events();
 
     assert!(!elder_test.has_unpolled_observations());
     assert!(!elder_test.is_candidate_member());

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -245,7 +245,12 @@ fn node_joins_in_front() {
     verify_invariant_for_all_nodes(&network, &mut nodes);
 }
 
+// Only run for mock parsec, as with DKG Joining node timeouts waiting for NodeApproval.
+// Elder go on to process it and take it on as an Elder.
+// This would not be an issue if Joining did not time out, or if elder processed them quicker.
+// This should be solved by Taking on all queued Adults before processing Elder change.
 #[test]
+#[cfg_attr(not(feature = "mock_parsec"), ignore)]
 fn multiple_joining_nodes() {
     let network = Network::new(
         NetworkParams {


### PR DESCRIPTION
This PR start DKG when Online/Offline is consensused, and trigger the SectionInfo vote when the DKG complete.

This also re-enable mock_base testing with real Parsec, as newly added node get the gossip from the parsec instance they were added from, like when they were added as an elder before.

Unit tests are updated.
multiple_joining_nodes is disabled for mock_base because of timeout better solved after other works.

Closes #1774 