### PR TITLE
Relocate request

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -305,7 +305,7 @@ impl Chain {
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::StartDkg(_)
             | AccumulatingEvent::RelocateRequest(_)
-            | AccumulatingEvent::DenyRelocateRequest { .. }
+            | AccumulatingEvent::RelocateResponse { .. }
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::SendAckMessage(_) => (),
@@ -838,7 +838,7 @@ impl Chain {
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::Relocate(_) 
             | AccumulatingEvent::RelocateRequest(_)
-            | AccumulatingEvent::DenyRelocateRequest { .. } => {
+            | AccumulatingEvent::RelocateResponse { .. } => {
                 !self.state.split_in_progress && self.our_info().is_quorum(proofs)
             }
             AccumulatingEvent::StartDkg(_) => {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -305,6 +305,7 @@ impl Chain {
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::StartDkg(_)
             | AccumulatingEvent::RelocationRequest(_)
+            | AccumulatingEvent::RefuseRelocationRequest { .. }
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::SendAckMessage(_) => (),
@@ -836,7 +837,8 @@ impl Chain {
             | AccumulatingEvent::AckMessage(_)
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::Relocate(_) 
-            | AccumulatingEvent::RelocationRequest(_) => {
+            | AccumulatingEvent::RelocationRequest(_)
+            | AccumulatingEvent::RefuseRelocationRequest { .. } => {
                 !self.state.split_in_progress && self.our_info().is_quorum(proofs)
             }
             AccumulatingEvent::StartDkg(_) => {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -304,8 +304,8 @@ impl Chain {
             AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::StartDkg(_)
-            | AccumulatingEvent::RelocationRequest(_)
-            | AccumulatingEvent::RefuseRelocationRequest { .. }
+            | AccumulatingEvent::RelocateRequest(_)
+            | AccumulatingEvent::DenyRelocateRequest { .. }
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::SendAckMessage(_) => (),
@@ -837,8 +837,8 @@ impl Chain {
             | AccumulatingEvent::AckMessage(_)
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::Relocate(_) 
-            | AccumulatingEvent::RelocationRequest(_)
-            | AccumulatingEvent::RefuseRelocationRequest { .. } => {
+            | AccumulatingEvent::RelocateRequest(_)
+            | AccumulatingEvent::DenyRelocateRequest { .. } => {
                 !self.state.split_in_progress && self.our_info().is_quorum(proofs)
             }
             AccumulatingEvent::StartDkg(_) => {
@@ -1384,23 +1384,23 @@ impl Chain {
         }
     }
 
-    pub fn compute_relocation_request_recipient(&mut self, old_dst: Option<XorName>) -> XorName {
+    pub fn compute_relocate_request_recipient(&mut self, old_dst: Option<XorName>) -> XorName {
         let new_dst = if let Some(old_dst) = old_dst {
-            self.compute_next_relocation_request_recipient(old_dst)
+            self.compute_next_relocate_request_recipient(old_dst)
         } else {
-            self.compute_first_relocation_request_recipient()
+            self.compute_first_relocate_request_recipient()
         };
 
-        self.state.relocation_request_recipient = Some(new_dst);
+        self.state.relocate_request_recipient = Some(new_dst);
         new_dst
     }
 
-    pub fn is_current_relocation_request_recipient(&self, name: &XorName) -> bool {
-        self.state.relocation_request_recipient.as_ref() == Some(name)
+    pub fn is_current_relocate_request_recipient(&self, name: &XorName) -> bool {
+        self.state.relocate_request_recipient.as_ref() == Some(name)
     }
 
-    pub fn reset_relocation_request(&mut self) {
-        self.state.relocation_request_recipient = None;
+    pub fn reset_relocate_request(&mut self) {
+        self.state.relocate_request_recipient = None;
     }
 
     pub fn dev_params(&self) -> &DevParams {
@@ -1414,14 +1414,14 @@ impl Chain {
 
 #[cfg(not(feature = "mock_base"))]
 impl Chain {
-    fn compute_first_relocation_request_recipient(&mut self) -> XorName {
+    fn compute_first_relocate_request_recipient(&mut self) -> XorName {
         relocation::compute_first_request_recipient(
             self.our_prefix(),
             self.our_info().member_names(),
         )
     }
 
-    fn compute_next_relocation_request_recipient(&mut self, prev: XorName) -> XorName {
+    fn compute_next_relocate_request_recipient(&mut self, prev: XorName) -> XorName {
         relocation::compute_next_request_recipient(self.our_prefix(), prev)
     }
 }
@@ -1480,7 +1480,7 @@ impl Chain {
             .unwrap_or(&self.our_prefix())
     }
 
-    fn compute_first_relocation_request_recipient(&mut self) -> XorName {
+    fn compute_first_relocate_request_recipient(&mut self) -> XorName {
         self.dev_params
             .next_relocation_request_recipient
             .take()
@@ -1492,7 +1492,7 @@ impl Chain {
             })
     }
 
-    fn compute_next_relocation_request_recipient(&mut self, prev: XorName) -> XorName {
+    fn compute_next_relocate_request_recipient(&mut self, prev: XorName) -> XorName {
         self.dev_params
             .next_relocation_request_recipient
             .take()

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1382,6 +1382,13 @@ impl Chain {
         }
     }
 
+    pub fn compute_relocation_request_recipient(&self) -> XorName {
+        relocation::compute_first_request_recipient(
+            self.our_prefix(),
+            self.our_info().member_names(),
+        )
+    }
+
     pub fn dev_params(&self) -> &DevParams {
         &self.dev_params
     }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -304,6 +304,7 @@ impl Chain {
             AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::StartDkg(_)
+            | AccumulatingEvent::RelocationRequest
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::SendAckMessage(_) => (),
@@ -694,6 +695,11 @@ impl Chain {
         self.neighbour_infos().flat_map(EldersInfo::member_nodes)
     }
 
+    /// Returns infos of all members of our section that are in the `Joined` state.
+    pub fn our_joined_members(&self) -> impl Iterator<Item = (&XorName, &MemberInfo)> {
+        self.state.our_joined_members()
+    }
+
     /// Return the keys we know
     pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
         self.state.get_their_keys_info()
@@ -829,7 +835,8 @@ impl Chain {
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::AckMessage(_)
             | AccumulatingEvent::User(_)
-            | AccumulatingEvent::Relocate(_) => {
+            | AccumulatingEvent::Relocate(_) 
+            | AccumulatingEvent::RelocationRequest => {
                 !self.state.split_in_progress && self.our_info().is_quorum(proofs)
             }
             AccumulatingEvent::StartDkg(_) => {

--- a/src/chain/config.rs
+++ b/src/chain/config.rs
@@ -39,6 +39,8 @@ pub struct DevParams {
     // Interval used for relocation in mock network tests.
     // Note: this is currently unused.
     pub next_relocation_interval: Option<XorTargetInterval>,
+    // Name to be used as the next relocation request recipient.
+    pub next_relocation_request_recipient: Option<XorName>,
 }
 
 #[cfg(not(feature = "mock_base"))]

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -123,9 +123,15 @@ pub enum AccumulatingEvent {
     Relocate(RelocateDetails),
 
     // Voted to trigger a request for a node to be relocated to our section.
-    // To make the vote unique within a single parsec instance, it contains the recipient of the
-    // previous request, if any.
+    // To make the vote unique within a single parsec instance, it contains the recipient name of
+    // the previous request, if any.
     RelocationRequest(Option<XorName>),
+
+    // Voted to refuse a relocation request.
+    RefuseRelocationRequest {
+        src: Prefix<XorName>,
+        dst: XorName,
+    },
 
     // Opaque user-defined event.
     User(Vec<u8>),
@@ -177,6 +183,11 @@ impl Debug for AccumulatingEvent {
             AccumulatingEvent::RelocationRequest(dst) => {
                 write!(formatter, "RelocationRequest({:?})", dst)
             }
+            AccumulatingEvent::RefuseRelocationRequest { src, dst } => write!(
+                formatter,
+                "RefuseRelocationRequest {{ src: {:?}, dst: {:?} }}",
+                src, dst
+            ),
             AccumulatingEvent::User(payload) => write!(formatter, "User({:<8})", HexFmt(payload)),
         }
     }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -122,8 +122,10 @@ pub enum AccumulatingEvent {
     // Voted for node to be relocated out of our section.
     Relocate(RelocateDetails),
 
-    // Voted to trigger a request to the network for a node to be relocated to our section.
-    RelocationRequest,
+    // Voted to trigger a request for a node to be relocated to our section.
+    // To make the vote unique within a single parsec instance, it contains the recipient of the
+    // previous request, if any.
+    RelocationRequest(Option<XorName>),
 
     // Opaque user-defined event.
     User(Vec<u8>),
@@ -172,7 +174,9 @@ impl Debug for AccumulatingEvent {
             }
             AccumulatingEvent::ParsecPrune => write!(formatter, "ParsecPrune"),
             AccumulatingEvent::Relocate(payload) => write!(formatter, "Relocate({:?})", payload),
-            AccumulatingEvent::RelocationRequest => write!(formatter, "RelocationRequest"),
+            AccumulatingEvent::RelocationRequest(dst) => {
+                write!(formatter, "RelocationRequest({:?})", dst)
+            }
             AccumulatingEvent::User(payload) => write!(formatter, "User({:<8})", HexFmt(payload)),
         }
     }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -122,6 +122,9 @@ pub enum AccumulatingEvent {
     // Voted for node to be relocated out of our section.
     Relocate(RelocateDetails),
 
+    // Voted to trigger a request to the network for a node to be relocated to our section.
+    RelocationRequest,
+
     // Opaque user-defined event.
     User(Vec<u8>),
 }
@@ -169,6 +172,7 @@ impl Debug for AccumulatingEvent {
             }
             AccumulatingEvent::ParsecPrune => write!(formatter, "ParsecPrune"),
             AccumulatingEvent::Relocate(payload) => write!(formatter, "Relocate({:?})", payload),
+            AccumulatingEvent::RelocationRequest => write!(formatter, "RelocationRequest"),
             AccumulatingEvent::User(payload) => write!(formatter, "User({:<8})", HexFmt(payload)),
         }
     }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -122,13 +122,13 @@ pub enum AccumulatingEvent {
     // Voted for node to be relocated out of our section.
     Relocate(RelocateDetails),
 
-    // Voted to trigger a request for a node to be relocated to our section.
+    // Voted to send a request for a node to be relocated to our section.
     // To make the vote unique within a single parsec instance, it contains the recipient name of
     // the previous request, if any.
-    RelocationRequest(Option<XorName>),
+    RelocateRequest(Option<XorName>),
 
-    // Voted to refuse a relocation request.
-    RefuseRelocationRequest {
+    // Voted to deny a relocate request.
+    DenyRelocateRequest {
         src: Prefix<XorName>,
         dst: XorName,
     },
@@ -180,12 +180,12 @@ impl Debug for AccumulatingEvent {
             }
             AccumulatingEvent::ParsecPrune => write!(formatter, "ParsecPrune"),
             AccumulatingEvent::Relocate(payload) => write!(formatter, "Relocate({:?})", payload),
-            AccumulatingEvent::RelocationRequest(dst) => {
-                write!(formatter, "RelocationRequest({:?})", dst)
+            AccumulatingEvent::RelocateRequest(dst) => {
+                write!(formatter, "RelocateRequest({:?})", dst)
             }
-            AccumulatingEvent::RefuseRelocationRequest { src, dst } => write!(
+            AccumulatingEvent::DenyRelocateRequest { src, dst } => write!(
                 formatter,
-                "RefuseRelocationRequest {{ src: {:?}, dst: {:?} }}",
+                "DenyRelocateRequest {{ src: {:?}, dst: {:?} }}",
                 src, dst
             ),
             AccumulatingEvent::User(payload) => write!(formatter, "User({:<8})", HexFmt(payload)),

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -127,8 +127,8 @@ pub enum AccumulatingEvent {
     // the previous request, if any.
     RelocateRequest(Option<XorName>),
 
-    // Voted to deny a relocate request.
-    DenyRelocateRequest {
+    // Voted to respond to a relocate request.
+    RelocateResponse {
         src: Prefix<XorName>,
         dst: XorName,
     },
@@ -183,9 +183,9 @@ impl Debug for AccumulatingEvent {
             AccumulatingEvent::RelocateRequest(dst) => {
                 write!(formatter, "RelocateRequest({:?})", dst)
             }
-            AccumulatingEvent::DenyRelocateRequest { src, dst } => write!(
+            AccumulatingEvent::RelocateResponse { src, dst } => write!(
                 formatter,
-                "DenyRelocateRequest {{ src: {:?}, dst: {:?} }}",
+                "RelocateResponse {{ src: {:?}, dst: {:?} }}",
                 src, dst
             ),
             AccumulatingEvent::User(payload) => write!(formatter, "User({:<8})", HexFmt(payload)),

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -64,6 +64,8 @@ pub struct SharedState {
     pub churn_event_backlog: VecDeque<AccumulatingEvent>,
     /// Queue of pending relocations.
     pub relocate_queue: VecDeque<RelocateDetails>,
+    /// Recipient of the currently ongoing relocation request, if any.
+    pub relocation_request_recipient: Option<XorName>,
 }
 
 impl SharedState {
@@ -103,6 +105,7 @@ impl SharedState {
             their_recent_keys: Default::default(),
             churn_event_backlog: Default::default(),
             relocate_queue: VecDeque::new(),
+            relocation_request_recipient: None,
         }
     }
 
@@ -133,6 +136,7 @@ impl SharedState {
             their_recent_keys,
             churn_event_backlog,
             relocate_queue,
+            relocation_request_recipient,
         ) = serialisation::deserialise(related_info)?;
         if self.our_infos.len() != 1 {
             // Check nodes with a history before genesis match the genesis block:
@@ -190,6 +194,12 @@ impl SharedState {
                 &self.relocate_queue,
                 &relocate_queue,
             );
+            update_with_genesis_related_info_check_same(
+                log_ident,
+                "relocation_request_recipient",
+                &self.relocation_request_recipient,
+                &relocation_request_recipient,
+            );
         }
         self.our_infos = our_infos;
         self.our_history = our_history;
@@ -200,6 +210,7 @@ impl SharedState {
         self.their_recent_keys = their_recent_keys;
         self.churn_event_backlog = churn_event_backlog;
         self.relocate_queue = relocate_queue;
+        self.relocation_request_recipient = relocation_request_recipient;
 
         Ok(())
     }
@@ -215,6 +226,7 @@ impl SharedState {
             &self.their_recent_keys,
             &self.churn_event_backlog,
             &self.relocate_queue,
+            &self.relocation_request_recipient,
         ))?)
     }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -64,8 +64,8 @@ pub struct SharedState {
     pub churn_event_backlog: VecDeque<AccumulatingEvent>,
     /// Queue of pending relocations.
     pub relocate_queue: VecDeque<RelocateDetails>,
-    /// Recipient of the currently ongoing relocation request, if any.
-    pub relocation_request_recipient: Option<XorName>,
+    /// Recipient of the currently ongoing relocate request, if any.
+    pub relocate_request_recipient: Option<XorName>,
 }
 
 impl SharedState {
@@ -105,7 +105,7 @@ impl SharedState {
             their_recent_keys: Default::default(),
             churn_event_backlog: Default::default(),
             relocate_queue: VecDeque::new(),
-            relocation_request_recipient: None,
+            relocate_request_recipient: None,
         }
     }
 
@@ -136,7 +136,7 @@ impl SharedState {
             their_recent_keys,
             churn_event_backlog,
             relocate_queue,
-            relocation_request_recipient,
+            relocate_request_recipient,
         ) = serialisation::deserialise(related_info)?;
         if self.our_infos.len() != 1 {
             // Check nodes with a history before genesis match the genesis block:
@@ -196,9 +196,9 @@ impl SharedState {
             );
             update_with_genesis_related_info_check_same(
                 log_ident,
-                "relocation_request_recipient",
-                &self.relocation_request_recipient,
-                &relocation_request_recipient,
+                "relocate_request_recipient",
+                &self.relocate_request_recipient,
+                &relocate_request_recipient,
             );
         }
         self.our_infos = our_infos;
@@ -210,7 +210,7 @@ impl SharedState {
         self.their_recent_keys = their_recent_keys;
         self.churn_event_backlog = churn_event_backlog;
         self.relocate_queue = relocate_queue;
-        self.relocation_request_recipient = relocation_request_recipient;
+        self.relocate_request_recipient = relocate_request_recipient;
 
         Ok(())
     }
@@ -226,7 +226,7 @@ impl SharedState {
             &self.their_recent_keys,
             &self.churn_event_backlog,
             &self.relocate_queue,
-            &self.relocation_request_recipient,
+            &self.relocate_request_recipient,
         ))?)
     }
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -531,6 +531,8 @@ pub enum MessageContent {
     },
     /// Send from a section A to another section B to request a node to be relocated from B to A.
     RelocationRequest,
+    /// Reply to a `RelocationRequest` that cannot be fulfilled due to insufficient section size.
+    RelocationRequestRefused,
 }
 
 impl Debug for HopMessage {
@@ -570,6 +572,7 @@ impl Debug for MessageContent {
                 ack_version,
             } => write!(formatter, "AckMessage({:?}, {})", src_prefix, ack_version),
             RelocationRequest => write!(formatter, "RelocationRequest"),
+            RelocationRequestRefused => write!(formatter, "RelocationRequestRefused"),
         }
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -529,6 +529,8 @@ pub enum MessageContent {
         /// The version acknowledged.
         ack_version: u64,
     },
+    /// Send from a section A to another section B to request a node to be relocated from B to A.
+    RelocationRequest,
 }
 
 impl Debug for HopMessage {
@@ -567,6 +569,7 @@ impl Debug for MessageContent {
                 src_prefix,
                 ack_version,
             } => write!(formatter, "AckMessage({:?}, {})", src_prefix, ack_version),
+            RelocationRequest => write!(formatter, "RelocationRequest"),
         }
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -530,9 +530,9 @@ pub enum MessageContent {
         ack_version: u64,
     },
     /// Send from a section A to another section B to request a node to be relocated from B to A.
-    RelocationRequest,
-    /// Reply to a `RelocationRequest` that cannot be fulfilled due to insufficient section size.
-    RelocationRequestRefused,
+    RelocateRequest,
+    /// Reply to a `RelocateRequest` that cannot be fulfilled due to insufficient section size.
+    RelocateRequestDenied,
 }
 
 impl Debug for HopMessage {
@@ -571,8 +571,8 @@ impl Debug for MessageContent {
                 src_prefix,
                 ack_version,
             } => write!(formatter, "AckMessage({:?}, {})", src_prefix, ack_version),
-            RelocationRequest => write!(formatter, "RelocationRequest"),
-            RelocationRequestRefused => write!(formatter, "RelocationRequestRefused"),
+            RelocateRequest => write!(formatter, "RelocateRequest"),
+            RelocateRequestDenied => write!(formatter, "RelocateRequestDenied"),
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -287,6 +287,17 @@ impl Node {
         self.perform_action(action)
     }
 
+    /// Try to increase the size of our section by requesting a node to be relocated to us from
+    /// another section in the network.
+    pub fn request_node(&mut self) -> Result<(), InterfaceError> {
+        if let Some(state) = self.machine.current_mut().elder_state_mut() {
+            state.request_node();
+            Ok(())
+        } else {
+            Err(InterfaceError::InvalidState)
+        }
+    }
+
     fn perform_action(&mut self, action: Action) -> Result<(), InterfaceError> {
         let transition = self
             .machine

--- a/src/node.rs
+++ b/src/node.rs
@@ -471,7 +471,7 @@ impl Node {
         self.chain().map(|chain| chain.min_split_size())
     }
 
-    /// Sets a name to be used when the next node relocation request is received by this node.
+    /// Override the next relocation destination.
     pub fn set_next_relocation_dst(&mut self, dst: Option<XorName>) {
         self.machine
             .current_mut()
@@ -479,7 +479,7 @@ impl Node {
             .next_relocation_dst = dst;
     }
 
-    /// Gets the next relocation distance that was previosly set with `set_next_relocation_dst`.
+    /// Gets the next relocation destination override, if any.
     pub fn next_relocation_dst(&self) -> Option<XorName> {
         self.machine.current().dev_params().next_relocation_dst
     }
@@ -490,6 +490,14 @@ impl Node {
             .current_mut()
             .dev_params_mut()
             .next_relocation_interval = interval;
+    }
+
+    /// Override the next relocation request recipient.
+    pub fn set_next_relocation_request_recipient(&mut self, name: Option<XorName>) {
+        self.machine
+            .current_mut()
+            .dev_params_mut()
+            .next_relocation_request_recipient = name;
     }
 
     /// Indicates if there are any pending observations in the parsec object

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -163,3 +163,15 @@ fn rehash_name(prefix: &Prefix<XorName>, mut name: XorName) -> XorName {
         }
     }
 }
+
+/// Error indicating the the previous relocate request recipient does not match the once in the
+/// newly accumulated `RelocateRequest` event.
+///
+/// If `unexpected_recipient` is
+///    - `None`, it means we initiated a new relocate request while one was still in progress.
+///    - `Some`, it means we voted to retry a denied request but the deny came from wrong source
+///      (possibly malicious).
+#[derive(Debug)]
+pub struct RelocateRequestRecipientError {
+    pub unexpected_recipient: Option<XorName>,
+}

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -133,7 +133,7 @@ pub fn compute_destination(relocated_name: &XorName, trigger_name: &XorName) -> 
     XorName(crypto::sha3_256(&buffer))
 }
 
-/// Computes the recipient of a relocation request using the current section elders.
+/// Computes the recipient of a relocate request using the current section elders.
 pub fn compute_first_request_recipient<'a, I: IntoIterator<Item = &'a XorName>>(
     sender_prefix: &Prefix<XorName>,
     sender_members: I,
@@ -149,7 +149,7 @@ pub fn compute_first_request_recipient<'a, I: IntoIterator<Item = &'a XorName>>(
     rehash_name(sender_prefix, output)
 }
 
-/// Computes the recipient of the next relocation request if the previous one was refused.
+/// Computes the recipient of the next relocate request if the previous one failed.
 pub fn compute_next_request_recipient(sender_prefix: &Prefix<XorName>, prev: XorName) -> XorName {
     rehash_name(sender_prefix, prev)
 }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -588,7 +588,7 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_relocation_request_event(&mut self) -> Result<(), RoutingError> {
+    fn handle_relocation_request_event(&mut self, _dst: XorName) -> Result<(), RoutingError> {
         Ok(())
     }
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -592,7 +592,7 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_deny_relocate_request_event(
+    fn handle_relocate_response_event(
         &mut self,
         _src: Prefix<XorName>,
         _dst: XorName,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -592,6 +592,14 @@ impl Approved for Adult {
         Ok(())
     }
 
+    fn handle_refuse_relocation_request_event(
+        &mut self,
+        _src: Prefix<XorName>,
+        _dst: XorName,
+    ) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn handle_their_key_info_event(
         &mut self,
         _key_info: SectionKeyInfo,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -588,11 +588,11 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_relocation_request_event(&mut self, _dst: XorName) -> Result<(), RoutingError> {
+    fn handle_relocate_request_event(&mut self, _dst: XorName) -> Result<(), RoutingError> {
         Ok(())
     }
 
-    fn handle_refuse_relocation_request_event(
+    fn handle_deny_relocate_request_event(
         &mut self,
         _src: Prefix<XorName>,
         _dst: XorName,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -588,6 +588,10 @@ impl Approved for Adult {
         Ok(())
     }
 
+    fn handle_relocation_request_event(&mut self) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn handle_their_key_info_event(
         &mut self,
         _key_info: SectionKeyInfo,

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -92,6 +92,9 @@ pub trait Approved: Base {
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError>;
 
+    /// Handle an accumulated `RelocationRequest` event
+    fn handle_relocation_request_event(&mut self) -> Result<(), RoutingError>;
+
     /// Handle an accumulated `User` event
     fn handle_user_event(
         &mut self,
@@ -325,6 +328,7 @@ pub trait Approved: Base {
                 AccumulatingEvent::Relocate(payload) => {
                     self.invoke_handle_relocate_event(payload, event.signature, outbox)?
                 }
+                AccumulatingEvent::RelocationRequest => self.handle_relocation_request_event()?,
                 AccumulatingEvent::User(payload) => self.handle_user_event(payload, outbox)?,
             }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -95,8 +95,8 @@ pub trait Approved: Base {
     /// Handle an accumulated `RelocateRequest` event
     fn handle_relocate_request_event(&mut self, dst: XorName) -> Result<(), RoutingError>;
 
-    /// Handle an accumulated `DenyRelocateRequest` event
-    fn handle_deny_relocate_request_event(
+    /// Handle an accumulated `RelocateResponse` event
+    fn handle_relocate_response_event(
         &mut self,
         src: Prefix<XorName>,
         dst: XorName,
@@ -338,8 +338,8 @@ pub trait Approved: Base {
                 AccumulatingEvent::RelocateRequest(old_dst) => {
                     self.invoke_handle_relocate_request_event(old_dst)?
                 }
-                AccumulatingEvent::DenyRelocateRequest { src, dst } => {
-                    self.handle_deny_relocate_request_event(src, dst)?
+                AccumulatingEvent::RelocateResponse { src, dst } => {
+                    self.handle_relocate_response_event(src, dst)?
                 }
                 AccumulatingEvent::User(payload) => self.handle_user_event(payload, outbox)?,
             }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -95,6 +95,13 @@ pub trait Approved: Base {
     /// Handle an accumulated `RelocationRequest` event
     fn handle_relocation_request_event(&mut self, dst: XorName) -> Result<(), RoutingError>;
 
+    /// Handle an accumulated `RefuseRelocationRequest` event
+    fn handle_refuse_relocation_request_event(
+        &mut self,
+        src: Prefix<XorName>,
+        dst: XorName,
+    ) -> Result<(), RoutingError>;
+
     /// Handle an accumulated `User` event
     fn handle_user_event(
         &mut self,
@@ -330,6 +337,9 @@ pub trait Approved: Base {
                 }
                 AccumulatingEvent::RelocationRequest(old_dst) => {
                     self.invoke_handle_relocation_request_event(old_dst)?
+                }
+                AccumulatingEvent::RefuseRelocationRequest { src, dst } => {
+                    self.handle_refuse_relocation_request_event(src, dst)?
                 }
                 AccumulatingEvent::User(payload) => self.handle_user_event(payload, outbox)?,
             }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -92,11 +92,11 @@ pub trait Approved: Base {
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError>;
 
-    /// Handle an accumulated `RelocationRequest` event
-    fn handle_relocation_request_event(&mut self, dst: XorName) -> Result<(), RoutingError>;
+    /// Handle an accumulated `RelocateRequest` event
+    fn handle_relocate_request_event(&mut self, dst: XorName) -> Result<(), RoutingError>;
 
-    /// Handle an accumulated `RefuseRelocationRequest` event
-    fn handle_refuse_relocation_request_event(
+    /// Handle an accumulated `DenyRelocateRequest` event
+    fn handle_deny_relocate_request_event(
         &mut self,
         src: Prefix<XorName>,
         dst: XorName,
@@ -335,11 +335,11 @@ pub trait Approved: Base {
                 AccumulatingEvent::Relocate(payload) => {
                     self.invoke_handle_relocate_event(payload, event.signature, outbox)?
                 }
-                AccumulatingEvent::RelocationRequest(old_dst) => {
-                    self.invoke_handle_relocation_request_event(old_dst)?
+                AccumulatingEvent::RelocateRequest(old_dst) => {
+                    self.invoke_handle_relocate_request_event(old_dst)?
                 }
-                AccumulatingEvent::RefuseRelocationRequest { src, dst } => {
-                    self.handle_refuse_relocation_request_event(src, dst)?
+                AccumulatingEvent::DenyRelocateRequest { src, dst } => {
+                    self.handle_deny_relocate_request_event(src, dst)?
                 }
                 AccumulatingEvent::User(payload) => self.handle_user_event(payload, outbox)?,
             }
@@ -451,7 +451,7 @@ pub trait Approved: Base {
         payload: OnlinePayload,
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        self.chain_mut().reset_relocation_request();
+        self.chain_mut().reset_relocate_request();
         self.handle_online_event(payload, outbox)
     }
 
@@ -474,14 +474,12 @@ pub trait Approved: Base {
         }
     }
 
-    fn invoke_handle_relocation_request_event(
+    fn invoke_handle_relocate_request_event(
         &mut self,
         old_dst: Option<XorName>,
     ) -> Result<(), RoutingError> {
-        let new_dst = self
-            .chain_mut()
-            .compute_relocation_request_recipient(old_dst);
-        self.handle_relocation_request_event(new_dst)
+        let new_dst = self.chain_mut().compute_relocate_request_recipient(old_dst);
+        self.handle_relocate_request_event(new_dst)
     }
 }
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -874,18 +874,7 @@ impl Elder {
     }
 
     fn handle_relocate_request_denied(&mut self, src: XorName) {
-        if !self.chain.is_current_relocate_request_recipient(&src) {
-            log_or_panic!(
-                LogLevel::Error,
-                "{} - Unexpected sender of RelocateRequestDenied: {}",
-                self,
-                src,
-            );
-            return;
-        }
-
         info!("{} - Relocate request to {} denied", self, src);
-
         // Try again
         self.vote_for_event(AccumulatingEvent::RelocateRequest(Some(src)))
     }

--- a/src/xor_name.rs
+++ b/src/xor_name.rs
@@ -252,6 +252,14 @@ impl<'a> ops::Div<&'a u32> for &'a XorName {
     }
 }
 
+impl<'a> ops::BitXorAssign<&'a Self> for XorName {
+    fn bitxor_assign(&mut self, rhs: &'a Self) {
+        for (lhs_byte, rhs_byte) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *lhs_byte ^= rhs_byte
+        }
+    }
+}
+
 impl AsRef<XorName> for XorName {
     fn as_ref(&self) -> &Self {
         self

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -218,9 +218,9 @@ pub fn poll_and_resend(nodes: &mut [TestNode]) {
 }
 
 /// Options for polling nodes in the test network.
-pub struct PollOptions {
+pub struct PollOptions<'a> {
     /// If set, polling continues while this predicate returns true even if all nodes are idle.
-    pub continue_predicate: Option<Box<dyn Fn(&[TestNode]) -> bool>>,
+    pub continue_predicate: Option<Box<dyn Fn(&[TestNode]) -> bool + 'a>>,
     /// If set and all nodes become idle, advances the time by this amount (in seconds) and polls
     /// again one more time.
     pub extra_advance: Option<u64>,
@@ -229,7 +229,7 @@ pub struct PollOptions {
     pub fire_join_timeout: bool,
 }
 
-impl Default for PollOptions {
+impl Default for PollOptions<'_> {
     fn default() -> Self {
         Self {
             continue_predicate: None,
@@ -239,10 +239,10 @@ impl Default for PollOptions {
     }
 }
 
-impl PollOptions {
+impl<'a> PollOptions<'a> {
     pub fn continue_if<F>(self, pred: F) -> Self
     where
-        F: Fn(&[TestNode]) -> bool + 'static,
+        F: Fn(&[TestNode]) -> bool + 'a,
     {
         Self {
             continue_predicate: Some(Box::new(pred)),


### PR DESCRIPTION
This PR implement the relocate request feature - that is - a section can request a node from another section to be relocated into it. This is a high-level overview of how the feature works:

1. Relocate request must be invoked explicitly by the upper layer. Autonomous relocate requests are not implemented yet (it will be a separate task)
2. Triggering relocate request starts by first voting for it in parsec
3. When it accumulates, we calculate a recipient of the request (a random, but common `XorName`) 
4. We send the request to that name as a `PrefixSection` -> `Section` message. We also store the recipient name in the shared state.
5. When the recipient section receives it, it votes to respond to it
6. When that vote accumulates, it decides whether it can fulfill the request by checking the number of nodes in the section. If it has more than `ELDER_SIZE`, it accepts it, otherwise it denies it.

## Accept

7. The recipient section votes to relocate its youngest node into the requester section.
8. That node relocates
9. When the requester section accumulates the `Online` vote, it resets the relocate request recipient name from shared state. The process now ends.

## Deny

7. The recipient section sends a deny message back to the requester section
8. When the requester section receives the message, it votes again, putting the previous recipient name into the vote to make it unique
9. When the vote accumulates, new recipient name is calculated by rehashing the previous name.
10. Go to point 4
