### PR TITLE
quic_p2p always return success or failure

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -387,14 +387,13 @@ impl Chain {
         };
 
         if self.is_peer_our_elder(&details.pub_id) {
+            let min_elders = self.elder_size() + 1;
             let num_elders = self.our_elders().len();
-            if num_elders <= self.elder_size() {
+
+            if num_elders < min_elders {
                 warn!(
                     "{} - Not relocating {} - not enough elders in the section ({}/{}).",
-                    self,
-                    details.pub_id,
-                    num_elders,
-                    self.elder_size() + 1,
+                    self, details.pub_id, num_elders, min_elders,
                 );
 
                 // Keep the details in the queue so when we gain more elders we can try to relocate

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -268,8 +268,8 @@ fn send_to_nonexisting_node() {
 
     // Note: the real quick-p2p will only emit `UnsentUserMessage` when a connection to the peer
     // was previously successfully established. That is not the case here, so we expect nothing.
-    // TODO: this is going to get changed in the real quic-p2p, so change it here too.
-    a.expect_none();
+    // TODO: this is going to get changed in the real quic-p2p, remove comment then.
+    a.expect_unsent_message(&b_addr, &msg, 0);
 }
 
 #[test]

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -427,6 +427,10 @@ impl Elder {
             .iter()
             .filter(|event| match event.payload {
                 // Only re-vote not yet accumulated events and still relevant to our new prefix.
+                AccumulatingEvent::Online(ref payload) => {
+                    our_pfx.matches(payload.p2p_node.name())
+                        && !completed_events.contains(&event.payload)
+                }
                 AccumulatingEvent::Offline(pub_id) => {
                     our_pfx.matches(pub_id.name()) && !completed_events.contains(&event.payload)
                 }
@@ -437,8 +441,7 @@ impl Elder {
                 // Drop: no longer relevant after prefix change.
                 // TODO: verify this is really the case. Some/all of these might still make sense
                 // to carry over. In case it does not, add a comment explaining why.
-                AccumulatingEvent::Online(_)
-                | AccumulatingEvent::StartDkg(_)
+                AccumulatingEvent::StartDkg(_)
                 | AccumulatingEvent::ParsecPrune
                 | AccumulatingEvent::Relocate(_) => false,
 

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -261,7 +261,7 @@ impl Base for JoiningPeer {
         _outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
         match msg {
-            DirectMessage::ConnectionResponse => (),
+            DirectMessage::ConnectionResponse | DirectMessage::BootstrapResponse(_) => (),
             _ => {
                 debug!(
                     "{} Unhandled direct message from {}, adding to backlog: {:?}",


### PR DESCRIPTION
An assumption of the system is that quic_p2p will always return a
success or failed status for a message. However, this was not always
happening.

Ensure it is the case.

Pull in as well https://github.com/maidsafe/routing/pull/1896
