### PR TITLE
Perf fix experiments

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use log::LogLevel;
 use std::cmp::Ordering;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fmt::{self, Debug, Display, Formatter},
     iter, mem,
 };
@@ -1380,7 +1380,7 @@ pub struct ParsecResetData {
     /// The cached events that should be revoted.
     pub cached_events: BTreeSet<NetworkEvent>,
     /// The completed events.
-    pub completed_events: BTreeSet<AccumulatingEvent>,
+    pub completed_events: HashSet<AccumulatingEvent>,
 }
 
 impl Debug for Chain {

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -9,7 +9,7 @@
 use super::{AccumulatingEvent, NetworkEvent, Proof, ProofSet, SectionInfoSigPayload};
 use crate::id::PublicId;
 use log::LogLevel;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::{mem, rc::Rc};
 
 /// An unresponsive node is detected by conunting how many (defined by UNRESPONSIVE_THRESHOLD)
@@ -83,7 +83,7 @@ pub(super) struct ChainAccumulator {
     chain_accumulator: BTreeMap<AccumulatingEvent, AccumulatingProof>,
     /// Events that were handled: Further incoming proofs for these can be ignored.
     /// When an event is completed, it cannot be or inserted in chain_accumulator.
-    completed_events: BTreeSet<AccumulatingEvent>,
+    completed_events: HashSet<AccumulatingEvent>,
     /// A struct retains the order of insertion, and keeps tracking of which node has not involved.
     /// Entry will be created when an event reached consensus.
     vote_statuses: VoteStatuses,
@@ -244,7 +244,7 @@ pub struct RemainingEvents {
     /// The cached events that should be revoted.
     pub cached_events: BTreeSet<NetworkEvent>,
     /// The completed events.
-    pub completed_events: BTreeSet<AccumulatingEvent>,
+    pub completed_events: HashSet<AccumulatingEvent>,
 }
 
 #[cfg(test)]
@@ -521,7 +521,7 @@ mod test {
             result,
             RemainingEvents {
                 cached_events: vec![data.network_event].into_iter().collect(),
-                completed_events: BTreeSet::new(),
+                completed_events: Default::default(),
             }
         );
         assert_eq!(incomplete_events(&acc), vec![]);

--- a/src/chain/elders_info.rs
+++ b/src/chain/elders_info.rs
@@ -120,22 +120,29 @@ impl EldersInfo {
 
     /// Returns `true` if the proofs are from a quorum of this section.
     pub fn is_quorum(&self, proofs: &ProofSet) -> bool {
+        if !(proofs.len() * QUORUM_DENOMINATOR > self.p2p_members().len() * QUORUM_NUMERATOR) {
+            return false;
+        }
+
         // WIP: the call to members is probably to heavy?
-        proofs
-            .ids()
-            .filter(|id| self.members().contains(id))
-            .count()
-            * QUORUM_DENOMINATOR
-            > self.members.len() * QUORUM_NUMERATOR
+        let members = self.members();
+        proofs.ids().filter(|id| members.contains(id)).count() * QUORUM_DENOMINATOR
+            > members.len() * QUORUM_NUMERATOR
     }
 
     /// Returns `true` if the proofs are from all members of this section.
     pub fn is_total_consensus(&self, proofs: &ProofSet) -> bool {
+        if !(proofs.len() >= self.p2p_members().len()) {
+            return false;
+        }
+
+        // WIP: the call to members is probably to heavy?
+        let members = self.members();
         proofs
             .ids()
-            .filter(|id| self.members().contains(id))
+            .filter(|id| members.contains(id))
             .count()
-            == self.members.len()
+            == members.len()
     }
 
     /// Returns `true` if `self` is a successor of `other_info`, according to its hash.

--- a/src/chain/proof.rs
+++ b/src/chain/proof.rs
@@ -106,7 +106,6 @@ impl ProofSet {
     }
 
     /// Returns the number of signatures.
-    #[cfg(feature = "mock_base")]
     pub fn len(&self) -> usize {
         self.sigs.len()
     }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -118,75 +118,75 @@ impl SharedState {
             return Ok(());
         }
 
-        let (
-            our_infos,
-            our_history,
-            our_members,
-            neighbour_infos,
-            their_keys,
-            their_knowledge,
-            their_recent_keys,
-            churn_event_backlog,
-        ) = serialisation::deserialise(related_info)?;
-        if self.our_infos.len() != 1 {
+        if self.our_infos.len() == 1 {
+            let (
+                our_infos,
+                our_history,
+                our_members,
+                neighbour_infos,
+                their_keys,
+                their_knowledge,
+                their_recent_keys,
+                churn_event_backlog,
+            ) = serialisation::deserialise(related_info)?;
             // Check nodes with a history before genesis match the genesis block:
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "our_infos",
-                &self.our_infos,
-                &our_infos,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "our_history",
-                &self.our_history,
-                &our_history,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "our_members",
-                &self.our_members,
-                &our_members,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "neighbour_infos",
-                &self.neighbour_infos,
-                &neighbour_infos,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "their_keys",
-                &self.their_keys,
-                &their_keys,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "their_knowledge",
-                &self.their_knowledge,
-                &their_knowledge,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "their_recent_keys",
-                &self.their_recent_keys,
-                &their_recent_keys,
-            );
-            update_with_genesis_related_info_check_same(
-                log_ident,
-                "churn_event_backlog",
-                &self.churn_event_backlog,
-                &churn_event_backlog,
-            );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "our_infos",
+            //     &self.our_infos,
+            //     &our_infos,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "our_history",
+            //     &self.our_history,
+            //     &our_history,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "our_members",
+            //     &self.our_members,
+            //     &our_members,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "neighbour_infos",
+            //     &self.neighbour_infos,
+            //     &neighbour_infos,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "their_keys",
+            //     &self.their_keys,
+            //     &their_keys,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "their_knowledge",
+            //     &self.their_knowledge,
+            //     &their_knowledge,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "their_recent_keys",
+            //     &self.their_recent_keys,
+            //     &their_recent_keys,
+            // );
+            // update_with_genesis_related_info_check_same(
+            //     log_ident,
+            //     "churn_event_backlog",
+            //     &self.churn_event_backlog,
+            //     &churn_event_backlog,
+            // );
+            self.our_infos = our_infos;
+            self.our_history = our_history;
+            self.our_members = our_members;
+            self.neighbour_infos = neighbour_infos;
+            self.their_keys = their_keys;
+            self.their_knowledge = their_knowledge;
+            self.their_recent_keys = their_recent_keys;
+            self.churn_event_backlog = churn_event_backlog;
         }
-        self.our_infos = our_infos;
-        self.our_history = our_history;
-        self.our_members = our_members;
-        self.neighbour_infos = neighbour_infos;
-        self.their_keys = their_keys;
-        self.their_knowledge = their_knowledge;
-        self.their_recent_keys = their_recent_keys;
-        self.churn_event_backlog = churn_event_backlog;
 
         Ok(())
     }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -661,7 +661,7 @@ impl Elder {
 
         let trimmed_info = GenesisPfxInfo {
             first_info: self.gen_pfx_info.first_info.clone(),
-            first_state_serialized: self.gen_pfx_info.first_state_serialized.clone(),
+            first_state_serialized: Default::default(),
             first_ages: self.gen_pfx_info.first_ages.clone(),
             latest_info: self.chain.our_info().clone(),
         };

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -428,7 +428,7 @@ fn aggressive_churn() {
             elder_size,
             safe_section_size,
         },
-        None,
+         Some([1,2,3,4]),
     );
     let mut rng = network.new_rng();
 
@@ -520,7 +520,7 @@ fn messages_during_churn() {
             elder_size,
             safe_section_size,
         },
-        None,
+        Some([1,2,3,4]),
     );
     let mut rng = network.new_rng();
     let prefixes = vec![2, 2, 2, 3, 3];
@@ -596,7 +596,7 @@ fn remove_unresponsive_node() {
             elder_size,
             safe_section_size,
         },
-        None,
+         Some([1,2,3,4]),
     );
 
     let mut nodes = create_connected_nodes(&network, safe_section_size);

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -428,7 +428,7 @@ fn aggressive_churn() {
             elder_size,
             safe_section_size,
         },
-         Some([1,2,3,4]),
+        Some([1, 2, 3, 4]),
     );
     let mut rng = network.new_rng();
 
@@ -520,7 +520,7 @@ fn messages_during_churn() {
             elder_size,
             safe_section_size,
         },
-        Some([1,2,3,4]),
+        Some([1, 2, 3, 4]),
     );
     let mut rng = network.new_rng();
     let prefixes = vec![2, 2, 2, 3, 3];
@@ -596,7 +596,7 @@ fn remove_unresponsive_node() {
             elder_size,
             safe_section_size,
         },
-         Some([1,2,3,4]),
+        Some([1, 2, 3, 4]),
     );
 
     let mut nodes = create_connected_nodes(&network, safe_section_size);


### PR DESCRIPTION
Here are the things that popped out when looking at profiling and some quick fixes to prove if they made a difference.

The simplest one is:
 - clear NodeApproval serialized data 14s -> 12s (11.5)

The fairly simple and biggest one is:
- Fix is_quorum creating many BTreeSet: 12s -> 8s
(Found using RUSTFLAGS="-C inline-threshold=25 -g" to avoid inlining and get clearer result in profiling).

HashSet made no difference was confused by too much inline.
No check for consensus is not ideal, maybe there are better way to do that.