### PR TITLE
Access to the connection info of elders

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -11,7 +11,7 @@ use crate::{
     chain::NetworkParams,
     error::{InterfaceError, RoutingError},
     event_stream::{EventStepper, EventStream},
-    id::{FullId, PublicId},
+    id::{FullId, P2pNode, PublicId},
     outbox::EventBox,
     pause::PausedState,
     quic_p2p::{OurType, Token},
@@ -26,7 +26,7 @@ use std::{net::SocketAddr, sync::mpsc};
 
 #[cfg(feature = "mock_base")]
 use {
-    crate::{chain::SectionProofChain, id::P2pNode, utils::XorTargetInterval, Chain, Prefix},
+    crate::{chain::SectionProofChain, utils::XorTargetInterval, Chain, Prefix},
     std::{
         collections::{BTreeMap, BTreeSet},
         fmt::{self, Display, Formatter},
@@ -183,6 +183,11 @@ impl Node {
     /// to the given one.
     pub fn close_group(&self, name: XorName, count: usize) -> Option<Vec<XorName>> {
         self.machine.current().close_group(name, count)
+    }
+
+    /// Returns the connection information of all the current section elders.
+    pub fn our_elders_info(&self) -> Option<impl Iterator<Item = &P2pNode>> {
+        self.machine.current().our_elders()
     }
 
     /// Returns the `PublicId` of this node.

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -131,6 +131,16 @@ impl State {
         )
     }
 
+    pub fn our_elders(&self) -> Option<impl Iterator<Item = &P2pNode>> {
+        match *self {
+            State::Elder(ref state) => Some(state.our_elders()),
+            State::BootstrappingPeer(_)
+            | State::JoiningPeer(_)
+            | State::Adult(_)
+            | State::Terminated => None,
+        }
+    }
+
     pub fn our_connection_info(&mut self) -> Result<ConnectionInfo, RoutingError> {
         state_dispatch!(
             self,

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -199,6 +199,10 @@ impl Elder {
         )
     }
 
+    pub fn our_elders(&self) -> impl Iterator<Item = &P2pNode> {
+        self.chain.our_elders()
+    }
+
     pub fn relocate(
         self,
         conn_infos: Vec<ConnectionInfo>,


### PR DESCRIPTION
Expose connection information of the elders in our section to the
user library. Vauls for example will use this to give it to a client
wanting to connect to the network (and thus via its section).

Closes #1889