### PR TITLE
forward hop messages as an Adult

### DIFF
--- a/src/pause.rs
+++ b/src/pause.rs
@@ -35,6 +35,6 @@ pub struct PausedState {
     // TODO: instead of storing both network_service and network_rx, store only the network config.
     pub(super) network_service: NetworkService,
     pub(super) network_rx: Option<mpmc::Receiver<NetworkEvent>>,
-    pub(super) parsec_map: ParsecMap,
     pub(super) sig_accumulator: SignatureAccumulator,
+    pub(super) parsec_map: ParsecMap,
 }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -29,6 +29,7 @@ use crate::{
     rng::MainRng,
     routing_message_filter::RoutingMessageFilter,
     routing_table::{Authority, Prefix},
+    signature_accumulator::SignatureAccumulator,
     state_machine::{State, Transition},
     time::Duration,
     timer::Timer,
@@ -52,6 +53,7 @@ pub struct AdultDetails {
     pub gen_pfx_info: GenesisPfxInfo,
     pub routing_msg_backlog: Vec<SignedRoutingMessage>,
     pub direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
+    pub sig_accumulator: SignatureAccumulator,
     pub routing_msg_filter: RoutingMessageFilter,
     pub timer: Timer,
     pub network_cfg: NetworkParams,
@@ -68,6 +70,7 @@ pub struct Adult {
     /// Routing messages addressed to us that we cannot handle until we are established.
     routing_msg_backlog: Vec<SignedRoutingMessage>,
     direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
+    sig_accumulator: SignatureAccumulator,
     parsec_map: ParsecMap,
     parsec_timer_token: u64,
     routing_msg_filter: RoutingMessageFilter,
@@ -106,6 +109,7 @@ impl Adult {
             gen_pfx_info: details.gen_pfx_info,
             routing_msg_backlog: details.routing_msg_backlog,
             direct_msg_backlog: details.direct_msg_backlog,
+            sig_accumulator: details.sig_accumulator,
             parsec_map,
             routing_msg_filter: details.routing_msg_filter,
             timer: details.timer,
@@ -173,6 +177,7 @@ impl Adult {
             msg_queue: Default::default(),
             routing_msg_backlog: self.routing_msg_backlog,
             direct_msg_backlog: self.direct_msg_backlog,
+            sig_accumulator: self.sig_accumulator,
             parsec_map: self.parsec_map,
             // we reset the message filter so that the node can correctly process some messages as
             // an Elder even if it has already seen them as an Adult

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -380,6 +380,7 @@ fn new_elder_state(
         msg_queue: Default::default(),
         routing_msg_backlog: Default::default(),
         direct_msg_backlog: Default::default(),
+        sig_accumulator: Default::default(),
         parsec_map,
         routing_msg_filter: RoutingMessageFilter::new(),
         timer,

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -102,6 +102,7 @@ impl JoiningPeer {
             routing_msg_backlog: self.routing_msg_backlog,
             direct_msg_backlog: self.direct_msg_backlog,
             routing_msg_filter: self.routing_msg_filter,
+            sig_accumulator: Default::default(),
             timer: self.timer,
             rng: self.rng,
             network_cfg: self.network_cfg,


### PR DESCRIPTION
Adults will be long lived with node ageing:
 - Pass Hop messages to our Elders as we may have been demoted.
 - Process signature accumulation and pass messages to our elders as we may have been demoted.

Note:
We are still keeping messages in our backlog so we can process them our_selves, we may have to vote for something as an elder. We will likely have to clean this up further to avoid stale messages being processed and fail signature check.