### PR TITLE
fix/elder: handle the case of bulk parsec poll

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -18,10 +18,10 @@ mod proof;
 mod shared_state;
 
 #[cfg(feature = "mock_base")]
-pub use self::chain_accumulator::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW};
+pub use self::chain_accumulator::UNRESPONSIVE_WINDOW;
 pub use self::{
     chain::{delivery_group_size, Chain, EldersChange, NetworkParams, ParsecResetData},
-    chain_accumulator::AccumulatingProof,
+    chain_accumulator::{AccumulatingProof, UNRESPONSIVE_THRESHOLD},
     elders_info::EldersInfo,
     member_info::{AgeCounter, MemberInfo, MemberPersona, MemberState, MIN_AGE, MIN_AGE_COUNTER},
     network_event::{

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -544,6 +544,10 @@ impl Approved for Adult {
         debug!("{} - Unhandled NeighbourMerge event", self);
         Ok(())
     }
+
+    fn check_voting_status(&mut self, _parsec_polled: usize) {
+        debug!("{} - Not Required CheckVotingStatus For Adult", self);
+    }
 }
 
 impl Display for Adult {


### PR DESCRIPTION
When executing tests, parsec polls observations in a bulk. This
will cause issue to the unresponsive track, making valid peer to
be considered as unresponsive.
This commit handle the case by having extra conditions of carrying
out vote status check, when a bulk of parsec poll happens.