### PR TITLE
Increase join timeout and use no timeout for relocating nodes

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -169,9 +169,13 @@ impl Chain {
         dkg_result: &DkgResultWrapper,
     ) -> Result<(), RoutingError> {
         if let Some(first) = participants.iter().next() {
-            let _ = self
+            if self
                 .new_section_bls_keys
-                .insert(*first.name(), dkg_result.0.clone());
+                .insert(*first.name(), dkg_result.0.clone())
+                .is_some()
+            {
+                log_or_panic!(LogLevel::Error, "{} - Ejected previous DKG result", self);
+            }
         }
 
         Ok(())

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -258,7 +258,20 @@ impl ParsecMap {
 
     #[cfg(all(not(feature = "mock_parsec"), feature = "mock_base"))]
     pub fn unpolled_observations_string(&self) -> String {
-        String::new()
+        use itertools::Itertools;
+
+        let parsec = if let Some(parsec) = self.map.values().last() {
+            parsec
+        } else {
+            return String::new();
+        };
+
+        // This doesn't contain as much info as the `mock_parsec` version but it's better than
+        // nothing.
+        format!(
+            "our_unpolled_observations: {:?}",
+            parsec.our_unpolled_observations().format(", ")
+        )
     }
 
     pub fn needs_pruning(&self) -> bool {

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -112,6 +112,13 @@ pub trait Approved: Base {
         p2p_node: P2pNode,
         outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
+        trace!(
+            "{} - handle parsec request v{} from {}",
+            self,
+            msg_version,
+            p2p_node.public_id()
+        );
+
         let log_ident = self.log_ident();
         let (response, poll) = self.parsec_map_mut().handle_request(
             msg_version,
@@ -138,6 +145,13 @@ pub trait Approved: Base {
         pub_id: PublicId,
         outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
+        trace!(
+            "{} - handle parsec response v{} from {}",
+            self,
+            msg_version,
+            pub_id
+        );
+
         let log_ident = self.log_ident();
         if self
             .parsec_map_mut()
@@ -184,6 +198,12 @@ pub trait Approved: Base {
             .parsec_map_mut()
             .create_gossip(version, gossip_target.public_id())
         {
+            trace!(
+                "{} - send parsec request v{} to {}",
+                self,
+                version,
+                gossip_target.public_id(),
+            );
             self.send_direct_message(gossip_target.connection_info(), msg);
         }
     }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -77,6 +77,11 @@ fn drop_random_nodes<R: Rng>(
         let dropped = nodes.remove(i);
         assert!(dropped_nodes.insert(dropped.name()));
     }
+
+    if !dropped_nodes.is_empty() {
+        warn!("    dropping {:?}", dropped_nodes);
+    }
+
     dropped_nodes
 }
 
@@ -114,6 +119,13 @@ fn add_nodes<R: Rng>(
             }
             added_nodes.push(node);
         }
+    }
+
+    if !added_nodes.is_empty() {
+        warn!(
+            "    adding {{{}}}",
+            added_nodes.iter().map(|node| node.name()).format(", ")
+        );
     }
 
     for added_node in added_nodes {

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -24,7 +24,7 @@ use std::{
 
 // Maximum number of times to try and poll in a loop.  This is several orders higher than the
 // anticipated upper limit for any test, and if hit is likely to indicate an infinite loop.
-const MAX_POLL_CALLS: usize = 1000;
+const MAX_POLL_CALLS: usize = 2000;
 
 // ----- Typs -----
 type PrefixAndSize = (Prefix<XorName>, usize);


### PR DESCRIPTION
- The timeout was too low and didn't account for backlogging due to heavy churn.
- When a node is relocating, it will never be rejected from joining the target section, so we need no timeout in that case (currently not even newly joining node can be rejected, but that will change soon so the timeout remains for that case).
- This commit also adds more detailed logging in a couple of places to help debugging.