### PR TITLE
Sign RealSectionKeyInfo with BLS key

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -11,7 +11,7 @@ use super::{
     shared_state::{SectionKeyInfo, SharedState},
     AccumulatedEvent, AccumulatingEvent, AgeCounter, DevParams, EldersChange, EldersInfo,
     GenesisPfxInfo, MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof,
-    ProofSet, RealBlsEventSigPayload, SectionProofChain,
+    ProofSet, SectionProofChain,
 };
 use crate::{
     error::RoutingError,
@@ -96,16 +96,6 @@ impl Chain {
             .secret_key_share
             .as_ref()
             .ok_or(RoutingError::InvalidElderDkgResult)
-    }
-
-    pub fn our_section_next_bls_keys_sig(
-        &self,
-        info: &EldersInfo,
-    ) -> Result<Option<RealBlsEventSigPayload>, RoutingError> {
-        Ok(Some(RealBlsEventSigPayload::new_for_section_key_info(
-            self.our_section_bls_secret_key_share()?,
-            &SectionKeyInfo::from_elders_info(info),
-        )?))
     }
 
     /// Returns the number of nodes which need to exist in each subsection of a given section to

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -259,7 +259,7 @@ pub struct RemainingEvents {
 
 #[cfg(test)]
 mod test {
-    use super::super::EldersInfo;
+    use super::super::{EldersInfo, SectionKeyInfo};
     use super::*;
     use crate::{
         id::FullId,
@@ -334,12 +334,13 @@ mod test {
             EventType::WithSignature => {
                 let elders_info = empty_elders_info();
                 let sig_payload = random_section_info_sig_payload(rng);
+                let key_info = SectionKeyInfo::from_elders_info(&elders_info);
+                let event = AccumulatingEvent::SectionInfo(elders_info.clone(), key_info);
 
                 TestData {
                     our_id: *id.public_id(),
-                    event: AccumulatingEvent::SectionInfo(elders_info.clone()),
-                    network_event: AccumulatingEvent::SectionInfo(elders_info.clone())
-                        .into_network_event_with(Some(sig_payload.clone()), None),
+                    event: event.clone(),
+                    network_event: event.into_network_event_with(Some(sig_payload.clone()), None),
                     first_proof,
                     proofs: proofs.clone(),
                     acc_proofs: AccumulatingProof {

--- a/src/chain/elders_info.rs
+++ b/src/chain/elders_info.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{AccumulatingEvent, IntoAccumulatingEvent, ProofSet};
+use super::ProofSet;
 use crate::{
     crypto::{self, Digest256},
     error::RoutingError,
@@ -171,12 +171,6 @@ impl EldersInfo {
             prev_hash,
             hash,
         })
-    }
-}
-
-impl IntoAccumulatingEvent for EldersInfo {
-    fn into_accumulating_event(self) -> AccumulatingEvent {
-        AccumulatingEvent::SectionInfo(self)
     }
 }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -32,7 +32,7 @@ pub use self::{
         SendAckMessagePayload,
     },
     proof::{Proof, ProofSet},
-    shared_state::{SectionKeyInfo, SectionProofChain},
+    shared_state::{RealSectionKeyInfo, SectionKeyInfo, SectionProofChain},
 };
 #[cfg(feature = "mock_base")]
 use crate::{error::RoutingError, id::P2pNode, BlsPublicKeySet, Prefix, XorName};

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -23,7 +23,6 @@ use crate::{
     XorName,
 };
 use hex_fmt::HexFmt;
-use maidsafe_utilities::serialisation;
 use serde::Serialize;
 use std::{
     collections::BTreeSet,
@@ -78,11 +77,11 @@ pub struct RealBlsEventSigPayload {
 }
 
 impl RealBlsEventSigPayload {
-    pub fn new<T: Serialize>(
+    pub fn new_for_section_key_info(
         key_share: &RealBlsSecretKeyShare,
-        payload: &T,
+        section_key_info: &SectionKeyInfo,
     ) -> Result<Self, RoutingError> {
-        let sig_share = key_share.sign(&serialisation::serialise(&payload)?[..]);
+        let sig_share = key_share.sign(&section_key_info.serialise_for_signature()?);
         let pub_key_share = key_share.public_key_share();
 
         Ok(Self {
@@ -111,7 +110,7 @@ pub enum AccumulatingEvent {
     /// Voted for node we no longer consider online.
     Offline(PublicId),
 
-    SectionInfo(EldersInfo),
+    SectionInfo(EldersInfo, SectionKeyInfo),
 
     // Voted for received message with info to update neighbour_info.
     NeighbourInfo(EldersInfo),
@@ -169,7 +168,7 @@ impl Debug for AccumulatingEvent {
             }
             AccumulatingEvent::Online(payload) => write!(formatter, "Online({:?})", payload),
             AccumulatingEvent::Offline(id) => write!(formatter, "Offline({})", id),
-            AccumulatingEvent::SectionInfo(info) => write!(formatter, "SectionInfo({:?})", info),
+            AccumulatingEvent::SectionInfo(info, _) => write!(formatter, "SectionInfo({:?})", info),
             AccumulatingEvent::NeighbourInfo(info) => {
                 write!(formatter, "NeighbourInfo({:?})", info)
             }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{EldersInfo, Proof, SectionKeyInfo};
+use super::{EldersInfo, Proof, RealSectionKeyInfo, SectionKeyInfo};
 use crate::{
     id::{FullId, P2pNode, PublicId},
     parsec,
@@ -79,7 +79,7 @@ pub struct RealBlsEventSigPayload {
 impl RealBlsEventSigPayload {
     pub fn new_for_section_key_info(
         key_share: &RealBlsSecretKeyShare,
-        section_key_info: &SectionKeyInfo,
+        section_key_info: &RealSectionKeyInfo,
     ) -> Result<Self, RoutingError> {
         let sig_share = key_share.sign(&section_key_info.serialise_for_signature()?);
         let pub_key_share = key_share.public_key_share();
@@ -110,7 +110,7 @@ pub enum AccumulatingEvent {
     /// Voted for node we no longer consider online.
     Offline(PublicId),
 
-    SectionInfo(EldersInfo, SectionKeyInfo),
+    SectionInfo(EldersInfo, RealSectionKeyInfo),
 
     // Voted for received message with info to update neighbour_info.
     NeighbourInfo(EldersInfo),
@@ -217,8 +217,14 @@ impl parsec::NetworkEvent for NetworkEvent {}
 
 impl Debug for NetworkEvent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        if self.signature.is_some() {
-            write!(formatter, "{:?}(signature)", self.payload)
+        if self.signature.is_some() || self.real_signature.is_some() {
+            write!(
+                formatter,
+                "{:?}(signature {} {})",
+                self.payload,
+                self.signature.is_some(),
+                self.real_signature.is_some()
+            )
         } else {
             self.payload.fmt(formatter)
         }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -491,7 +491,7 @@ impl SectionProofBlock {
     }
 
     pub fn verify_with_pk(&self, pk: &BlsPublicKey) -> bool {
-        if let Some(to_verify) = self.key_info.serialise_for_signature() {
+        if let Ok(to_verify) = self.key_info.serialise_for_signature() {
             pk.verify(&self.sig, to_verify)
         } else {
             false
@@ -634,8 +634,10 @@ impl SectionKeyInfo {
         self.key_info_holder.internal_elders_info().version()
     }
 
-    pub fn serialise_for_signature(&self) -> Option<Vec<u8>> {
-        serialisation::serialise(self.key_info_holder.internal_elders_info()).ok()
+    pub fn serialise_for_signature(&self) -> Result<Vec<u8>, RoutingError> {
+        Ok(serialisation::serialise(
+            self.key_info_holder.internal_elders_info(),
+        )?)
     }
 }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     error::RoutingError, id::PublicId, relocation::RelocateDetails, utils::LogIdent, BlsPublicKey,
-    BlsPublicKeySet, BlsSignature, Prefix, XorName,
+    BlsPublicKeySet, BlsSignature, Prefix, RealBlsPublicKey, XorName,
 };
 use itertools::Itertools;
 use log::LogLevel;
@@ -638,6 +638,31 @@ impl SectionKeyInfo {
         Ok(serialisation::serialise(
             self.key_info_holder.internal_elders_info(),
         )?)
+    }
+}
+
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+pub struct RealSectionKeyInfo {
+    /// The section version. This increases monotonically whenever the set of elders changes.
+    /// Identical to `ElderInfo`'s.
+    version: u64,
+    /// The section prefix. It matches all the members' names.
+    prefix: Prefix<XorName>,
+    /// The section BLS public key set
+    key: RealBlsPublicKey,
+}
+
+impl RealSectionKeyInfo {
+    pub fn from_elders_info(info: &EldersInfo, key: RealBlsPublicKey) -> Self {
+        Self {
+            version: *info.version(),
+            prefix: *info.prefix(),
+            key,
+        }
+    }
+
+    pub fn serialise_for_signature(&self) -> Result<Vec<u8>, RoutingError> {
+        Ok(serialisation::serialise(&self)?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,9 +196,9 @@ pub(crate) use chain::Chain;
 use quic_p2p;
 
 pub use threshold_crypto::{
-    PublicKeySet as RealBlsPublicKeySet, PublicKeyShare as RealBlsPublicKeyShare,
-    SecretKeySet as RealBlsSecretKeySet, SecretKeyShare as RealBlsSecretKeyShare,
-    SignatureShare as RealBlsSignatureShare,
+    PublicKey as RealBlsPublicKey, PublicKeySet as RealBlsPublicKeySet,
+    PublicKeyShare as RealBlsPublicKeyShare, SecretKeySet as RealBlsSecretKeySet,
+    SecretKeyShare as RealBlsSecretKeyShare, SignatureShare as RealBlsSignatureShare,
 };
 
 // Format that can be sent between peers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ pub use crate::{
         section_proof_chain_from_elders_info, NetworkParams, MIN_AGE,
     },
     messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
+    parsec::generate_bls_threshold_secret_key,
 };
 pub use crate::{
     error::{InterfaceError, RoutingError},

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -128,6 +128,19 @@ where
         });
     }
 
+    pub fn get_dkg_result_as(
+        &mut self,
+        participants: BTreeSet<S::PublicId>,
+        vote_id: &S,
+    ) -> DkgResult {
+        state::with(
+            self.section_hash,
+            |state: &mut SectionState<T, S::PublicId>| {
+                state.get_or_generate_keys(&mut self.rng, vote_id.public_id(), participants.clone())
+            },
+        )
+    }
+
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &S::PublicId> {
         let iter = if self.peer_list.contains(self.our_id.public_id()) {
             Some(

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -302,7 +302,7 @@ pub trait Approved: Base {
                 AccumulatingEvent::Offline(pub_id) => {
                     self.handle_offline_event(pub_id, outbox)?;
                 }
-                AccumulatingEvent::SectionInfo(elders_info) => {
+                AccumulatingEvent::SectionInfo(elders_info, _) => {
                     match self.handle_section_info_event(
                         elders_info,
                         our_pfx,

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -421,7 +421,7 @@ impl Elder {
                 | AccumulatingEvent::Relocate(_) => false,
 
                 // Keep: Additional signatures for neighbours for sec-msg-relay.
-                AccumulatingEvent::SectionInfo(ref elders_info)
+                AccumulatingEvent::SectionInfo(ref elders_info, _)
                 | AccumulatingEvent::NeighbourInfo(ref elders_info) => {
                     our_pfx.is_neighbour(elders_info.prefix())
                 }
@@ -907,10 +907,11 @@ impl Elder {
     fn vote_for_section_info(&mut self, elders_info: EldersInfo) -> Result<(), RoutingError> {
         let signature_payload = EventSigPayload::new(&self.full_id, &elders_info)?;
         let real_signature_payload = self.chain.our_section_next_bls_keys_sig(&elders_info)?;
+        let key_info = SectionKeyInfo::from_elders_info(&elders_info);
+        let acc_event = AccumulatingEvent::SectionInfo(elders_info, key_info);
 
-        let event = elders_info
-            .into_accumulating_event()
-            .into_network_event_with(Some(signature_payload), real_signature_payload);
+        let event =
+            acc_event.into_network_event_with(Some(signature_payload), real_signature_payload);
         self.vote_for_network_event(event);
         Ok(())
     }

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -139,7 +139,7 @@ impl ElderUnderTest {
         let parsec = unwrap!(self.machine.current_mut().elder_state_mut()).parsec_map_mut();
         for event in events {
             self.other_full_ids.iter().take(count).for_each(|full_id| {
-                let sig_event = if let AccumulatingEvent::SectionInfo(ref info) = event {
+                let sig_event = if let AccumulatingEvent::SectionInfo(ref info, _) = event {
                     Some(unwrap!(EventSigPayload::new(&full_id, info)))
                 } else {
                     None
@@ -202,9 +202,13 @@ impl ElderUnderTest {
     }
 
     fn accumulate_section_info_if_vote(&mut self, section_info_payload: EldersInfo) {
+        let section_key_info = SectionKeyInfo::from_elders_info(&section_info_payload);
         let _ = self.n_vote_for_gossipped(
             NOT_ACCUMULATE_ALONE_VOTE_COUNT,
-            iter::once(AccumulatingEvent::SectionInfo(section_info_payload)),
+            iter::once(AccumulatingEvent::SectionInfo(
+                section_info_payload,
+                section_key_info,
+            )),
         );
     }
 


### PR DESCRIPTION
Closes #1891 

Sign RealSectionKeyInfo, this also force the code & test to provide the BlsPublicKey where needed.
This is an essential part of being able to remove bls_emu.

Note:
- `self.vote_for_section_info(merged_info)?;` can no longer be called as it require a BlsPublicKey for the new section, and we do not have it. Merge is broken already so comment this out. The whole merge code may be removed when needed.
-`our_section_next_bls_keys_sig` was not doing the right thing, as that signature need to be provided by all nodes whether they were participants or not, they will have the BlsPublicKey and need to sign it.