### PR TITLE
Fix bug in preventing disconnection from nodes relocated to us

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -694,6 +694,13 @@ impl Chain {
         self.neighbour_infos().flat_map(EldersInfo::member_nodes)
     }
 
+    /// Returns all members of our section that have state == `Joined`.
+    pub fn our_joined_members(&self) -> impl Iterator<Item = &P2pNode> {
+        self.state
+            .our_joined_members()
+            .map(|(_, info)| &info.p2p_node)
+    }
+
     /// Return the keys we know
     pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
         self.state.get_their_keys_info()

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -48,7 +48,7 @@ use log::LogLevel;
 use serde::Serialize;
 use std::{
     cmp,
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
     fmt::{self, Display, Formatter},
     iter, mem,
     net::SocketAddr,
@@ -339,10 +339,16 @@ impl Elder {
     // to and disconnect from peers that are no longer elders of neighbour sections.
     fn update_peer_connections(&mut self, change: EldersChange) {
         if !self.chain.split_in_progress() {
+            let our_member_connections: HashSet<_> = self
+                .chain
+                .our_joined_members()
+                .map(|node| *node.peer_addr())
+                .collect();
+
             for p2p_node in change.removed {
                 // The peer might have been relocated from a neighbour to us - in that case do not
                 // disconnect from them.
-                if self.chain.is_peer_our_member(p2p_node.public_id()) {
+                if our_member_connections.contains(p2p_node.peer_addr()) {
                     continue;
                 }
 


### PR DESCRIPTION
The code preventing disconnection from a node relocated from neighbour to us was buggy because it assumed the node would have the same `PublicId`. Changed to lookup by `SocketAddr` instead.