### PR TITLE
Elder promotion and demotion

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -404,13 +404,13 @@ impl Chain {
                 continue;
             }
 
-            if our_section_size >= safe_section_size {
-                if !member_info.increment_age_counter() {
-                    continue;
-                }
-            } else {
-                member_info.increment_age();
+            //if our_section_size >= safe_section_size {
+            if !member_info.increment_age_counter() {
+                continue;
             }
+            // } else {
+            //     member_info.increment_age();
+            // }
 
             let destination =
                 relocation::compute_destination(&our_prefix, name, trigger_node.name());

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1426,7 +1426,7 @@ impl Chain {
             }
             Authority::Section(ref target_name) => {
                 let (prefix, section) = self.closest_section_info(*target_name);
-                if prefix == self.our_prefix() {
+                if prefix == self.our_prefix() || prefix.is_neighbour(self.our_prefix()) {
                     // Exclude our name since we don't need to send to ourself
                     let our_name = self.our_id().name();
 
@@ -1442,11 +1442,14 @@ impl Chain {
                 candidates(target_name)?
             }
             Authority::PrefixSection(ref prefix) => {
-                if prefix.is_compatible(&self.our_prefix()) {
+                if prefix.is_compatible(self.our_prefix()) || prefix.is_neighbour(self.our_prefix())
+                {
                     // only route the message when we have all the targets in our routing table -
                     // this is to prevent spamming the network by sending messages with
                     // intentionally short prefixes
-                    if !prefix.is_covered_by(self.prefixes().iter()) {
+                    if prefix.is_compatible(self.our_prefix())
+                        && !prefix.is_covered_by(self.prefixes().iter())
+                    {
                         return Err(Error::CannotRoute);
                     }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -616,7 +616,7 @@ impl Chain {
                 first_bls_keys: self.our_section_bls_keys().clone(),
                 first_state_serialized: self.get_genesis_related_info()?,
                 first_ages: self.get_age_counters(),
-                latest_info: Default::default(),
+                latest_info: self.our_info().clone(),
                 parsec_version,
             },
             cached_events: remaining

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -326,6 +326,7 @@ impl Chain {
             | AccumulatingEvent::StartDkg(_)
             | AccumulatingEvent::User(_)
             | AccumulatingEvent::ParsecPrune
+            | AccumulatingEvent::RelocatePrepare(_, _)
             | AccumulatingEvent::SendAckMessage(_) => (),
         }
 
@@ -985,7 +986,8 @@ impl Chain {
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::AckMessage(_)
             | AccumulatingEvent::User(_)
-            | AccumulatingEvent::Relocate(_) => {
+            | AccumulatingEvent::Relocate(_)
+            | AccumulatingEvent::RelocatePrepare(_, _) => {
                 !self.state.split_in_progress && self.our_info().is_quorum(proofs)
             }
             AccumulatingEvent::StartDkg(_) => {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -769,6 +769,13 @@ impl Chain {
         self.state.our_info().member_nodes()
     }
 
+    fn elders_and_adults(&self) -> impl Iterator<Item = &PublicId> {
+        self.state
+            .our_joined_members()
+            .filter(|(_, info)| info.is_mature())
+            .map(|(_, info)| info.p2p_node.public_id())
+    }
+
     fn our_expected_elders(&self) -> BTreeMap<XorName, P2pNode> {
         let mut elders: BTreeMap<_, _> = self
             .state
@@ -798,6 +805,20 @@ impl Chain {
         );
 
         elders
+    }
+
+    fn eldest_members_matching_prefix(
+        &self,
+        prefix: &Prefix<XorName>,
+    ) -> BTreeMap<XorName, P2pNode> {
+        self.state
+            .our_joined_members()
+            .filter(|(name, _)| prefix.matches(name))
+            .sorted_by(|&(_, info1), &(_, info2)| Ord::cmp(&info2.age_counter, &info1.age_counter))
+            .into_iter()
+            .map(|(name, info)| (*name, info.p2p_node.clone()))
+            .take(self.elder_size())
+            .collect()
     }
 
     /// Returns all neighbour elders.
@@ -1172,9 +1193,8 @@ impl Chain {
         let our_name = self.our_id.name();
         let our_prefix_bit_count = self.our_prefix().bit_count();
         let (our_new_size, sibling_new_size) = self
-            .state
-            .our_joined_members()
-            .map(|(name, _)| our_name.common_prefix(name) > our_prefix_bit_count)
+            .elders_and_adults()
+            .map(|id| our_name.common_prefix(id.name()) > our_prefix_bit_count)
             .fold((0, 0), |(ours, siblings), is_our_prefix| {
                 if is_our_prefix {
                     (ours + 1, siblings)
@@ -1188,18 +1208,15 @@ impl Chain {
         Ok(our_new_size >= min_split_size && sibling_new_size >= min_split_size)
     }
 
-    /// Splits our section and generates new section infos for the child sections.
+    /// Splits our section and generates new elders infos for the child sections.
     fn split_self(&mut self) -> Result<(EldersInfo, EldersInfo), RoutingError> {
         let next_bit = self.our_id.name().bit(self.our_prefix().bit_count());
 
         let our_prefix = self.our_prefix().pushed(next_bit);
         let other_prefix = self.our_prefix().pushed(!next_bit);
 
-        let (our_new_section, other_section) = self
-            .state
-            .our_joined_members()
-            .map(|(key, value)| (*key, value.p2p_node.clone()))
-            .partition(|node| our_prefix.matches(&node.0));
+        let our_new_section = self.eldest_members_matching_prefix(&our_prefix);
+        let other_section = self.eldest_members_matching_prefix(&other_prefix);
 
         let our_new_info =
             EldersInfo::new(our_new_section, our_prefix, Some(self.state.our_info()))?;

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -292,7 +292,7 @@ impl Chain {
         match event {
             AccumulatingEvent::SectionInfo(ref info, ref key_info) => {
                 let change = EldersChangeBuilder::new(self);
-                if self.add_elders_info(info.clone(), key_info.clone(), proofs)? {
+                if self.add_elders_info(info.clone(), key_info.clone(), proofs.clone())? {
                     let change = change.build(self);
                     return Ok(Some(
                         AccumulatedEvent::new(event).with_elders_change(change),
@@ -712,6 +712,15 @@ impl Chain {
             .map(|member_info| &member_info.p2p_node)
     }
 
+    /// Returns the connection infos for all non-Elders in the section
+    pub fn adults_and_infants_conn_infos(&self) -> Vec<ConnectionInfo> {
+        self.state
+            .our_joined_members()
+            .filter(|(_, info)| !self.state.our_info().is_member(info.p2p_node.public_id()))
+            .map(|(_, info)| info.p2p_node.connection_info().clone())
+            .collect()
+    }
+
     pub fn get_our_info_p2p_node(&self, name: &XorName) -> Option<&P2pNode> {
         self.state.our_info().member_map().get(name)
     }
@@ -1046,7 +1055,7 @@ impl Chain {
 
     /// Handles our own section info, or the section info of our sibling directly after a split.
     /// Returns whether the event should be handled by the caller.
-    fn add_elders_info(
+    pub fn add_elders_info(
         &mut self,
         elders_info: EldersInfo,
         key_info: SectionKeyInfo,

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -781,7 +781,9 @@ impl Chain {
     fn elders_and_adults(&self) -> impl Iterator<Item = &PublicId> {
         self.state
             .our_joined_members()
-            .filter(|(_, info)| info.is_mature())
+            // FIXME: we temporarily treat all section
+            // members as Adults
+            //.filter(|(_, info)| info.is_mature())
             .map(|(_, info)| info.p2p_node.public_id())
     }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -291,23 +291,23 @@ impl Chain {
     ) -> Result<Option<AccumulatedEvent>, RoutingError> {
         match event {
             AccumulatingEvent::SectionInfo(ref info, ref key_info) => {
-                let change = NeighbourChangeBuilder::new(self);
+                let change = EldersChangeBuilder::new(self);
                 if self.add_elders_info(info.clone(), key_info.clone(), proofs)? {
                     let change = change.build(self);
                     return Ok(Some(
-                        AccumulatedEvent::new(event).with_neighbour_change(change),
+                        AccumulatedEvent::new(event).with_elders_change(change),
                     ));
                 } else {
                     return Ok(None);
                 }
             }
             AccumulatingEvent::NeighbourInfo(ref info) => {
-                let change = NeighbourChangeBuilder::new(self);
+                let change = EldersChangeBuilder::new(self);
                 self.add_neighbour_elders_info(info.clone())?;
                 let change = change.build(self);
 
                 return Ok(Some(
-                    AccumulatedEvent::new(event).with_neighbour_change(change),
+                    AccumulatedEvent::new(event).with_elders_change(change),
                 ));
             }
             AccumulatingEvent::TheirKeyInfo(ref key_info) => {
@@ -373,7 +373,10 @@ impl Chain {
 
     // Increment the age counters of the members.
     pub fn increment_age_counters(&mut self, trigger_node: &PublicId) {
-        if self.state.our_joined_members().count() >= self.safe_section_size()
+        let our_section_size = self.state.our_joined_members().count();
+        let safe_section_size = self.safe_section_size();
+
+        if our_section_size >= safe_section_size
             && self
                 .state
                 .get_persona(trigger_node)
@@ -401,8 +404,12 @@ impl Chain {
                 continue;
             }
 
-            if !member_info.increment_age_counter() {
-                continue;
+            if our_section_size >= safe_section_size {
+                if !member_info.increment_age_counter() {
+                    continue;
+                }
+            } else {
+                member_info.increment_age();
             }
 
             let destination =
@@ -563,15 +570,34 @@ impl Chain {
             return Ok(Some(vec![our_info, other_info]));
         }
 
-        let new_info = EldersInfo::new(
-            self.our_expected_elders(),
-            *self.state.our_info().prefix(),
-            Some(self.state.our_info()),
-        )?;
+        let expected_elders_map = self.our_expected_elders();
+        let expected_elders: BTreeSet<_> = expected_elders_map.values().cloned().collect();
+        let current_elders: BTreeSet<_> = self.state.our_info().member_nodes().cloned().collect();
 
-        self.members_changed = false;
-        self.churn_in_progress = true;
-        Ok(Some(vec![new_info]))
+        if expected_elders != current_elders {
+            let old_size = self.state.our_info().len();
+
+            let new_info = EldersInfo::new(
+                expected_elders_map,
+                *self.state.our_info().prefix(),
+                Some(self.state.our_info()),
+            )?;
+
+            if self.state.our_info().len() < self.elder_size() && old_size >= self.elder_size() {
+                panic!(
+                    "Merging situation encountered! Not supported: {:?}: {:?}",
+                    self.our_id(),
+                    self.state.our_info()
+                );
+            }
+
+            self.members_changed = false;
+            self.churn_in_progress = true;
+            Ok(Some(vec![new_info]))
+        } else {
+            self.members_changed = false;
+            Ok(None)
+        }
     }
 
     /// Gets the data needed to initialise a new Parsec instance
@@ -747,13 +773,16 @@ impl Chain {
         let mut elders: BTreeMap<_, _> = self
             .state
             .our_joined_members()
+            .sorted_by(|&(_, info1), &(_, info2)| Ord::cmp(&info2.age_counter, &info1.age_counter))
+            .into_iter()
             .map(|(name, info)| (*name, info.p2p_node.clone()))
+            .take(self.elder_size())
             .collect();
 
         // Ensure that we can still handle one node lost when relocating.
         // Currently re-promoting relocating adult to elder is not supported.
         // Ensure that the node we eject are the we want to relocate first.
-        let min_elders = self.elder_size() + 1;
+        let min_elders = self.elder_size();
         let num_elders = elders.len();
         let our_info_map = self.our_info().member_map();
         elders.extend(
@@ -1664,22 +1693,34 @@ impl SectionKeys {
     }
 }
 
-struct NeighbourChangeBuilder {
-    old: BTreeSet<P2pNode>,
+struct EldersChangeBuilder {
+    old_own: BTreeSet<P2pNode>,
+    old_neighbour: BTreeSet<P2pNode>,
 }
 
-impl NeighbourChangeBuilder {
+impl EldersChangeBuilder {
     fn new(chain: &Chain) -> Self {
         Self {
-            old: chain.neighbour_elder_nodes().cloned().collect(),
+            old_own: chain.our_info().member_nodes().cloned().collect(),
+            old_neighbour: chain.neighbour_elder_nodes().cloned().collect(),
         }
     }
 
     fn build(self, chain: &Chain) -> EldersChange {
-        let new: BTreeSet<_> = chain.neighbour_elder_nodes().cloned().collect();
+        let new_neighbour: BTreeSet<_> = chain.neighbour_elder_nodes().cloned().collect();
+        let new_own: BTreeSet<_> = chain.our_info().member_nodes().cloned().collect();
         EldersChange {
-            added: new.difference(&self.old).cloned().collect(),
-            removed: self.old.difference(&new).cloned().collect(),
+            neighbour_added: new_neighbour
+                .difference(&self.old_neighbour)
+                .cloned()
+                .collect(),
+            neighbour_removed: self
+                .old_neighbour
+                .difference(&new_neighbour)
+                .cloned()
+                .collect(),
+            own_added: new_own.difference(&self.old_own).cloned().collect(),
+            own_removed: self.old_own.difference(&new_own).cloned().collect(),
         }
     }
 }

--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -195,7 +195,7 @@ impl ChainAccumulator {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
 pub struct AccumulatingProof {
     parsec_proofs: ProofSet,
     sig_shares: BTreeMap<PublicId, EventSigPayload>,

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -85,7 +85,7 @@ impl MemberInfo {
     }
 
     pub fn is_mature(&self) -> bool {
-        self.age_counter > AgeCounter(2u32.pow(MAX_INFANT_AGE))
+        self.age_counter >= AgeCounter(2u32.pow(MAX_INFANT_AGE + 1))
     }
 
     #[cfg(feature = "mock_base")]

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -80,6 +80,7 @@ impl MemberInfo {
     }
 
     // Increment the age.
+    #[allow(unused)]
     pub fn increment_age(&mut self) {
         self.age_counter = AgeCounter::from_age(self.age().saturating_add(1));
     }

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -79,6 +79,11 @@ impl MemberInfo {
         self.age_counter.increment()
     }
 
+    // Increment the age.
+    pub fn increment_age(&mut self) {
+        self.age_counter = AgeCounter::from_age(self.age().saturating_add(1));
+    }
+
     pub fn is_mature(&self) -> bool {
         self.age_counter > AgeCounter(2u32.pow(MAX_INFANT_AGE))
     }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -122,6 +122,9 @@ pub enum AccumulatingEvent {
     // Voted for node to be relocated out of our section.
     Relocate(RelocateDetails),
 
+    // Voted to initiate the relocation if value <= 0, otherwise re-vote with value - 1.
+    RelocatePrepare(RelocateDetails, i32),
+
     // Opaque user-defined event.
     User(Vec<u8>),
 }
@@ -169,6 +172,9 @@ impl Debug for AccumulatingEvent {
             }
             AccumulatingEvent::ParsecPrune => write!(formatter, "ParsecPrune"),
             AccumulatingEvent::Relocate(payload) => write!(formatter, "Relocate({:?})", payload),
+            AccumulatingEvent::RelocatePrepare(payload, count_down) => {
+                write!(formatter, "RelocatePrepare({:?}, {})", payload, count_down)
+            }
             AccumulatingEvent::User(payload) => write!(formatter, "User({:<8})", HexFmt(payload)),
         }
     }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -214,7 +214,7 @@ impl Debug for NetworkEvent {
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
 pub struct AccumulatedEvent {
     pub content: AccumulatingEvent,
-    pub neighbour_change: EldersChange,
+    pub elders_change: EldersChange,
     pub signature: Option<BlsSignature>,
 }
 
@@ -222,7 +222,7 @@ impl AccumulatedEvent {
     pub fn new(content: AccumulatingEvent) -> Self {
         Self {
             content,
-            neighbour_change: EldersChange::default(),
+            elders_change: EldersChange::default(),
             signature: None,
         }
     }
@@ -231,9 +231,9 @@ impl AccumulatedEvent {
         Self { signature, ..self }
     }
 
-    pub fn with_neighbour_change(self, neighbour_change: EldersChange) -> Self {
+    pub fn with_elders_change(self, elders_change: EldersChange) -> Self {
         Self {
-            neighbour_change,
+            elders_change,
             ..self
         }
     }
@@ -249,7 +249,11 @@ impl Debug for AccumulatedEvent {
 #[derive(Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EldersChange {
     // Peers that became elders.
-    pub added: BTreeSet<P2pNode>,
+    pub neighbour_added: BTreeSet<P2pNode>,
     // Peers that ceased to be elders.
-    pub removed: BTreeSet<P2pNode>,
+    pub neighbour_removed: BTreeSet<P2pNode>,
+    // Peers that became elders.
+    pub own_added: BTreeSet<P2pNode>,
+    // Peers that ceased to be elders.
+    pub own_removed: BTreeSet<P2pNode>,
 }

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    chain::EldersInfo,
+    chain::{EldersInfo, GenesisPfxInfo},
     crypto::signing::Signature,
     error::{BootstrapResponseError, RoutingError},
     id::{FullId, PublicId},
@@ -53,6 +53,8 @@ pub enum DirectMessage {
     ParsecResponse(u64, parsec::Response),
     /// Send from a section to the node being relocated.
     Relocate(SignedRelocateDetails),
+    /// Update sent to Adults by Elders
+    GenesisUpdate(GenesisPfxInfo),
 }
 
 /// Response to a BootstrapRequest
@@ -100,6 +102,7 @@ impl Debug for DirectMessage {
             ParsecResponse(v, _) => write!(formatter, "ParsecResponse({}, _)", v),
             ParsecPoke(v) => write!(formatter, "ParsecPoke({})", v),
             Relocate(payload) => write!(formatter, "Relocate({:?})", payload.content()),
+            GenesisUpdate(gen_pfx_info) => write!(formatter, "GenesisUpdate({:?})", gen_pfx_info),
         }
     }
 }
@@ -131,6 +134,9 @@ impl Hash for DirectMessage {
                 version.hash(state);
                 // Fake hash via serialisation
                 serialise(&response).ok().hash(state)
+            }
+            GenesisUpdate(gen_pfx_info) => {
+                gen_pfx_info.hash(state);
             }
             Relocate(details) => details.hash(state),
         }

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -145,6 +145,11 @@ where
     }
 
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &S::PublicId> {
+        trace!(
+            "gossip_recipients: {:?} -- {:?}",
+            self.peer_list,
+            self.dkg_participants
+        );
         let iter = if self.peer_list.contains(self.our_id.public_id()) {
             Some(
                 self.peer_list

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -236,7 +236,7 @@ where
         }
 
         state::with::<T, S::PublicId, _, _>(self.section_hash, |state| {
-            state.dkg_participant(self.our_id.public_id())
+            state.contains_dkg_participant(self.our_id.public_id())
         })
     }
 

--- a/src/mock/parsec/state.rs
+++ b/src/mock/parsec/state.rs
@@ -113,7 +113,7 @@ impl<T: NetworkEvent, P: PublicId> SectionState<T, P> {
         self.key_gen.get_or_generate(rng, our_id, participants)
     }
 
-    pub fn dkg_participant(&self, our_id: &P) -> bool {
+    pub fn contains_dkg_participant(&self, our_id: &P) -> bool {
         self.key_gen.contains_participant(our_id)
     }
 }

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -394,6 +394,7 @@ fn packet_is_parsec_gossip() {
     };
 
     use maidsafe_utilities::serialisation;
+    use rand::Rng;
     use serde::Serialize;
 
     let mut rng = rng::new();
@@ -422,6 +423,7 @@ fn packet_is_parsec_gossip() {
     };
 
     let msgs = [
+        make_message(DirectMessage::ParsecPoke(23)),
         make_message(DirectMessage::ParsecRequest(42, req)),
         make_message(DirectMessage::ParsecResponse(1337, rsp)),
     ];
@@ -431,7 +433,7 @@ fn packet_is_parsec_gossip() {
 
     // No other direct message types contain a Parsec request or response.
     let msgs = [
-        make_message(DirectMessage::ParsecPoke(5)),
+        make_message(DirectMessage::BootstrapRequest(rng.gen())),
         make_message(DirectMessage::ConnectionResponse),
     ];
     for msg in &msgs {

--- a/src/node.rs
+++ b/src/node.rs
@@ -373,6 +373,14 @@ impl Node {
         self.elder_state().is_some()
     }
 
+    /// Returns whether the current state is `Elder` or `Adult`.
+    pub fn is_approved(&self) -> bool {
+        match self.machine.current() {
+            State::Elder(_) | State::Adult(_) => true,
+            _ => false,
+        }
+    }
+
     /// Our `Prefix` once we are a part of the section.
     pub fn our_prefix(&self) -> Option<&Prefix<XorName>> {
         self.chain().map(Chain::our_prefix)

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -120,6 +120,7 @@ impl ParsecMap {
         pub_id: id::PublicId,
         log_ident: &LogIdent,
     ) -> (Option<DirectMessage>, bool) {
+        trace!("{} handle_request from {:?}", log_ident, pub_id);
         // Increase the size before fetching the parsec to satisfy the borrow checker
         self.count_size(
             serialisation::serialised_size(&request),

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -746,7 +746,6 @@ impl Approved for Adult {
 
         info!("{} - handle Relocate: {:?}.", self, details);
         self.chain.remove_member(&details.pub_id);
-        self.disconnect_by_id_lookup(&details.pub_id);
 
         Ok(())
     }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -46,7 +46,8 @@ use std::{
     net::SocketAddr,
 };
 
-const POKE_TIMEOUT: Duration = Duration::from_secs(60);
+// Poke in a similar speed as GOSSIP_TIMEOUT
+const POKE_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub struct AdultDetails {
     pub network_service: NetworkService,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -259,6 +259,7 @@ impl Adult {
         );
 
         for recipient in recipients {
+            trace!("{} send poke to {:?}", self, recipient);
             self.send_direct_message(&recipient, DirectMessage::ParsecPoke(version));
         }
     }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -348,12 +348,7 @@ impl Adult {
             &self.gen_pfx_info,
             &LogIdent::new(self.full_id.public_id()),
         );
-        self.chain = Chain::new(
-            self.chain.network_cfg(),
-            *self.id(),
-            gen_pfx_info,
-            None,
-        );
+        self.chain = Chain::new(self.chain.network_cfg(), *self.id(), gen_pfx_info, None);
         Ok(Transition::Stay)
     }
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -34,6 +34,7 @@ use crate::{
     state_machine::{State, Transition},
     time::Duration,
     timer::Timer,
+    utils::LogIdent,
     xor_name::XorName,
     BlsSignature, ConnectionInfo, NetworkService,
 };
@@ -321,6 +322,31 @@ impl Adult {
         );
     }
 
+    fn handle_genesis_update(
+        &mut self,
+        gen_pfx_info: GenesisPfxInfo,
+    ) -> Result<Transition, RoutingError> {
+        // An Adult can receive the same message from multiple Elders - bail early if we are
+        // already up to date
+        if gen_pfx_info == self.gen_pfx_info {
+            return Ok(Transition::Stay);
+        }
+        self.gen_pfx_info = gen_pfx_info.clone();
+        self.parsec_map.init(
+            &mut self.rng,
+            self.full_id.clone(),
+            &self.gen_pfx_info,
+            &LogIdent::new(self.full_id.public_id()),
+        );
+        self.chain = Chain::new(
+            self.chain.network_cfg(),
+            *self.id(),
+            gen_pfx_info,
+            None,
+        );
+        Ok(Transition::Stay)
+    }
+
     // Send signed_msg to our elders so they can route it properly.
     fn send_signed_message_to_elders(
         &mut self,
@@ -534,6 +560,7 @@ impl Base for Adult {
                 debug!("{} - Received connection response from {}", self, p2p_node);
                 Ok(Transition::Stay)
             }
+            GenesisUpdate(gen_pfx_info) => self.handle_genesis_update(gen_pfx_info),
             Relocate(details) => Ok(self.handle_relocate(details)),
             msg @ BootstrapResponse(_) => {
                 debug!(

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -247,6 +247,7 @@ impl Adult {
             .gen_pfx_info
             .latest_info
             .member_nodes()
+            .filter(|node| node.public_id() != self.id())
             .map(P2pNode::connection_info)
             .cloned()
             .collect_vec();

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -251,6 +251,11 @@ impl Adult {
             .cloned()
             .collect_vec();
 
+        debug!(
+            "{} Sending Parsec Poke for version {} to {:?}",
+            self, version, recipients
+        );
+
         for recipient in recipients {
             self.send_direct_message(&recipient, DirectMessage::ParsecPoke(version));
         }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -352,6 +352,13 @@ impl Adult {
             &LogIdent::new(self.full_id.public_id()),
         );
         self.chain = Chain::new(self.chain.network_cfg(), *self.id(), gen_pfx_info, None);
+
+        // We were not promoted during the last section change, so we are not going to need these
+        // messages anymore. This also prevents the messages from becoming stale (fail the trust
+        // check) when they are eventually taken from the backlog and swarmed to other nodes.
+        self.routing_msg_backlog.clear();
+        self.direct_msg_backlog.clear();
+
         Ok(Transition::Stay)
     }
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -741,6 +741,15 @@ impl Approved for Adult {
         Ok(())
     }
 
+    fn handle_relocate_prepare_event(
+        &mut self,
+        _payload: RelocateDetails,
+        _count_down: i32,
+        _outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn handle_their_key_info_event(
         &mut self,
         _key_info: SectionKeyInfo,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -337,6 +337,8 @@ impl Adult {
         &mut self,
         gen_pfx_info: GenesisPfxInfo,
     ) -> Result<Transition, RoutingError> {
+        info!("{} - Received GenesisUpdate: {:?}", self, gen_pfx_info);
+
         // An Adult can receive the same message from multiple Elders - bail early if we are
         // already up to date
         if gen_pfx_info == self.gen_pfx_info {

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -341,7 +341,7 @@ impl Adult {
 
         // An Adult can receive the same message from multiple Elders - bail early if we are
         // already up to date
-        if gen_pfx_info == self.gen_pfx_info {
+        if gen_pfx_info.parsec_version <= self.gen_pfx_info.parsec_version {
             return Ok(Transition::Stay);
         }
         self.gen_pfx_info = gen_pfx_info.clone();

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -615,7 +615,7 @@ impl Approved for Adult {
     fn handle_online_event(
         &mut self,
         payload: OnlinePayload,
-        outbox: &mut dyn EventBox,
+        _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
         if !self.chain.can_add_member(payload.p2p_node.public_id()) {
             info!("{} - ignore Online: {:?}.", self, payload);
@@ -624,8 +624,10 @@ impl Approved for Adult {
 
             let pub_id = *payload.p2p_node.public_id();
             self.chain.add_member(payload.p2p_node, payload.age);
-            self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
             self.chain.increment_age_counters(&pub_id);
+
+            // FIXME: send appropriate events
+            // self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
         }
 
         Ok(())
@@ -634,7 +636,7 @@ impl Approved for Adult {
     fn handle_offline_event(
         &mut self,
         pub_id: PublicId,
-        outbox: &mut dyn EventBox,
+        _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
         if !self.chain.can_remove_member(&pub_id) {
             info!("{} - ignore Offline: {}.", self, pub_id);
@@ -643,8 +645,10 @@ impl Approved for Adult {
 
             self.chain.increment_age_counters(&pub_id);
             self.chain.remove_member(&pub_id);
-            self.send_event(Event::NodeLost(*pub_id.name()), outbox);
             self.disconnect_by_id_lookup(&pub_id);
+
+            // FIXME: send appropriate events
+            // self.send_event(Event::NodeLost(*pub_id.name()), outbox);
         }
 
         Ok(())
@@ -685,7 +689,7 @@ impl Approved for Adult {
         &mut self,
         details: RelocateDetails,
         _signature: BlsSignature,
-        outbox: &mut dyn EventBox,
+        _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
         if !self.chain.can_remove_member(&details.pub_id) {
             info!("{} - ignore Relocate: {:?} - not a member", self, details);
@@ -694,7 +698,6 @@ impl Approved for Adult {
 
         info!("{} - handle Relocate: {:?}.", self, details);
         self.chain.remove_member(&details.pub_id);
-        self.send_event(Event::NodeLost(*details.pub_id.name()), outbox);
         self.disconnect_by_id_lookup(&details.pub_id);
 
         Ok(())

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -368,10 +368,10 @@ pub trait Approved: Base {
                 self.handle_offline_event(pub_id, outbox)?;
             }
             AccumulatingEvent::SectionInfo(_, _) => {
-                return self.handle_section_info_event(old_pfx, event.neighbour_change, outbox);
+                return self.handle_section_info_event(old_pfx, event.elders_change, outbox);
             }
             AccumulatingEvent::NeighbourInfo(elders_info) => {
-                self.handle_neighbour_info_event(elders_info, event.neighbour_change)?;
+                self.handle_neighbour_info_event(elders_info, event.elders_change)?;
             }
             AccumulatingEvent::TheirKeyInfo(key_info) => {
                 self.handle_their_key_info_event(key_info)?

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -395,11 +395,12 @@ pub trait Approved: Base {
     // Checking members vote status and vote to remove those non-resposive nodes.
     fn check_voting_status(&mut self) {
         let unresponsive_nodes = self.chain_mut().check_vote_status();
-        let log_indent = self.log_ident();
+        let log_ident = self.log_ident();
         for pub_id in unresponsive_nodes.iter() {
+            info!("{} Voting for unresponsive node {:?}", log_ident, pub_id);
             self.parsec_map_mut().vote_for(
                 AccumulatingEvent::Offline(*pub_id).into_network_event(),
-                &log_indent,
+                &log_ident,
             );
         }
     }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -144,7 +144,12 @@ pub trait Approved: Base {
         );
 
         if let Some(response) = response {
-            trace!("{} seng gossip response to {:?}", self, p2p_node);
+            trace!(
+                "{} - send parsec response v{} to {:?}",
+                self,
+                msg_version,
+                p2p_node,
+            );
             self.send_direct_message(p2p_node.connection_info(), response);
         }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -136,6 +136,7 @@ pub trait Approved: Base {
         );
 
         if let Some(response) = response {
+            trace!("{} seng gossip response to {:?}", self, p2p_node);
             self.send_direct_message(p2p_node.connection_info(), response);
         }
 
@@ -178,6 +179,7 @@ pub trait Approved: Base {
                 let version = self.parsec_map().last_version();
                 let recipients = self.parsec_map().gossip_recipients();
                 if recipients.is_empty() {
+                    trace!("{} Not sending gossip", self);
                     // Parsec hasn't caught up with the event of us joining yet.
                     return;
                 }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -100,6 +100,14 @@ pub trait Approved: Base {
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError>;
 
+    /// Handles an accumulated `Offline` event.
+    fn handle_relocate_prepare_event(
+        &mut self,
+        payload: RelocateDetails,
+        count_down: i32,
+        outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError>;
+
     /// Handle an accumulated `User` event
     fn handle_user_event(
         &mut self,
@@ -387,6 +395,9 @@ pub trait Approved: Base {
             AccumulatingEvent::ParsecPrune => self.handle_prune()?,
             AccumulatingEvent::Relocate(payload) => {
                 self.invoke_handle_relocate_event(payload, event.signature, outbox)?
+            }
+            AccumulatingEvent::RelocatePrepare(pub_id, count) => {
+                self.handle_relocate_prepare_event(pub_id, count, outbox)?
             }
             AccumulatingEvent::User(payload) => self.handle_user_event(payload, outbox)?,
         }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -697,8 +697,10 @@ impl Elder {
         &mut self,
         signed_msg: SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
-        if self.in_authority(&signed_msg.routing_message().dst) {
-            self.check_signed_message_trust(&signed_msg)?;
+        if self.in_authority(&signed_msg.routing_message().dst)
+            && signed_msg.check_trust(&self.chain)
+        {
+            // If message still for us and we still trust it, then it must not be stale.
             self.check_signed_message_integrity(&signed_msg)?;
             self.update_our_knowledge(&signed_msg);
             self.routing_msg_queue.push_back(signed_msg);

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -609,6 +609,13 @@ impl Elder {
         });
     }
 
+    fn send_genesis_updates(&mut self) {
+        for conn_info in self.chain.adults_and_infants_conn_infos() {
+            let message = DirectMessage::GenesisUpdate(self.gen_pfx_info.clone());
+            self.send_direct_message(&conn_info, message);
+        }
+    }
+
     /// Handles a signature of a `SignedMessage`, and if we have enough to verify the signed
     /// message, handles it.
     fn handle_message_signature(
@@ -1404,6 +1411,9 @@ impl Base for Elder {
                 );
                 self.direct_msg_backlog.push((p2p_node, msg));
             }
+            GenesisUpdate(_) => {
+                debug!("{} Unhandled direct message: {:?}", self, msg);
+            }
         }
         Ok(Transition::Stay)
     }
@@ -1648,6 +1658,7 @@ impl Approved for Elder {
         info!("{} - handle parsec prune.", self);
         let complete_data = self.prepare_reset_parsec()?;
         self.reset_parsec_with_data(complete_data.gen_pfx_info, complete_data.to_vote_again)?;
+        self.send_genesis_updates();
         Ok(())
     }
 
@@ -1697,6 +1708,7 @@ impl Approved for Elder {
 
         self.update_peer_connections(elders_change);
         self.send_neighbour_infos();
+        self.send_genesis_updates();
 
         // Vote to update our self messages proof
         self.vote_send_section_info_ack(SendAckMessagePayload {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -697,6 +697,12 @@ impl Elder {
         &mut self,
         signed_msg: SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
+        trace!(
+            "{} - Handle backlogged signed message: {:?}",
+            self,
+            signed_msg.routing_message()
+        );
+
         if self.in_authority(&signed_msg.routing_message().dst)
             && signed_msg.check_trust(&self.chain)
         {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1293,9 +1293,6 @@ impl Base for Elder {
     fn finish_handle_transition(&mut self, outbox: &mut dyn EventBox) -> Transition {
         debug!("{} - State change to Elder finished.", self);
 
-        // Complete the polling that was interupted by the transition.
-        let _ = self.parsec_poll(outbox);
-
         let mut transition = Transition::Stay;
         for (pub_id, msg) in mem::replace(&mut self.direct_msg_backlog, Default::default()) {
             if let Transition::Stay = &transition {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1664,6 +1664,14 @@ impl Approved for Elder {
 
         info!("{} - handle SectionInfo: {:?}.", self, elders_info);
 
+        for pub_id in &elders_change.own_added {
+            self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
+        }
+
+        for pub_id in &elders_change.own_removed {
+            self.send_event(Event::NodeLost(*pub_id.name()), outbox);
+        }
+
         let complete_data = if info_prefix.is_extension_of(&old_pfx) {
             self.prepare_finalise_split()?
         } else if old_pfx.is_extension_of(&info_prefix) {
@@ -1686,14 +1694,6 @@ impl Approved for Elder {
 
         self.reset_parsec_with_data(complete_data.gen_pfx_info, complete_data.to_vote_again)?;
         self.process_post_reset_events(old_pfx, complete_data.to_process);
-
-        for pub_id in &elders_change.own_added {
-            self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-        }
-
-        for pub_id in &elders_change.own_removed {
-            self.send_event(Event::NodeLost(*pub_id.name()), outbox);
-        }
 
         self.update_peer_connections(elders_change);
         self.send_neighbour_infos();

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -435,6 +435,7 @@ fn construct() {
 }
 
 #[test]
+#[ignore]
 fn when_accumulate_online_then_node_is_added_to_our_members() {
     let mut elder_test = ElderUnderTest::new();
     let new_info = elder_test.new_elders_info_with_candidate();
@@ -447,6 +448,7 @@ fn when_accumulate_online_then_node_is_added_to_our_members() {
 }
 
 #[test]
+#[ignore]
 fn when_accumulate_online_and_accumulate_section_info_then_node_is_added_to_our_elders_info() {
     let mut elder_test = ElderUnderTest::new();
     let new_info = elder_test.new_elders_info_with_candidate();
@@ -462,6 +464,7 @@ fn when_accumulate_online_and_accumulate_section_info_then_node_is_added_to_our_
 }
 
 #[test]
+#[ignore]
 fn when_accumulate_offline_then_node_is_removed_from_our_members() {
     let mut elder_test = ElderUnderTest::new();
     let new_info = elder_test.new_elders_info_with_candidate();
@@ -481,6 +484,7 @@ fn when_accumulate_offline_then_node_is_removed_from_our_members() {
 }
 
 #[test]
+#[ignore]
 fn when_accumulate_offline_and_accumulate_section_info_then_node_is_removed_from_our_elders_info() {
     let mut elder_test = ElderUnderTest::new();
     let new_info = elder_test.new_elders_info_with_candidate();

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -27,10 +27,10 @@ use crate::{
 use std::{iter, net::SocketAddr};
 use unwrap::unwrap;
 
-// Accumulate even if 1 old node and an additional new node do not vote.
-const NO_SINGLE_VETO_VOTE_COUNT: usize = 7;
-const ACCUMULATE_VOTE_COUNT: usize = 6;
-const NOT_ACCUMULATE_ALONE_VOTE_COUNT: usize = 5;
+// Minimal number of votes to reach accumulation.
+const ACCUMULATE_VOTE_COUNT: usize = 5;
+// Only one vote missing to reach accumulation.
+const NOT_ACCUMULATE_ALONE_VOTE_COUNT: usize = 4;
 
 struct JoiningNodeInfo {
     full_id: FullId,
@@ -70,11 +70,7 @@ struct ElderUnderTest {
 }
 
 impl ElderUnderTest {
-    fn new() -> Self {
-        Self::with_section_size(NO_SINGLE_VETO_VOTE_COUNT)
-    }
-
-    fn with_section_size(sec_size: usize) -> Self {
+    fn new(sec_size: usize) -> Self {
         let mut rng = rng::new();
         let socket_addr: SocketAddr = unwrap!("127.0.0.1:9999".parse());
         let connection_info = ConnectionInfo::from(socket_addr);
@@ -282,6 +278,11 @@ impl ElderUnderTest {
     }
 
     fn new_elders_info_with_candidate(&mut self) -> DkgToSectionInfo {
+        assert!(
+            self.elders_info.len() < ELDER_SIZE,
+            "There is already ELDER_SIZE elders - the candidate won't be promoted"
+        );
+
         let new_elder_info = unwrap!(EldersInfo::new(
             self.elders_info
                 .member_nodes()
@@ -429,16 +430,15 @@ impl StateMachineExt for StateMachine {
 
 #[test]
 fn construct() {
-    let elder_test = ElderUnderTest::new();
+    let elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
 
     assert!(!elder_test.has_unpolled_observations());
     assert!(!elder_test.is_candidate_elder());
 }
 
 #[test]
-#[ignore]
 fn when_accumulate_online_then_node_is_added_to_our_members() {
-    let mut elder_test = ElderUnderTest::new();
+    let mut elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
     let new_info = elder_test.new_elders_info_with_candidate();
     elder_test.accumulate_online(elder_test.candidate.clone());
     elder_test.accumulate_start_dkg(&new_info);
@@ -449,9 +449,8 @@ fn when_accumulate_online_then_node_is_added_to_our_members() {
 }
 
 #[test]
-#[ignore]
-fn when_accumulate_online_and_accumulate_section_info_then_node_is_added_to_our_elders_info() {
-    let mut elder_test = ElderUnderTest::new();
+fn when_accumulate_online_and_start_dkg_and_section_info_then_node_is_added_to_our_elders() {
+    let mut elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
     let new_info = elder_test.new_elders_info_with_candidate();
     elder_test.accumulate_online(elder_test.candidate.clone());
     elder_test.accumulate_start_dkg(&new_info);
@@ -465,9 +464,8 @@ fn when_accumulate_online_and_accumulate_section_info_then_node_is_added_to_our_
 }
 
 #[test]
-#[ignore]
 fn when_accumulate_offline_then_node_is_removed_from_our_members() {
-    let mut elder_test = ElderUnderTest::new();
+    let mut elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
     let new_info = elder_test.new_elders_info_with_candidate();
     elder_test.accumulate_online(elder_test.candidate.clone());
     elder_test.accumulate_start_dkg(&new_info);
@@ -485,9 +483,8 @@ fn when_accumulate_offline_then_node_is_removed_from_our_members() {
 }
 
 #[test]
-#[ignore]
-fn when_accumulate_offline_and_accumulate_section_info_then_node_is_removed_from_our_elders_info() {
-    let mut elder_test = ElderUnderTest::new();
+fn when_accumulate_offline_and_start_dkg_and_section_info_then_node_is_removed_from_our_elders() {
+    let mut elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
     let new_info = elder_test.new_elders_info_with_candidate();
     elder_test.accumulate_online(elder_test.candidate.clone());
     elder_test.accumulate_start_dkg(&new_info);
@@ -510,7 +507,7 @@ fn when_accumulate_offline_and_accumulate_section_info_then_node_is_removed_from
 fn accept_previously_rejected_node_after_reaching_elder_size() {
     // Set section size to one less than the desired number of the elders in a section. This makes
     // us reject any bootstrapping nodes.
-    let mut elder_test = ElderUnderTest::with_section_size(ELDER_SIZE - 1);
+    let mut elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
     let node = JoiningNodeInfo::with_addr(&mut elder_test.rng, "198.51.100.0:5000");
 
     // Bootstrap fails for insufficient section size.

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -15,6 +15,7 @@
 
 use super::*;
 use crate::{
+    chain::SectionKeyInfo,
     generate_bls_threshold_secret_key,
     messages::DirectMessage,
     mock::Network,

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -31,6 +31,7 @@ use crate::{
     xor_name::XorName,
     NetworkService,
 };
+use log::LogLevel;
 use std::{
     fmt::{self, Display, Formatter},
     time::Duration,
@@ -267,9 +268,11 @@ impl Base for JoiningPeer {
                         self.elders_info = info;
                         self.send_join_requests();
                     } else {
-                        info!(
+                        log_or_panic!(
+                            LogLevel::Error,
                             "{} - Newer Join response not for our prefix {:?}",
-                            self, info
+                            self,
+                            info
                         );
                     }
                 }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -8,7 +8,7 @@
 
 use super::{
     count_sections, create_connected_nodes, create_connected_nodes_until_split, current_sections,
-    gen_range, gen_range_except, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
+    gen_elder_index, gen_range, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
 };
 use itertools::Itertools;
 use rand::Rng;
@@ -99,7 +99,7 @@ fn add_nodes<R: Rng>(
     let mut added_nodes = Vec::new();
     while !prefixes.is_empty() {
         let proxy_index = if nodes.len() > unwrap!(nodes[0].inner.elder_size()) {
-            gen_range(rng, 0, nodes.len())
+            gen_elder_index(rng, nodes)
         } else {
             0
         };
@@ -124,22 +124,16 @@ fn add_nodes<R: Rng>(
         );
     }
 
+    let mut min_index = 1;
+    let mut added_indices = BTreeSet::new();
     for added_node in added_nodes {
-        let index = gen_range(rng, 1, nodes.len() + 1);
+        let index = gen_range(rng, min_index, nodes.len() + 1);
         nodes.insert(index, added_node);
+        min_index = index + 1;
+        let _ = added_indices.insert(index);
     }
 
-    nodes
-        .iter()
-        .enumerate()
-        .filter_map(|(index, node)| {
-            if !node.inner.is_elder() {
-                Some(index)
-            } else {
-                None
-            }
-        })
-        .collect()
+    added_indices
 }
 
 /// Checks if the given indices have been accepted to the network.
@@ -265,7 +259,10 @@ impl Expectations {
         elder_size: usize,
     ) {
         let mut sent_count = 0;
-        for node in nodes.iter_mut().filter(|node| node.is_recipient(&src)) {
+        for node in nodes
+            .iter_mut()
+            .filter(|node| node.inner.is_elder() && node.is_recipient(&src))
+        {
             unwrap!(node.inner.send_message(src, dst, content.to_vec()));
             sent_count += 1;
         }
@@ -293,7 +290,7 @@ impl Expectations {
     /// Adds the expectation that the nodes belonging to `dst` receive the message.
     fn expect(&mut self, nodes: &mut [TestNode], dst: Authority<XorName>, key: MessageKey) {
         if dst.is_multiple() && !self.sections.contains_key(&dst) {
-            let is_recipient = |n: &&TestNode| n.is_recipient(&dst);
+            let is_recipient = |n: &&TestNode| n.inner.is_elder() && n.is_recipient(&dst);
             let section = nodes
                 .iter()
                 .filter(is_recipient)
@@ -313,7 +310,7 @@ impl Expectations {
             .sections
             .iter_mut()
             .map(|(dst, section)| {
-                let is_recipient = |n: &&TestNode| n.is_recipient(dst);
+                let is_recipient = |n: &&TestNode| n.inner.is_elder() && n.is_recipient(dst);
                 let old_section = section.clone();
                 let new_section: HashSet<_> = nodes
                     .iter()
@@ -402,8 +399,8 @@ impl Expectations {
 fn send_and_receive<R: Rng>(rng: &mut R, nodes: &mut [TestNode], elder_size: usize) {
     // Create random content and pick random sending and receiving nodes.
     let content: Vec<_> = rng.gen_iter().take(100).collect();
-    let index0 = gen_range(rng, 0, nodes.len());
-    let index1 = gen_range(rng, 0, nodes.len());
+    let index0 = gen_elder_index(rng, nodes);
+    let index1 = gen_elder_index(rng, nodes);
     let auth_n0 = Authority::Node(nodes[index0].name());
     let auth_n1 = Authority::Node(nodes[index1].name());
     let auth_g0 = Authority::Section(rng.gen());
@@ -550,8 +547,8 @@ fn messages_during_churn() {
 
         // Create random data and pick random sending and receiving nodes.
         let content: Vec<_> = rng.gen_iter().take(100).collect();
-        let index0 = gen_range_except(&mut rng, 0, nodes.len(), &new_indices);
-        let index1 = gen_range_except(&mut rng, 0, nodes.len(), &new_indices);
+        let index0 = gen_elder_index(&mut rng, &nodes);
+        let index1 = gen_elder_index(&mut rng, &nodes);
         let auth_n0 = Authority::Node(nodes[index0].name());
         let auth_n1 = Authority::Node(nodes[index1].name());
         let auth_g0 = Authority::Section(rng.gen());
@@ -609,7 +606,7 @@ fn messages_during_churn() {
 
 #[test]
 fn remove_unresponsive_node() {
-    let elder_size = 4;
+    let elder_size = 8;
     let safe_section_size = 8;
     let network = Network::new(NetworkParams {
         elder_size,
@@ -620,8 +617,12 @@ fn remove_unresponsive_node() {
     poll_and_resend(&mut nodes);
     // Pause a node to act as non-responsive.
     let mut rng = network.new_rng();
-    let non_responsive_index = rng.gen_range(1, nodes.len());
+    let non_responsive_index = gen_elder_index(&mut rng, &nodes);
     let non_responsive_name = nodes[non_responsive_index].name();
+    info!(
+        "{:?} chosen as non-responsive.",
+        nodes[non_responsive_index].name()
+    );
     let mut _non_responsive_node = None;
 
     // Sending some user events to create a sequence of observations.
@@ -657,7 +658,7 @@ fn remove_unresponsive_node() {
     }
 
     // Verify the other nodes saw the paused node and removed it.
-    for node in nodes.iter_mut() {
+    for node in nodes.iter_mut().filter(|n| n.inner.is_elder()) {
         expect_any_event!(node, Event::NodeLost(_));
     }
 }

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -351,14 +351,38 @@ fn simultaneous_joining_nodes(
 
     //
     // Assert
-    // Verify that the all nodes are now elders and other invariants.
+    // Verify that the sections all have enough elders and other invariants
     //
-    let non_elders = nodes
+    let non_approved = nodes
         .iter()
-        .filter(|node| !node.inner.is_elder())
+        .filter(|node| !node.inner.is_approved())
         .map(TestNode::name)
         .collect_vec();
-    assert!(non_elders.is_empty(), "Should be elders: {:?}", non_elders);
+    assert!(
+        non_approved.is_empty(),
+        "Should be approved: {:?}",
+        non_approved
+    );
+
+    let mut elders_count_by_prefix = BTreeMap::new();
+    for node in nodes.iter() {
+        if let Some(prefix) = node.inner.our_prefix() {
+            let entry = elders_count_by_prefix.entry(*prefix).or_insert(0);
+            if node.inner.is_elder() {
+                *entry += 1;
+            }
+        }
+    }
+    let prefixes_not_enough_elders = elders_count_by_prefix
+        .into_iter()
+        .filter(|(_, num_elders)| *num_elders < network.elder_size())
+        .map(|(prefix, _)| prefix)
+        .collect::<Vec<_>>();
+    assert!(
+        prefixes_not_enough_elders.is_empty(),
+        "Prefixes with too few elders: {:?}",
+        prefixes_not_enough_elders
+    );
     verify_invariant_for_all_nodes(&network, &mut nodes);
 }
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -848,7 +848,7 @@ pub fn verify_invariant_for_all_nodes(network: &Network, nodes: &mut [TestNode])
     verify_section_invariants_between_nodes(nodes);
 
     let mut all_missing_peers = BTreeSet::<PublicId>::new();
-    for node in nodes.iter_mut().filter(|node| node.inner.is_elder()) {
+    for node in nodes.iter_mut() {
         // Confirm elders from chain are connected according to PeerMap
         let our_id = unwrap!(node.inner.id());
         let missing_peers = node

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -253,7 +253,14 @@ impl PollOptions {
 
 /// Polls and processes all events, until there are no unacknowledged messages left.
 pub fn poll_and_resend_with_options(nodes: &mut [TestNode], mut options: PollOptions) {
-    let node_busy = |node: &TestNode| node.inner.has_unpolled_observations();
+    let node_busy = |node: &TestNode| {
+        if node.inner.has_unpolled_observations() {
+            trace!("{} busy!", node.inner);
+            true
+        } else {
+            false
+        }
+    };
     for _ in 0..MAX_POLL_CALLS {
         if poll_all(nodes) || nodes.iter().any(node_busy) {
             // Advance time for next route/gossip iter.

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -380,9 +380,10 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
 
         assert!(
             node_added_count >= n,
-            "{} - Got only {} NodeAdded events.",
+            "{} - Got only {} NodeAdded events, expected at least {}.",
             node.inner,
-            node_added_count
+            node_added_count,
+            n
         );
     }
 
@@ -939,14 +940,13 @@ fn add_node_to_section(network: &Network, nodes: &mut Vec<TestNode>, prefix: &Pr
     );
 
     // Poll until the new node transitions to the `Elder` state.
+    let elder_size = network.elder_size();
     poll_and_resend_with_options(
         nodes,
         PollOptions::default()
-            .continue_if(|nodes| {
-                !nodes
-                    .last()
-                    .map(|node| node.inner.is_elder())
-                    .unwrap_or(false)
+            .continue_if(move |nodes| {
+                nodes.len() >= elder_size
+                    && nodes.iter().filter(|node| node.inner.is_elder()).count() < elder_size
             })
             .fire_join_timeout(false),
     );


### PR DESCRIPTION
Taking over from https://github.com/maidsafe/routing/pull/1856
Implement part of https://github.com/maidsafe/routing/issues/1835

This implements the logic for promoting and demoting Elders as needed and updates the splitting logic correspondingly.