### PR TITLE
Make sure messages are trusted by all nodes during ongoing split

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -731,22 +731,10 @@ impl Chain {
             && self.is_new(elders_info)
     }
 
-    /// Returns the index of the public key in our_history that will be trusted by the target
-    /// Authority
-    fn proving_index(&self, target: &Authority<XorName>) -> u64 {
-        self.state
-            .their_knowledge
-            .iter()
-            .filter(|(prefix, _)| target.is_compatible(prefix))
-            .map(|(_, index)| *index)
-            .min()
-            .unwrap_or(0)
-    }
-
     /// Provide a SectionProofChain that proves the given signature to the section with a given
     /// prefix
     pub fn prove(&self, target: &Authority<XorName>) -> SectionProofChain {
-        let first_index = self.proving_index(target);
+        let first_index = self.state.proving_index(target);
         self.state.our_history.slice_from(first_index as usize)
     }
 


### PR DESCRIPTION
Consider this situation:

A section `P` splits into `P0` and `P1`. Say `P0` already updates some other section `R` about their knowledge. Then `R` sends a message to `P0`. `P1` might not have fully caught itself to the split so it still thinks its prefix is `P` and so it considers itself in authority of that message. But if the message is proven only for `P0`, then `P1` would not trust it.

The fix is to construct the proof so that it is still trusted by both `P0` and `P1` until `P1` also realizes the split and updates `R` about their knowledge.

Closes #1810

Fixes failure of `aggressive_churn` with `features=mock` and seed `[3801065637, 2093151754, 3731311097, 4215731170]`.