### PR TITLE
introduce single flow for promoting elders on node add/remove

### DIFF
--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -262,26 +262,6 @@ impl Adult {
         );
         self.disconnect(p2p_node.peer_addr());
     }
-
-    fn add_elder(
-        &mut self,
-        pub_id: PublicId,
-        outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        let _ = self.chain.promote_and_demote_elders()?;
-        self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-        Ok(())
-    }
-
-    fn remove_elder(
-        &mut self,
-        pub_id: PublicId,
-        outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        let _ = self.chain.promote_and_demote_elders()?;
-        self.send_event(Event::NodeLost(*pub_id.name()), outbox);
-        Ok(())
-    }
 }
 
 #[cfg(feature = "mock_base")]
@@ -520,10 +500,12 @@ impl Approved for Adult {
 
         let pub_id = *payload.p2p_node.public_id();
         self.chain.add_member(payload.p2p_node, payload.age);
+        self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
         self.chain.increment_age_counters(&pub_id);
         let _ = self.chain.poll_relocation();
+        let _ = self.chain.promote_and_demote_elders()?;
 
-        self.add_elder(pub_id, outbox)
+        Ok(())
     }
 
     fn handle_offline_event(
@@ -539,9 +521,9 @@ impl Approved for Adult {
         info!("{} - handle Offline: {}.", self, pub_id);
         self.chain.increment_age_counters(&pub_id);
         self.chain.remove_member(&pub_id);
+        self.send_event(Event::NodeLost(*pub_id.name()), outbox);
         let _ = self.chain.poll_relocation();
-
-        self.remove_elder(pub_id, outbox)?;
+        let _ = self.chain.promote_and_demote_elders()?;
         self.disconnect_by_id_lookup(&pub_id);
 
         Ok(())
@@ -600,7 +582,8 @@ impl Approved for Adult {
 
         info!("{} - handle Relocate: {:?}.", self, details);
         self.chain.remove_member(&details.pub_id);
-        self.remove_elder(details.pub_id, outbox)?;
+        self.send_event(Event::NodeLost(*details.pub_id.name()), outbox);
+        let _ = self.chain.promote_and_demote_elders()?;
         self.disconnect_by_id_lookup(&details.pub_id);
 
         Ok(())

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -268,7 +268,7 @@ impl Adult {
         pub_id: PublicId,
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        let _ = self.chain.add_elder(pub_id)?;
+        let _ = self.chain.promote_and_demote_elders()?;
         self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
         Ok(())
     }
@@ -278,7 +278,7 @@ impl Adult {
         pub_id: PublicId,
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        let _ = self.chain.remove_elder(pub_id)?;
+        let _ = self.chain.promote_and_demote_elders()?;
         self.send_event(Event::NodeLost(*pub_id.name()), outbox);
         Ok(())
     }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1110,35 +1110,12 @@ impl Elder {
         true
     }
 
-    fn add_elder(
-        &mut self,
-        pub_id: PublicId,
-        outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
+    fn promote_and_demote_elders(&mut self) -> Result<(), RoutingError> {
         for info in self.chain.promote_and_demote_elders()? {
             let participants: BTreeSet<_> = info.member_ids().copied().collect();
             let _ = self.dkg_cache.insert(participants.clone(), info);
             self.vote_for_event(AccumulatingEvent::StartDkg(participants));
         }
-
-        self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-        self.print_rt_size();
-
-        Ok(())
-    }
-
-    fn remove_elder(
-        &mut self,
-        pub_id: PublicId,
-        outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        for info in self.chain.promote_and_demote_elders()? {
-            let participants: BTreeSet<_> = info.member_ids().copied().collect();
-            let _ = self.dkg_cache.insert(participants.clone(), info);
-            self.vote_for_event(AccumulatingEvent::StartDkg(participants));
-        }
-
-        self.send_event(Event::NodeLost(*pub_id.name()), outbox);
 
         Ok(())
     }
@@ -1505,6 +1482,7 @@ impl Approved for Elder {
 
         let pub_id = *payload.p2p_node.public_id();
         self.chain.add_member(payload.p2p_node.clone(), payload.age);
+        self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
         self.chain.increment_age_counters(&pub_id);
 
         if let Some(relocate_details) = self.chain.poll_relocation() {
@@ -1512,7 +1490,10 @@ impl Approved for Elder {
         }
 
         self.handle_candidate_approval(payload.p2p_node, outbox);
-        self.add_elder(pub_id, outbox)
+        self.promote_and_demote_elders()?;
+        self.print_rt_size();
+
+        Ok(())
     }
 
     fn handle_offline_event(
@@ -1528,12 +1509,13 @@ impl Approved for Elder {
         info!("{} - handle Offline: {}.", self, pub_id);
         self.chain.increment_age_counters(&pub_id);
         self.chain.remove_member(&pub_id);
+        self.send_event(Event::NodeLost(*pub_id.name()), outbox);
 
         if let Some(relocate_details) = self.chain.poll_relocation() {
             self.vote_for_relocate(relocate_details)?;
         }
 
-        self.remove_elder(pub_id, outbox)?;
+        self.promote_and_demote_elders()?;
         self.disconnect_by_id_lookup(&pub_id);
 
         Ok(())
@@ -1697,7 +1679,8 @@ impl Approved for Elder {
         }
 
         self.chain.remove_member(&pub_id);
-        self.remove_elder(pub_id, outbox)?;
+        self.send_event(Event::NodeLost(*pub_id.name()), outbox);
+        self.promote_and_demote_elders()?;
         self.disconnect_by_id_lookup(&pub_id);
 
         Ok(())


### PR DESCRIPTION
Small clean up to support https://github.com/maidsafe/routing/pull/1856 by taking some of the changes from it.

With Node Ageing, not all new adult node will become elders.
The promote_and_demote_elders compute the new elder state based on its
current state regardless of whether a node was added or removed.

For now this keep the same behavior, promoting all Adults to be Elders
immediately.