### PR TITLE
Fix incorrect pruning of our_members on split

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1028,6 +1028,7 @@ impl Chain {
         }
         self.churn_in_progress = false;
         self.check_and_clean_neighbour_infos(None);
+        self.state.remove_our_members_not_matching_our_prefix();
         Ok(())
     }
 
@@ -1143,9 +1144,6 @@ impl Chain {
         let our_new_info =
             EldersInfo::new(our_new_section, our_prefix, Some(self.state.our_info()))?;
         let other_info = EldersInfo::new(other_section, other_prefix, Some(self.state.our_info()))?;
-
-        self.state
-            .remove_our_members_not_matching_prefix(&our_prefix);
 
         Ok((our_new_info, other_info))
     }

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -277,12 +277,12 @@ impl SharedState {
         }
     }
 
-    /// Remove all entries from `out_members` whose name does not match `prefix`.
-    pub fn remove_our_members_not_matching_prefix(&mut self, prefix: &Prefix<XorName>) {
+    /// Remove all entries from `out_members` whose name does not match our prefix.
+    pub fn remove_our_members_not_matching_our_prefix(&mut self) {
         let (our_members, post_split_sibling_members) =
             mem::replace(&mut self.our_members, BTreeMap::new())
                 .into_iter()
-                .partition(|(name, _)| prefix.matches(name));
+                .partition(|(name, _)| self.our_prefix().matches(name));
         self.our_members = our_members;
         self.post_split_sibling_members = post_split_sibling_members;
     }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -353,11 +353,13 @@ impl Elder {
         let to_connect: Vec<_> = self
             .chain
             .our_elders()
-            .filter(|p2p_node| !self.peer_map().has(p2p_node.peer_addr()))
+            .filter(|p2p_node| {
+                p2p_node.public_id() != self.id() && !self.peer_map().has(p2p_node.peer_addr())
+            })
             .cloned()
             .collect();
 
-        for p2p_node in to_connect.into_iter() {
+        for p2p_node in to_connect {
             self.establish_connection(p2p_node)
         }
     }
@@ -1519,8 +1521,6 @@ impl Approved for Elder {
         }
 
         self.handle_candidate_approval(payload.p2p_node, outbox);
-
-        // TODO: vote for StartDkg and only when that gets consensused, vote for AddElder.
         self.add_elder(pub_id, outbox)
     }
 


### PR DESCRIPTION
The `our_members` container is now pruned only after both post-split `SectionInfo`s are accumulated, not immediately when the new node is added. This fixes issue with parsec gossip being sent only to the subset of the nodes during ongoing split.

Closes #1909