### PR TITLE
fix/chain: extend cached keys to pass churn test

### DIFF
--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -26,8 +26,8 @@ use unwrap::unwrap;
 
 // Number of recent keys we keep: i.e how many other section churns we can handle before a
 // message send with a previous version of a section is no longer trusted.
-// With low churn rate, a ad hoc 10 should be big enough to avoid losing messages.
-const MAX_THEIR_RECENT_KEYS: usize = 10;
+// With low churn rate, a ad hoc 20 should be big enough to avoid losing messages.
+const MAX_THEIR_RECENT_KEYS: usize = 20;
 
 /// Section state that is shared among all elders of a section via Parsec consensus.
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Fix aggressive_churn Some([2134840958, 10390792, 1455924021, 536582862]).
AckMessage sent to ourselves was received when one node already purged
the relevant self key from cached keys.

Test:
Verify seed pass.
soak test.