### PR TITLE
Start signing next key with previous BLS key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "~1.0.8"
 
 [features]
 mock_base = ["lru_time_cache/fake_clock", "parsec/mock", "parsec/malice-detection", "ctrlc", "lazy_static"]
-mock_crypto = ["mock_base"]
+mock_crypto = ["mock_base", "threshold_crypto/use-insecure-test-only-mock-crypto"]
 mock_parsec = ["mock_base"]
 mock_serialise = ["mock_base"]
 mock = ["mock_crypto", "mock_parsec", "mock_serialise"]

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -11,7 +11,7 @@ use super::{
     shared_state::{PrefixChange, SectionKeyInfo, SharedState},
     AccumulatedEvent, AccumulatingEvent, AgeCounter, DevParams, EldersChange, EldersInfo,
     GenesisPfxInfo, MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof,
-    ProofSet, SectionProofChain,
+    ProofSet, RealBlsEventSigPayload, SectionProofChain,
 };
 use crate::{
     error::RoutingError,
@@ -96,6 +96,26 @@ impl Chain {
             .secret_key_share
             .as_ref()
             .ok_or(RoutingError::InvalidElderDkgResult)
+    }
+
+    pub fn our_section_next_bls_keys_sig(
+        &self,
+        info: &EldersInfo,
+    ) -> Result<Option<RealBlsEventSigPayload>, RoutingError> {
+        if !info.is_member(self.our_id()) {
+            return Ok(None);
+        }
+
+        let next_public_key_set = &self
+            .new_section_bls_keys
+            .as_ref()
+            .ok_or(RoutingError::InvalidElderDkgResult)?
+            .public_key_set;
+
+        Ok(Some(RealBlsEventSigPayload::new(
+            self.our_section_bls_secret_key_share()?,
+            next_public_key_set,
+        )?))
     }
 
     /// Returns the number of nodes which need to exist in each subsection of a given section to

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -163,7 +163,7 @@ impl ChainAccumulator {
                 .into_iter()
                 .filter(|&(_, ref proofs)| proofs.parsec_proofs.contains_id(our_id))
                 .map(|(event, proofs)| {
-                    event.into_network_event_with(proofs.into_sig_shares().remove(our_id))
+                    event.into_network_event_with(proofs.into_sig_shares().remove(our_id), None)
                 })
                 .collect(),
             completed_events,
@@ -336,7 +336,7 @@ mod test {
                     our_id: *id.public_id(),
                     event: AccumulatingEvent::SectionInfo(elders_info.clone()),
                     network_event: AccumulatingEvent::SectionInfo(elders_info.clone())
-                        .into_network_event_with(Some(sig_payload.clone())),
+                        .into_network_event_with(Some(sig_payload.clone()), None),
                     first_proof,
                     proofs: proofs.clone(),
                     acc_proofs: AccumulatingProof {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -28,7 +28,8 @@ pub use self::{
     member_info::{AgeCounter, MemberInfo, MemberPersona, MemberState, MIN_AGE, MIN_AGE_COUNTER},
     network_event::{
         AccumulatedEvent, AccumulatingEvent, AckMessagePayload, EldersChange, EventSigPayload,
-        IntoAccumulatingEvent, NetworkEvent, OnlinePayload, SendAckMessagePayload,
+        IntoAccumulatingEvent, NetworkEvent, OnlinePayload, RealBlsEventSigPayload,
+        SendAckMessagePayload,
     },
     proof::{Proof, ProofSet},
     shared_state::{PrefixChange, SectionKeyInfo, SectionProofChain},

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -33,15 +33,16 @@ pub use self::{
     proof::{Proof, ProofSet},
     shared_state::{PrefixChange, SectionKeyInfo, SectionProofChain},
 };
-use crate::PublicId;
 #[cfg(feature = "mock_base")]
 use crate::{error::RoutingError, id::P2pNode, BlsPublicKeySet, Prefix, XorName};
+use crate::{PublicId, RealBlsPublicKeySet};
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Formatter};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct GenesisPfxInfo {
     pub first_info: EldersInfo,
+    pub first_bls_keys: RealBlsPublicKeySet,
     pub first_state_serialized: Vec<u8>,
     pub first_ages: BTreeMap<PublicId, AgeCounter>,
     pub latest_info: EldersInfo,

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,6 +98,8 @@ pub enum RoutingError {
     UntrustedMessage,
     /// A new SectionInfo is invalid.
     InvalidNewSectionInfo,
+    /// An Elder DKG result is invalid.
+    InvalidElderDkgResult,
 }
 
 impl From<RoutingTableError> for RoutingError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,8 +196,9 @@ pub(crate) use chain::Chain;
 use quic_p2p;
 
 pub use threshold_crypto::{
-    PublicKeySet as RealBlsPublicKeySet, SecretKeySet as RealBlsSecretKeySet,
-    SecretKeyShare as RealBlsSecretKeyShare, SignatureShare as RealBlsSignatureShare,
+    PublicKeySet as RealBlsPublicKeySet, PublicKeyShare as RealBlsPublicKeyShare,
+    SecretKeySet as RealBlsSecretKeySet, SecretKeyShare as RealBlsSecretKeyShare,
+    SignatureShare as RealBlsSignatureShare,
 };
 
 // Format that can be sent between peers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,11 @@ pub(crate) use chain::Chain;
 #[cfg(not(feature = "mock_base"))]
 use quic_p2p;
 
+pub use threshold_crypto::{
+    PublicKeySet as RealBlsPublicKeySet, SecretKeySet as RealBlsSecretKeySet,
+    SecretKeyShare as RealBlsSecretKeyShare, SignatureShare as RealBlsSignatureShare,
+};
+
 // Format that can be sent between peers
 #[cfg(not(feature = "mock_serialise"))]
 pub(crate) type NetworkBytes = bytes::Bytes;

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -93,6 +93,7 @@ impl Adult {
             details.dev_params,
             public_id,
             details.gen_pfx_info.clone(),
+            None,
         );
 
         let node = Self {

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -266,6 +266,8 @@ pub trait Approved: Base {
                     participants,
                     dkg_result,
                 } => {
+                    self.chain_mut()
+                        .handle_dkg_result_event(participants, dkg_result)?;
                     self.handle_dkg_result_event(participants, dkg_result)?;
                 }
             }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         SignedRoutingMessage,
     },
     outbox::EventBox,
-    parsec::{self, DkgResultWrapper, ParsecMap},
+    parsec::{self, generate_first_dkg_result, DkgResultWrapper, ParsecMap},
     pause::PausedState,
     peer_map::PeerMap,
     relocation::{RelocateDetails, RelocatePayload, SignedRelocateDetails},
@@ -113,8 +113,10 @@ impl Elder {
         let p2p_node = P2pNode::new(public_id, connection_info);
         let mut first_ages = BTreeMap::new();
         let _ = first_ages.insert(public_id, MIN_AGE_COUNTER);
+        let first_dkg_result = generate_first_dkg_result(&mut rng);
         let gen_pfx_info = GenesisPfxInfo {
             first_info: create_first_elders_info(p2p_node)?,
+            first_bls_keys: first_dkg_result.public_key_set,
             first_state_serialized: Vec::new(),
             first_ages,
             latest_info: EldersInfo::default(),
@@ -126,6 +128,7 @@ impl Elder {
             DevParams::default(),
             public_id,
             gen_pfx_info.clone(),
+            first_dkg_result.secret_key_share,
         );
 
         let details = ElderDetails {
@@ -676,6 +679,7 @@ impl Elder {
 
         let trimmed_info = GenesisPfxInfo {
             first_info: self.gen_pfx_info.first_info.clone(),
+            first_bls_keys: self.gen_pfx_info.first_bls_keys.clone(),
             first_state_serialized: Default::default(),
             first_ages: self.gen_pfx_info.first_ages.clone(),
             latest_info: self.chain.our_info().clone(),

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -20,7 +20,7 @@ use crate::{
     outbox::EventBox,
     rng::{self, MainRng},
     state_machine::{State, StateMachine, Transition},
-    NetworkConfig, NetworkParams, NetworkService, ELDER_SIZE,
+    NetworkConfig, NetworkParams, NetworkService, RealBlsSecretKeyShare, ELDER_SIZE,
 };
 use std::{iter, net::SocketAddr};
 use unwrap::unwrap;
@@ -89,8 +89,10 @@ impl ElderUnderTest {
             .map(|id| (*id.public_id(), MIN_AGE_COUNTER))
             .collect();
 
+        let dkg_result = generate_first_dkg_result(&mut rng);
         let gen_pfx_info = GenesisPfxInfo {
             first_info: elders_info.clone(),
+            first_bls_keys: dkg_result.public_key_set,
             first_state_serialized: Vec::new(),
             first_ages,
             latest_info: EldersInfo::default(),
@@ -98,7 +100,13 @@ impl ElderUnderTest {
         };
 
         let full_id = full_ids[0].clone();
-        let machine = make_state_machine(&mut rng, &full_id, &gen_pfx_info, &mut ());
+        let machine = make_state_machine(
+            &mut rng,
+            &full_id,
+            &gen_pfx_info,
+            dkg_result.secret_key_share,
+            &mut (),
+        );
 
         let other_full_ids = full_ids[1..].iter().cloned().collect_vec();
 
@@ -312,6 +320,7 @@ impl ElderUnderTest {
 fn new_elder_state(
     full_id: &FullId,
     gen_pfx_info: &GenesisPfxInfo,
+    secret_key_share: Option<RealBlsSecretKeyShare>,
     network_service: NetworkService,
     timer: Timer,
     rng: &mut MainRng,
@@ -325,6 +334,7 @@ fn new_elder_state(
         Default::default(),
         public_id,
         gen_pfx_info.clone(),
+        secret_key_share,
     );
 
     let details = ElderDetails {
@@ -353,6 +363,7 @@ fn make_state_machine(
     rng: &mut MainRng,
     full_id: &FullId,
     gen_pfx_info: &GenesisPfxInfo,
+    secret_key_share: Option<RealBlsSecretKeyShare>,
     outbox: &mut dyn EventBox,
 ) -> StateMachine {
     let network = Network::new(NetworkParams {
@@ -365,7 +376,15 @@ fn make_state_machine(
 
     StateMachine::new(
         move |network_service, timer, outbox2| {
-            new_elder_state(full_id, gen_pfx_info, network_service, timer, rng, outbox2)
+            new_elder_state(
+                full_id,
+                gen_pfx_info,
+                secret_key_share,
+                network_service,
+                timer,
+                rng,
+                outbox2,
+            )
         },
         config,
         outbox,

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -147,7 +147,10 @@ impl ElderUnderTest {
 
                 info!("Vote as {:?} for event {:?}", full_id.public_id(), event);
                 parsec.vote_for_as(
-                    event.clone().into_network_event_with(sig_event).into_obs(),
+                    event
+                        .clone()
+                        .into_network_event_with(sig_event, None)
+                        .into_obs(),
                     &full_id,
                 );
             });


### PR DESCRIPTION
Partially address #1891 

Use DkgResult and BLS keys to sign the next key.
This is incomplete in the sense that we are not yet signing the SectionKeyInfo as we should, but provide the initial setup to continue the work of removing bls_emu
