### PR TITLE
Fix rng initialization in mock network tests not being reproducible

### DIFF
--- a/src/rng.rs
+++ b/src/rng.rs
@@ -324,9 +324,8 @@ mod seed_printer {
         } else {
             format!("{}: {}", label, seed)
         };
-
         let border = (0..msg.len()).map(|_| "=").collect::<String>();
-        eprintln!("\n{}\n{}\n{}\n", border, msg, border);
+        println!("\n{}\n{}\n{}\n", border, msg, border);
     }
 
     // Print the seed also on SIGINT and SIGTERM

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -11,8 +11,8 @@ use fake_clock::FakeClock;
 use itertools::Itertools;
 use rand::Rng;
 use routing::{
-    mock::Network, rng::MainRng, test_consts, Authority, Event, EventStream, FullId, NetworkConfig,
-    Node, NodeBuilder, PausedState, Prefix, PublicId, XorName, Xorable,
+    mock::Network, test_consts, Authority, Event, EventStream, FullId, NetworkConfig, Node,
+    NodeBuilder, PausedState, Prefix, PublicId, XorName, Xorable,
 };
 use std::{
     cmp,
@@ -171,16 +171,12 @@ impl<'a> TestNodeBuilder<'a> {
         }
     }
 
-    pub fn rng(self, rng: MainRng) -> Self {
-        Self {
-            inner: self.inner.rng(rng),
-            ..self
-        }
-    }
-
     pub fn create(self) -> TestNode {
-        let (inner, _node_rx) =
-            unwrap!(self.inner.network_cfg(self.network.network_cfg()).create());
+        let (inner, _node_rx) = unwrap!(self
+            .inner
+            .network_cfg(self.network.network_cfg())
+            .rng(self.network.new_rng())
+            .create());
 
         TestNode {
             inner,
@@ -944,7 +940,6 @@ fn add_node_to_section(
         TestNode::builder(network)
             .network_config(config)
             .full_id(full_id)
-            .rng(rng)
             .create(),
     );
 


### PR DESCRIPTION
`Node` rngs were not properly initialized using `Network`'s global rng resulting in non-repeatable tests.