### PR TITLE
fix/routing: Remove unneeded ConnectionRequest handling

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -17,9 +17,8 @@ use crate::{
     error::{Result, RoutingError},
     id::{FullId, PublicId},
     routing_table::{Authority, Prefix},
-    types::MessageId,
     xor_name::XorName,
-    BlsPublicKeySet, BlsSignature, BlsSignatureShare, ConnectionInfo,
+    BlsPublicKeySet, BlsSignature, BlsSignatureShare,
 };
 use log::LogLevel;
 use maidsafe_utilities::serialisation::serialise;
@@ -505,15 +504,6 @@ impl RoutingMessage {
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
 pub enum MessageContent {
-    /// Send a request containing our connection info to a member of a section to connect to us.
-    ConnectionRequest {
-        /// The sender's public ID.
-        pub_id: PublicId,
-        /// Sender's connection info.
-        conn_info: ConnectionInfo,
-        /// The message's unique identifier.
-        msg_id: MessageId,
-    },
     /// Inform neighbours about our new section.
     NeighbourInfo(EldersInfo),
     /// User-facing message
@@ -555,11 +545,6 @@ impl Debug for MessageContent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         use self::MessageContent::*;
         match self {
-            ConnectionRequest { pub_id, msg_id, .. } => write!(
-                formatter,
-                "ConnectionRequest({:?}, {:?}, ..)",
-                pub_id, msg_id
-            ),
             NeighbourInfo(info) => write!(formatter, "NeighbourInfo({:?})", info),
             UserMessage(content) => write!(formatter, "UserMessage({:?})", content,),
             NodeApproval(gen_info) => write!(formatter, "NodeApproval({:?})", gen_info),
@@ -581,6 +566,7 @@ mod tests {
         rng,
         routing_table::{Authority, Prefix},
         xor_name::XorName,
+        ConnectionInfo,
     };
     use rand;
     use std::collections::BTreeMap;

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -191,45 +191,10 @@ impl Adult {
     fn dispatch_routing_message(
         &mut self,
         msg: SignedRoutingMessage,
-        outbox: &mut dyn EventBox,
+        _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        use crate::{messages::MessageContent::*, routing_table::Authority::*};
-
-        let (msg, metadata) = msg.into_parts();
-
-        match msg {
-            RoutingMessage {
-                content:
-                    ConnectionRequest {
-                        conn_info,
-                        pub_id,
-                        msg_id,
-                    },
-                src: Node(_),
-                dst: Node(_),
-            } => {
-                if self.our_prefix().matches(&msg.src.name()) {
-                    self.handle_connection_request(conn_info, pub_id, msg.src, msg.dst, outbox)
-                } else {
-                    self.add_message_to_backlog(SignedRoutingMessage::from_parts(
-                        RoutingMessage {
-                            content: ConnectionRequest {
-                                conn_info,
-                                pub_id,
-                                msg_id,
-                            },
-                            ..msg
-                        },
-                        metadata,
-                    ));
-                    Ok(())
-                }
-            }
-            _ => {
-                self.add_message_to_backlog(SignedRoutingMessage::from_parts(msg, metadata));
-                Ok(())
-            }
-        }
+        self.add_message_to_backlog(msg);
+        Ok(())
     }
 
     // Sends a `ParsecPoke` message to trigger a gossip request from current section members to us.

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -15,14 +15,13 @@ use crate::{
     error::RoutingError,
     event::Event,
     id::{P2pNode, PublicId},
-    messages::{DirectMessage, MessageContent, RoutingMessage},
     outbox::EventBox,
     parsec::{self, Block, DkgResultWrapper, Observation, ParsecMap},
     relocation::{RelocateDetails, SignedRelocateDetails},
-    routing_table::{Authority, Prefix},
+    routing_table::Prefix,
     state_machine::Transition,
     xor_name::XorName,
-    BlsSignature, ConnectionInfo,
+    BlsSignature,
 };
 use log::LogLevel;
 use rand::Rng;
@@ -364,76 +363,6 @@ pub trait Approved: Base {
                 &log_indent,
             );
         }
-    }
-
-    fn send_connection_request(
-        &mut self,
-        their_pub_id: PublicId,
-        src: Authority<XorName>,
-        dst: Authority<XorName>,
-        _: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        if their_pub_id == *self.id() {
-            trace!("{} - Not sending connection request to ourselves.", self);
-            return Ok(());
-        }
-
-        if let Some(p2p_node) = self.chain().get_p2p_node(their_pub_id.name()) {
-            if self.peer_map().has(p2p_node.peer_addr()) {
-                trace!(
-                    "{} - Not sending connection request to {} - already connected.",
-                    self,
-                    their_pub_id
-                );
-                return Ok(());
-            }
-        }
-
-        let msg_id = self.rng().gen();
-        let content = MessageContent::ConnectionRequest {
-            conn_info: self.our_connection_info()?,
-            pub_id: *self.full_id().public_id(),
-            msg_id,
-        };
-
-        trace!("{} - Sending connection request to {}.", self, their_pub_id);
-
-        self.send_routing_message(RoutingMessage { src, dst, content })
-            .map_err(|err| {
-                debug!(
-                    "{} - Failed to send connection request to {}: {:?}.",
-                    self, their_pub_id, err
-                );
-                err
-            })
-    }
-
-    fn handle_connection_request(
-        &mut self,
-        their_conn_info: ConnectionInfo,
-        their_pub_id: PublicId,
-        src: Authority<XorName>,
-        dst: Authority<XorName>,
-        _: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        if src.single_signing_name() != Some(their_pub_id.name()) {
-            // Connection request not from the source node.
-            return Err(RoutingError::InvalidSource);
-        }
-
-        if dst.single_signing_name() != Some(self.name()) {
-            // Connection request not for us.
-            return Err(RoutingError::InvalidDestination);
-        }
-
-        debug!(
-            "{} - Received connection request from {:?}.",
-            self, their_pub_id
-        );
-
-        self.send_direct_message(&their_conn_info, DirectMessage::ConnectionResponse);
-
-        Ok(())
     }
 
     fn disconnect_by_id_lookup(&mut self, pub_id: &PublicId) {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -571,16 +571,6 @@ impl Elder {
         }
 
         match (msg.content, msg.src, msg.dst) {
-            (
-                ConnectionRequest {
-                    conn_info, pub_id, ..
-                },
-                src @ Authority::Node(_),
-                dst @ Authority::Node(_),
-            ) => {
-                self.handle_connection_request(conn_info, pub_id, src, dst, outbox)?;
-                Ok(Transition::Stay)
-            }
             (NeighbourInfo(elders_info), Authority::Section(_), Authority::PrefixSection(_)) => {
                 self.handle_neighbour_info(elders_info)?;
                 Ok(Transition::Stay)
@@ -1220,21 +1210,6 @@ impl Base for Elder {
         let pub_id = *p2p_node.public_id();
         if self.chain.is_peer_our_member(&pub_id) {
             self.vote_for_event(AccumulatingEvent::Offline(pub_id));
-        }
-
-        if self.chain.is_peer_elder(&pub_id) {
-            debug!(
-                "{} - Sending connection request to {} due to lost peer.",
-                self, pub_id
-            );
-
-            let our_name = *self.name();
-            let _ = self.send_connection_request(
-                pub_id,
-                Authority::Node(our_name),
-                Authority::Node(*pub_id.name()),
-                outbox,
-            );
         }
 
         Transition::Stay

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -154,14 +154,6 @@ impl JoiningPeer {
                 src: Authority::PrefixSection(_),
                 dst: Authority::Node { .. },
             } => Ok(self.handle_node_approval(gen_info)),
-            RoutingMessage {
-                content: MessageContent::ConnectionRequest { conn_info, .. },
-                src: Authority::Node(_),
-                dst: Authority::Node(_),
-            } => {
-                self.send_direct_message(&conn_info, DirectMessage::ConnectionResponse);
-                Ok(Transition::Stay)
-            }
             _ => {
                 debug!(
                     "{} - Unhandled routing message, adding to backlog: {:?}",


### PR DESCRIPTION
ConnectionRequest is now mostly unused, only to try to re-establish
a connection with a lost elder. This is the remaining part of the work
to use responsiveness as an alternative to having a live connection.

However, this part of the code is no longer needed at this stage as
there is no need to try to find the connection information since we
already have them.

Test:
clippy + soak test