### PR TITLE
Move PeerMap to NetworkService

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -695,12 +695,10 @@ impl Chain {
     }
 
     /// Returns a set of elders we should be connected to.
-    // WIP: should we remove potential duplicates?
     pub fn elders(&self) -> impl Iterator<Item = &P2pNode> {
         self.neighbour_infos()
             .chain(iter::once(self.state.our_info()))
             .flat_map(EldersInfo::member_nodes)
-            .chain(self.state.new_info.member_nodes())
     }
 
     /// Checks if given `PublicId` is an elder in our section or one of our neighbour sections.

--- a/src/network_service/mod.rs
+++ b/src/network_service/mod.rs
@@ -44,7 +44,7 @@ impl NetworkService {
 
     pub fn send_message_to_initial_targets(
         &mut self,
-        conn_infos: Vec<ConnectionInfo>,
+        conn_infos: &[ConnectionInfo],
         dg_size: usize,
         msg: NetworkBytes,
     ) {

--- a/src/network_service/mod.rs
+++ b/src/network_service/mod.rs
@@ -9,6 +9,7 @@
 mod sending_targets_cache;
 
 use crate::{
+    peer_map::PeerMap,
     quic_p2p::{Builder, Error, Peer, Token},
     utils::LogIdent,
     ConnectionInfo, NetworkBytes, NetworkConfig, NetworkEvent, QuicP2p,
@@ -24,6 +25,7 @@ pub struct NetworkService {
     quic_p2p: QuicP2p,
     cache: SendingTargetsCache,
     next_msg_token: Token,
+    pub peer_map: PeerMap,
 }
 
 impl NetworkService {
@@ -83,6 +85,12 @@ impl NetworkService {
     pub fn our_connection_info(&mut self) -> Result<ConnectionInfo, Error> {
         self.quic_p2p.our_connection_info()
     }
+
+    pub fn remove_and_disconnect_all(&mut self) {
+        for conn_info in self.peer_map.remove_all() {
+            self.quic_p2p.disconnect_from(conn_info.peer_addr);
+        }
+    }
 }
 
 pub struct NetworkBuilder {
@@ -107,6 +115,7 @@ impl NetworkBuilder {
             quic_p2p: self.quic_p2p.build()?,
             cache: Default::default(),
             next_msg_token: 0,
+            peer_map: PeerMap::new(),
         })
     }
 }

--- a/src/network_service/sending_targets_cache.rs
+++ b/src/network_service/sending_targets_cache.rs
@@ -49,7 +49,7 @@ impl SendingTargetsCache {
     pub fn insert_message(
         &mut self,
         token: Token,
-        initial_targets: Vec<ConnectionInfo>,
+        initial_targets: &[ConnectionInfo],
         dg_size: usize,
     ) {
         // When a message is inserted into the cache initially, we are only sending it to `dg_size`
@@ -57,11 +57,11 @@ impl SendingTargetsCache {
         // states to Sending(0), and the rest to Failed(0) (indicating that we haven't sent to
         // them, and so they haven't failed yet)
         let targets = initial_targets
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(idx, tgt_info)| {
                 (
-                    tgt_info,
+                    tgt_info.clone(),
                     if idx < dg_size {
                         TargetState::Sending(0)
                     } else {

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -11,7 +11,6 @@ use crate::{
     id::FullId,
     messages::SignedRoutingMessage,
     parsec::ParsecMap,
-    peer_map::PeerMap,
     routing_message_filter::RoutingMessageFilter,
     signature_accumulator::SignatureAccumulator,
     NetworkEvent, NetworkService,
@@ -37,6 +36,5 @@ pub struct PausedState {
     pub(super) network_service: NetworkService,
     pub(super) network_rx: Option<mpmc::Receiver<NetworkEvent>>,
     pub(super) parsec_map: ParsecMap,
-    pub(super) peer_map: PeerMap,
     pub(super) sig_accumulator: SignatureAccumulator,
 }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -51,7 +51,6 @@ pub struct AdultDetails {
     pub gen_pfx_info: GenesisPfxInfo,
     pub routing_msg_backlog: Vec<SignedRoutingMessage>,
     pub direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
-    pub peer_map: PeerMap,
     pub routing_msg_filter: RoutingMessageFilter,
     pub timer: Timer,
     pub network_cfg: NetworkParams,
@@ -69,7 +68,6 @@ pub struct Adult {
     routing_msg_backlog: Vec<SignedRoutingMessage>,
     direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
     parsec_map: ParsecMap,
-    peer_map: PeerMap,
     parsec_timer_token: u64,
     routing_msg_filter: RoutingMessageFilter,
     timer: Timer,
@@ -106,7 +104,6 @@ impl Adult {
             routing_msg_backlog: details.routing_msg_backlog,
             direct_msg_backlog: details.direct_msg_backlog,
             parsec_map,
-            peer_map: details.peer_map,
             routing_msg_filter: details.routing_msg_filter,
             timer: details.timer,
             parsec_timer_token,
@@ -152,7 +149,6 @@ impl Adult {
             routing_msg_backlog: self.routing_msg_backlog,
             direct_msg_backlog: self.direct_msg_backlog,
             parsec_map: self.parsec_map,
-            peer_map: self.peer_map,
             // we reset the message filter so that the node can correctly process some messages as
             // an Elder even if it has already seen them as an Adult
             routing_msg_filter: RoutingMessageFilter::new(),
@@ -307,11 +303,11 @@ impl Base for Adult {
     }
 
     fn peer_map(&self) -> &PeerMap {
-        &self.peer_map
+        &self.network_service().peer_map
     }
 
     fn peer_map_mut(&mut self) -> &mut PeerMap {
-        &mut self.peer_map
+        &mut self.network_service_mut().peer_map
     }
 
     fn timer(&mut self) -> &mut Timer {

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -474,6 +474,10 @@ impl Approved for Adult {
         &mut self.parsec_map
     }
 
+    fn chain(&self) -> &Chain {
+        &self.chain
+    }
+
     fn chain_mut(&mut self) -> &mut Chain {
         &mut self.chain
     }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -215,6 +215,7 @@ impl Adult {
             .gen_pfx_info
             .latest_info
             .member_nodes()
+            .map(P2pNode::connection_info)
             .cloned()
             .collect_vec();
 
@@ -241,7 +242,7 @@ impl Adult {
         );
 
         self.send_direct_message(
-            &p2p_node,
+            p2p_node.connection_info(),
             DirectMessage::BootstrapResponse(BootstrapResponse::Error(
                 BootstrapResponseError::NotApproved,
             )),
@@ -445,7 +446,7 @@ impl Base for Adult {
                 .is_new()
             {
                 let message = self.to_hop_message(signed_msg.clone())?;
-                self.send_message(p2p_node, message);
+                self.send_message(p2p_node.connection_info(), message);
             }
         }
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -432,6 +432,8 @@ impl Base for Adult {
         // Need to collect IDs first so that self is not borrowed via the iterator
         //
         // WIP: this is probably out of date? How else do we know which our section members are?
+        // WIP: once ConnectionRequest/ConnectionResponse is removed this whole function can
+        // probably be removed.
         let target_nodes = self
             .gen_pfx_info
             .latest_info

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -32,6 +32,7 @@ use std::collections::BTreeSet;
 pub trait Approved: Base {
     fn parsec_map(&self) -> &ParsecMap;
     fn parsec_map_mut(&mut self) -> &mut ParsecMap;
+    fn chain(&self) -> &Chain;
     fn chain_mut(&mut self) -> &mut Chain;
     fn send_event(&mut self, event: Event, outbox: &mut dyn EventBox);
     fn set_pfx_successfully_polled(&mut self, val: bool);
@@ -161,11 +162,8 @@ pub trait Approved: Base {
 
                 let p2p_recipients: Vec<_> = recipients
                     .into_iter()
-                    .filter_map(|pub_id| {
-                        self.peer_map()
-                            .get_connection_info(pub_id)
-                            .map(|conn_info| P2pNode::new(*pub_id, conn_info.clone()))
-                    })
+                    .filter_map(|pub_id| self.chain().get_member_p2p_node(pub_id.name()))
+                    .cloned()
                     .collect();
 
                 if p2p_recipients.is_empty() {
@@ -178,7 +176,6 @@ pub trait Approved: Base {
                 }
 
                 let rand_index = self.rng().gen_range(0, p2p_recipients.len());
-                // WIP: need to figure out who to send to without consulting the peer_map
                 (version, p2p_recipients[rand_index].clone())
             }
         };

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -121,7 +121,7 @@ pub trait Approved: Base {
         );
 
         if let Some(response) = response {
-            self.send_direct_message(&p2p_node, response);
+            self.send_direct_message(p2p_node.connection_info(), response);
         }
 
         if poll {
@@ -184,7 +184,7 @@ pub trait Approved: Base {
             .parsec_map_mut()
             .create_gossip(version, gossip_target.public_id())
         {
-            self.send_direct_message(&gossip_target, msg);
+            self.send_direct_message(gossip_target.connection_info(), msg);
         }
     }
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -71,7 +71,6 @@ pub struct ElderDetails {
     pub routing_msg_backlog: Vec<SignedRoutingMessage>,
     pub direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
     pub parsec_map: ParsecMap,
-    pub peer_map: PeerMap,
     pub routing_msg_filter: RoutingMessageFilter,
     pub timer: Timer,
     pub rng: MainRng,
@@ -86,7 +85,6 @@ pub struct Elder {
     msg_queue: VecDeque<SignedRoutingMessage>,
     routing_msg_backlog: Vec<SignedRoutingMessage>,
     direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
-    peer_map: PeerMap,
     routing_msg_filter: RoutingMessageFilter,
     sig_accumulator: SignatureAccumulator,
     tick_timer_token: u64,
@@ -129,7 +127,6 @@ impl Elder {
             public_id,
             gen_pfx_info.clone(),
         );
-        let peer_map = PeerMap::new();
 
         let details = ElderDetails {
             chain,
@@ -141,7 +138,6 @@ impl Elder {
             routing_msg_backlog: Default::default(),
             direct_msg_backlog: Default::default(),
             parsec_map,
-            peer_map,
             routing_msg_filter: RoutingMessageFilter::new(),
             timer,
             rng,
@@ -179,7 +175,6 @@ impl Elder {
             network_service: self.network_service,
             network_rx: None,
             parsec_map: self.parsec_map,
-            peer_map: self.peer_map,
             sig_accumulator: self.sig_accumulator,
         })
     }
@@ -196,7 +191,6 @@ impl Elder {
                 routing_msg_backlog: Default::default(),
                 direct_msg_backlog: Default::default(),
                 parsec_map: state.parsec_map,
-                peer_map: state.peer_map,
                 routing_msg_filter: state.msg_filter,
                 timer,
                 rng: rng::new(),
@@ -245,7 +239,6 @@ impl Elder {
             msg_queue: details.msg_queue,
             routing_msg_backlog: details.routing_msg_backlog,
             direct_msg_backlog: details.direct_msg_backlog,
-            peer_map: details.peer_map,
             routing_msg_filter: details.routing_msg_filter,
             sig_accumulator,
             tick_timer_token,
@@ -371,8 +364,8 @@ impl Elder {
 
         for p2p_node in change.added {
             let pub_id = *p2p_node.public_id();
-            if !self.peer_map.has(&pub_id) {
-                self.peer_map
+            if !self.peer_map().has(&pub_id) {
+                self.peer_map_mut()
                     .insert(pub_id, p2p_node.connection_info().clone());
                 self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
             };
@@ -381,13 +374,13 @@ impl Elder {
         let to_connect: Vec<_> = self
             .chain
             .our_elders()
-            .filter(|p2p_node| !self.peer_map.has(p2p_node.public_id()))
+            .filter(|p2p_node| !self.peer_map().has(p2p_node.public_id()))
             .cloned()
             .collect();
 
         for p2p_node in to_connect.into_iter() {
             let pub_id = p2p_node.public_id();
-            self.peer_map
+            self.peer_map_mut()
                 .insert(*pub_id, p2p_node.connection_info().clone());
             self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
         }
@@ -661,13 +654,13 @@ impl Elder {
         let dst = Authority::Node(*pub_id.name());
 
         // Make sure we are connected to the candidate
-        if !self.peer_map.has(&pub_id) {
+        if !self.peer_map().has(&pub_id) {
             trace!(
                 "{} - Not yet connected to {} - use p2p_node.",
                 self,
                 p2p_node
             );
-            self.peer_map
+            self.peer_map_mut()
                 .insert(pub_id, p2p_node.connection_info().clone());
             self.send_direct_message(&p2p_node, DirectMessage::ConnectionResponse);
         };
@@ -714,7 +707,7 @@ impl Elder {
         );
 
         let pub_id = *p2p_node.public_id();
-        if !self.peer_map.has(&pub_id) {
+        if !self.peer_map().has(&pub_id) {
             log_or_panic!(
                 LogLevel::Error,
                 "Not connected to the sender of BootstrapRequest."
@@ -872,11 +865,7 @@ impl Elder {
             .cloned()
             .collect();
 
-        for conn_info in self.peer_map.remove_all() {
-            self.network_service
-                .service_mut()
-                .disconnect_from(conn_info.peer_addr);
-        }
+        self.network_service_mut().remove_and_disconnect_all();
 
         Transition::Relocate {
             details,
@@ -1075,7 +1064,7 @@ impl Elder {
     // it must be restarted.
     fn check_elder_connections(&mut self, outbox: &mut dyn EventBox) -> bool {
         if self
-            .peer_map
+            .peer_map()
             .connected_ids()
             .filter(|id| self.chain.our_id() != *id)
             .any(|id| self.chain.is_peer_our_elder(id))
@@ -1201,11 +1190,11 @@ impl Base for Elder {
     }
 
     fn peer_map(&self) -> &PeerMap {
-        &self.peer_map
+        &self.network_service().peer_map
     }
 
     fn peer_map_mut(&mut self) -> &mut PeerMap {
-        &mut self.peer_map
+        &mut self.network_service_mut().peer_map
     }
 
     fn timer(&mut self) -> &mut Timer {
@@ -1461,7 +1450,7 @@ impl Elder {
     }
 
     pub fn identify_connection(&mut self, pub_id: PublicId, peer_addr: SocketAddr) {
-        self.peer_map.identify(pub_id, peer_addr)
+        self.peer_map_mut().identify(pub_id, peer_addr)
     }
 
     pub fn send_msg_to_targets(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1480,6 +1480,10 @@ impl Approved for Elder {
         &mut self.parsec_map
     }
 
+    fn chain(&self) -> &Chain {
+        &self.chain
+    }
+
     fn chain_mut(&mut self) -> &mut Chain {
         &mut self.chain
     }

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -326,7 +326,6 @@ fn new_elder_state(
         public_id,
         gen_pfx_info.clone(),
     );
-    let peer_map = PeerMap::new();
 
     let details = ElderDetails {
         chain,
@@ -338,7 +337,6 @@ fn new_elder_state(
         routing_msg_backlog: Default::default(),
         direct_msg_backlog: Default::default(),
         parsec_map,
-        peer_map,
         routing_msg_filter: RoutingMessageFilter::new(),
         timer,
         rng: rng::new_from(rng),

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -25,10 +25,8 @@ fn get_position_with_other_prefix(nodes: &Nodes, prefix: &Prefix<XorName>) -> us
 }
 
 fn send_message(nodes: &mut Nodes, src: usize, dst: usize, message: Message) {
-    let public_id = unwrap!(nodes[dst].inner.id());
     let connection_info = unwrap!(nodes[dst].inner.our_connection_info());
-    let p2p_node = P2pNode::new(public_id, connection_info);
-    let targets = vec![p2p_node];
+    let targets = vec![connection_info];
 
     let _ = nodes[src]
         .inner


### PR DESCRIPTION
- Move `PeerMap` to `NetworkService` as a prepatory step for Part 3 (#1885) in the connection request/response refactoring. The intention (in Part 3) is to strip down `PeerMap` to only keep track of client `SocketAddr` and mapping certificates to nodes.
Any notion of "connectedness" is set to be deprecated.
- Remove `peer_map` call in `send_parsec_gossip`
- Fix a few minor issues pointed out in the review of #1884 