### PR TITLE
Fix relocation overrides

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1483,6 +1483,14 @@ impl Chain {
             .min_by_key(|prefix| prefix.bit_count())
             .unwrap_or(&self.our_prefix())
     }
+
+    /// Returns the age counter of the given member or `None` if not a member.
+    pub fn member_age_counter(&self, name: &XorName) -> Option<u32> {
+        self.state
+            .our_members
+            .get(name)
+            .map(|member| member.age_counter_value())
+    }
 }
 
 #[cfg(test)]

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -9,9 +9,9 @@
 use super::{
     chain_accumulator::{AccumulatingProof, ChainAccumulator, InsertError},
     shared_state::{SectionKeyInfo, SectionProofBlock, SharedState, SplitCache},
-    AccumulatedEvent, AccumulatingEvent, AgeCounter, DevParams, EldersChange, EldersInfo,
-    GenesisPfxInfo, MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof,
-    ProofSet, SectionProofChain,
+    AccumulatedEvent, AccumulatingEvent, AgeCounter, EldersChange, EldersInfo, GenesisPfxInfo,
+    MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof, ProofSet,
+    SectionProofChain,
 };
 use crate::{
     error::RoutingError,
@@ -49,8 +49,6 @@ pub fn delivery_group_size(n: usize) -> usize {
 pub struct Chain {
     /// Network parameters
     network_cfg: NetworkParams,
-    /// Development/testing configuration.
-    dev_params: DevParams,
     /// This node's public ID.
     our_id: PublicId,
     /// Our current Section BLS keys.
@@ -119,7 +117,6 @@ impl Chain {
     /// Create a new chain given genesis information
     pub fn new(
         network_cfg: NetworkParams,
-        dev_params: DevParams,
         our_id: PublicId,
         gen_info: GenesisPfxInfo,
         secret_key_share: Option<BlsSecretKeyShare>,
@@ -130,7 +127,6 @@ impl Chain {
             .and_then(|key| SectionKeyShare::new(key, &our_id, &gen_info.first_info));
         Self {
             network_cfg,
-            dev_params,
             our_id,
             our_section_bls_keys: SectionKeys {
                 public_key_set: gen_info.first_bls_keys.clone(),
@@ -358,7 +354,7 @@ impl Chain {
             }
 
             let destination =
-                compute_relocation_destination(name, trigger_node.name(), &mut self.dev_params);
+                relocation::compute_destination(&our_prefix, name, trigger_node.name());
             if our_prefix.matches(&destination) {
                 // Relocation destination inside the current section - ignoring.
                 continue;
@@ -540,13 +536,6 @@ impl Chain {
         &mut self,
         parsec_version: u64,
     ) -> Result<ParsecResetData, RoutingError> {
-        // Clear any relocation overrides
-        #[cfg(feature = "mock_base")]
-        {
-            self.dev_params.next_relocation_dst = None;
-            self.dev_params.next_relocation_interval = None;
-        }
-
         // TODO: Bring back using their_knowledge to clean_older section in our_infos
         self.check_and_clean_neighbour_infos(None);
         self.state.split_in_progress = false;
@@ -1397,14 +1386,6 @@ impl Chain {
             );
         }
     }
-
-    pub fn dev_params(&self) -> &DevParams {
-        &self.dev_params
-    }
-
-    pub fn dev_params_mut(&mut self) -> &mut DevParams {
-        &mut self.dev_params
-    }
 }
 
 /// The outcome of a prefix change.
@@ -1522,27 +1503,6 @@ fn key_matching_first_elder_name(
     name_to_key
         .remove(first_name)
         .ok_or(RoutingError::InvalidElderDkgResult)
-}
-
-#[cfg(not(feature = "mock_base"))]
-fn compute_relocation_destination(
-    relocated_name: &XorName,
-    trigger_name: &XorName,
-    _dev_params: &mut DevParams,
-) -> XorName {
-    relocation::compute_destination(relocated_name, trigger_name)
-}
-
-#[cfg(feature = "mock_base")]
-fn compute_relocation_destination(
-    relocated_name: &XorName,
-    trigger_name: &XorName,
-    dev_params: &mut DevParams,
-) -> XorName {
-    dev_params
-        .next_relocation_dst
-        .take()
-        .unwrap_or_else(|| relocation::compute_destination(relocated_name, trigger_name))
 }
 
 /// The secret share of the section key.
@@ -1730,7 +1690,6 @@ mod tests {
         };
 
         let mut chain = Chain::new(
-            Default::default(),
             Default::default(),
             *our_id.public_id(),
             genesis_info,

--- a/src/chain/config.rs
+++ b/src/chain/config.rs
@@ -8,9 +8,6 @@
 
 use crate::{ELDER_SIZE, SAFE_SECTION_SIZE};
 
-#[cfg(feature = "mock_base")]
-use crate::{utils::XorTargetInterval, xor_name::XorName};
-
 /// Network parameters: number of elders, safe section size
 #[derive(Clone, Copy, Debug)]
 pub struct NetworkParams {
@@ -28,19 +25,3 @@ impl Default for NetworkParams {
         }
     }
 }
-
-/// Development-only node data (used mainly for the mock-network tests).
-#[cfg(feature = "mock_base")]
-#[derive(Default, Clone)]
-pub struct DevParams {
-    // Value which can be set in mock-network tests to be used as the next relocation
-    // destination.
-    pub next_relocation_dst: Option<XorName>,
-    // Interval used for relocation in mock network tests.
-    // Note: this is currently unused.
-    pub next_relocation_interval: Option<XorTargetInterval>,
-}
-
-#[cfg(not(feature = "mock_base"))]
-#[derive(Default, Clone)]
-pub struct DevParams;

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -82,6 +82,11 @@ impl MemberInfo {
     pub fn is_mature(&self) -> bool {
         self.age_counter > AgeCounter(2u32.pow(MAX_INFANT_AGE))
     }
+
+    #[cfg(feature = "mock_base")]
+    pub fn age_counter_value(&self) -> u32 {
+        self.age_counter.0
+    }
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -23,7 +23,7 @@ pub use self::chain_accumulator::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW};
 pub use self::{
     chain::{delivery_group_size, Chain, ParsecResetData, SectionKeyShare},
     chain_accumulator::AccumulatingProof,
-    config::{DevParams, NetworkParams},
+    config::NetworkParams,
     elders_info::EldersInfo,
     member_info::{AgeCounter, MemberInfo, MemberPersona, MemberState, MIN_AGE, MIN_AGE_COUNTER},
     network_event::{

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -241,12 +241,6 @@ impl SharedState {
         self.our_infos.iter().find(|info| info.hash() == hash)
     }
 
-    /// Returns our member infos.
-    #[allow(unused)]
-    pub fn our_members(&self) -> &BTreeMap<XorName, MemberInfo> {
-        &self.our_members
-    }
-
     /// Returns an iterator over the members that have state == `Joined`.
     pub fn our_joined_members(&self) -> impl Iterator<Item = (&XorName, &MemberInfo)> {
         self.our_members

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub use crate::{
     },
     messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
     parsec::generate_bls_threshold_secret_key,
+    relocation::Overrides as RelocationOverrides,
 };
 pub use crate::{
     error::{InterfaceError, RoutingError},

--- a/src/node.rs
+++ b/src/node.rs
@@ -27,7 +27,7 @@ use std::{net::SocketAddr, sync::mpsc};
 
 #[cfg(feature = "mock_base")]
 use {
-    crate::{chain::SectionProofChain, utils::XorTargetInterval, Chain, Prefix},
+    crate::{chain::SectionProofChain, Chain, Prefix},
     std::{
         collections::{BTreeMap, BTreeSet},
         fmt::{self, Display, Formatter},
@@ -133,7 +133,6 @@ impl NodeBuilder {
                         network_cfg,
                         timer,
                         rng,
-                        dev_params: Default::default(),
                     }))
                 }
             },
@@ -458,27 +457,6 @@ impl Node {
     /// Only if we have a chain (meaning we are elders) we will process this API
     pub fn min_split_size(&self) -> Option<usize> {
         self.chain().map(|chain| chain.min_split_size())
-    }
-
-    /// Sets a name to be used when the next node relocation request is received by this node.
-    pub fn set_next_relocation_dst(&mut self, dst: Option<XorName>) {
-        self.machine
-            .current_mut()
-            .dev_params_mut()
-            .next_relocation_dst = dst;
-    }
-
-    /// Gets the next relocation distance that was previosly set with `set_next_relocation_dst`.
-    pub fn next_relocation_dst(&self) -> Option<XorName> {
-        self.machine.current().dev_params().next_relocation_dst
-    }
-
-    /// Sets an interval to be used when a node is required to generate a new name.
-    pub fn set_next_relocation_interval(&mut self, interval: Option<XorTargetInterval>) {
-        self.machine
-            .current_mut()
-            .dev_params_mut()
-            .next_relocation_interval = interval;
     }
 
     /// Indicates if there are any pending observations in the parsec object

--- a/src/node.rs
+++ b/src/node.rs
@@ -484,6 +484,13 @@ impl Node {
     pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
         self.machine.current().in_authority(auth)
     }
+
+    /// Returns the age counter of the given node if it is member of the same section as this node,
+    /// `None` otherwise.
+    pub fn member_age_counter(&self, name: &XorName) -> Option<u32> {
+        self.chain()
+            .and_then(|chain| chain.member_age_counter(name))
+    }
 }
 
 #[cfg(feature = "mock_base")]

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -225,7 +225,11 @@ mod overrides {
     }
 
     struct OverrideInfo {
+        // Name that will be used as the next relocation destination.
         next: XorName,
+        // Map of original relocation destinations to the overridden ones. As this map is shared
+        // among all nodes in the network, this assures that every node will pick the same
+        // destination name for a given relocated node no matter when the calculation is performed.
         used: HashMap<XorName, XorName>,
     }
 

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -13,11 +13,15 @@ use crate::{
     crypto::{self, signing::Signature},
     error::RoutingError,
     id::{FullId, PublicId},
+    routing_table::Prefix,
     xor_name::{XorName, XOR_NAME_LEN},
     BlsSignature,
 };
 use maidsafe_utilities::serialisation::serialise;
 use std::fmt;
+
+#[cfg(feature = "mock_base")]
+pub use self::overrides::Overrides;
 
 /// Details of a relocation: which node to relocate, where to relocate it to and what age it should
 /// get once relocated.
@@ -122,10 +126,127 @@ impl RelocatePayload {
     }
 }
 
-pub fn compute_destination(relocated_name: &XorName, trigger_name: &XorName) -> XorName {
+#[cfg(not(feature = "mock_base"))]
+pub fn compute_destination(
+    _src_prefix: &Prefix<XorName>,
+    relocated_name: &XorName,
+    trigger_name: &XorName,
+) -> XorName {
+    compute_destination_without_override(relocated_name, trigger_name)
+}
+
+#[cfg(feature = "mock_base")]
+pub fn compute_destination(
+    src_prefix: &Prefix<XorName>,
+    relocated_name: &XorName,
+    trigger_name: &XorName,
+) -> XorName {
+    self::overrides::get(
+        src_prefix,
+        compute_destination_without_override(relocated_name, trigger_name),
+    )
+}
+
+fn compute_destination_without_override(
+    relocated_name: &XorName,
+    trigger_name: &XorName,
+) -> XorName {
     let mut buffer = [0; 2 * XOR_NAME_LEN];
     buffer[..XOR_NAME_LEN].copy_from_slice(&relocated_name.0);
     buffer[XOR_NAME_LEN..].copy_from_slice(&trigger_name.0);
 
     XorName(crypto::sha3_256(&buffer))
+}
+
+#[cfg(feature = "mock_base")]
+mod overrides {
+    use crate::{Prefix, XorName};
+    use std::{
+        cell::{Cell, RefCell},
+        collections::HashMap,
+    };
+
+    /// Mechanism for overriding relocation destinations. Useful for tests.
+    pub struct Overrides;
+
+    impl Overrides {
+        /// Create new instance of relocation overrides. There can be only one per thread.
+        /// The overrides are automatically `clear`ed when this instance goes out of scope.
+        pub fn new() -> Self {
+            GUARD.with(|guard| {
+                if guard.get() {
+                    panic!("There can be only one instance of RelocationOverrides per thread.");
+                } else {
+                    guard.set(true)
+                }
+            });
+
+            Self
+        }
+
+        /// Override relocation destination for the given source prefix - that is, any node to be
+        /// relocated from that prefix will be relocated to the given destination.
+        /// The override applies only to the exact prefix, not to its parents / children.
+        pub fn set(&self, src_prefix: Prefix<XorName>, dst: XorName) {
+            OVERRIDES.with(|map| {
+                let _ = map
+                    .borrow_mut()
+                    .entry(src_prefix)
+                    .and_modify(|info| info.next = dst)
+                    .or_insert_with(|| OverrideInfo {
+                        next: dst,
+                        used: HashMap::new(),
+                    });
+            })
+        }
+
+        /// Suppress relocations from the given source prefix.
+        pub fn suppress(&self, src_prefix: Prefix<XorName>) {
+            self.set(src_prefix, src_prefix.name())
+        }
+
+        /// Clear all relocation overrides.
+        pub fn clear(&self) {
+            OVERRIDES.with(|map| map.borrow_mut().clear());
+        }
+    }
+
+    impl Default for Overrides {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl Drop for Overrides {
+        fn drop(&mut self) {
+            self.clear();
+            GUARD.with(|guard| guard.set(false));
+        }
+    }
+
+    struct OverrideInfo {
+        next: XorName,
+        used: HashMap<XorName, XorName>,
+    }
+
+    impl OverrideInfo {
+        fn get(&mut self, original_dst: XorName) -> XorName {
+            *self.used.entry(original_dst).or_insert(self.next)
+        }
+    }
+
+    pub(super) fn get(src_prefix: &Prefix<XorName>, original_dst: XorName) -> XorName {
+        OVERRIDES.with(|map| {
+            if let Some(info) = map.borrow_mut().get_mut(src_prefix) {
+                info.get(original_dst)
+            } else {
+                original_dst
+            }
+        })
+    }
+
+    thread_local! {
+        static GUARD: Cell<bool> = Cell::new(false);
+        static OVERRIDES: RefCell<HashMap<Prefix<XorName>, OverrideInfo>> = RefCell::new(HashMap::new());
+    }
 }

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -23,7 +23,7 @@ use crate::{
     ConnectionInfo, NetworkConfig, NetworkEvent, NetworkService,
 };
 #[cfg(feature = "mock_base")]
-use crate::{chain::DevParams, rng::MainRng, routing_table::Authority, Chain};
+use crate::{rng::MainRng, routing_table::Authority, Chain};
 use crossbeam_channel as mpmc;
 #[cfg(feature = "mock_base")]
 use std::net::SocketAddr;
@@ -222,22 +222,6 @@ impl Debug for State {
 
 #[cfg(feature = "mock_base")]
 impl State {
-    pub fn dev_params(&self) -> &DevParams {
-        state_dispatch!(
-            *self,
-            ref state => state.dev_params(),
-            Terminated => unreachable!()
-        )
-    }
-
-    pub fn dev_params_mut(&mut self) -> &mut DevParams {
-        state_dispatch!(
-            *self,
-            ref mut state => state.dev_params_mut(),
-            Terminated => unreachable!()
-        )
-    }
-
     pub fn chain(&self) -> Option<&Chain> {
         match *self {
             State::Adult(ref state) => Some(state.chain()),

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     chain::{
-        Chain, DevParams, EldersChange, EldersInfo, GenesisPfxInfo, NetworkParams, OnlinePayload,
+        Chain, EldersChange, EldersInfo, GenesisPfxInfo, NetworkParams, OnlinePayload,
         SectionKeyInfo, SendAckMessagePayload,
     },
     error::RoutingError,
@@ -57,7 +57,6 @@ pub struct AdultDetails {
     pub routing_msg_filter: RoutingMessageFilter,
     pub timer: Timer,
     pub network_cfg: NetworkParams,
-    pub dev_params: DevParams,
     pub rng: MainRng,
 }
 
@@ -95,7 +94,6 @@ impl Adult {
 
         let chain = Chain::new(
             details.network_cfg,
-            details.dev_params,
             public_id,
             details.gen_pfx_info.clone(),
             None,
@@ -139,7 +137,6 @@ impl Adult {
                 network_cfg,
                 timer: self.timer,
                 rng: self.rng,
-                dev_params: self.chain.dev_params().clone(),
             },
         )))
     }
@@ -156,7 +153,6 @@ impl Adult {
                 network_cfg: self.chain.network_cfg(),
                 timer: self.timer,
                 rng: self.rng,
-                dev_params: self.chain.dev_params().clone(),
             },
             conn_infos,
             details,
@@ -531,14 +527,6 @@ impl Base for Adult {
         let mut signed_msg = SignedRoutingMessage::single_source(routing_msg, self.full_id())?;
         self.send_signed_message_to_elders(&mut signed_msg)?;
         Ok(())
-    }
-
-    fn dev_params(&self) -> &DevParams {
-        self.chain.dev_params()
-    }
-
-    fn dev_params_mut(&mut self) -> &mut DevParams {
-        self.chain.dev_params_mut()
     }
 }
 

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -8,7 +8,7 @@
 
 use super::{common::Base, joining_peer::JoiningPeerDetails};
 use crate::{
-    chain::{DevParams, NetworkParams},
+    chain::NetworkParams,
     error::{InterfaceError, RoutingError},
     event::Event,
     id::{FullId, P2pNode},
@@ -41,7 +41,6 @@ pub struct BootstrappingPeerDetails {
     pub network_cfg: NetworkParams,
     pub timer: Timer,
     pub rng: MainRng,
-    pub dev_params: DevParams,
 }
 
 // State of Client or Node while bootstrapping.
@@ -54,7 +53,6 @@ pub struct BootstrappingPeer {
     rng: MainRng,
     relocate_details: Option<SignedRelocateDetails>,
     network_cfg: NetworkParams,
-    dev_params: DevParams,
 }
 
 impl BootstrappingPeer {
@@ -69,7 +67,6 @@ impl BootstrappingPeer {
             rng: details.rng,
             relocate_details: None,
             network_cfg: details.network_cfg,
-            dev_params: details.dev_params,
         }
     }
 
@@ -88,7 +85,6 @@ impl BootstrappingPeer {
             rng: details.rng,
             relocate_details: Some(relocate_details),
             network_cfg: details.network_cfg,
-            dev_params: details.dev_params,
         };
 
         for conn_info in conn_infos {
@@ -112,7 +108,6 @@ impl BootstrappingPeer {
             rng: self.rng,
             p2p_nodes,
             relocate_payload,
-            dev_params: self.dev_params,
         };
 
         Ok(State::JoiningPeer(JoiningPeer::new(details)))
@@ -335,14 +330,6 @@ impl Base for BootstrappingPeer {
         );
         Ok(())
     }
-
-    fn dev_params(&self) -> &DevParams {
-        &self.dev_params
-    }
-
-    fn dev_params_mut(&mut self) -> &mut DevParams {
-        &mut self.dev_params
-    }
 }
 
 impl Display for BootstrappingPeer {
@@ -405,7 +392,6 @@ mod tests {
                     network_cfg,
                     timer,
                     rng,
-                    dev_params: Default::default(),
                 }))
             },
             config,

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -8,7 +8,6 @@
 
 use crate::{
     action::Action,
-    chain::DevParams,
     error::{InterfaceError, RoutingError},
     id::{FullId, P2pNode, PublicId},
     messages::{
@@ -41,8 +40,6 @@ pub trait Base: Display {
     fn timer(&mut self) -> &mut Timer;
     fn send_routing_message(&mut self, routing_msg: RoutingMessage) -> Result<(), RoutingError>;
     fn rng(&mut self) -> &mut MainRng;
-    fn dev_params(&self) -> &DevParams;
-    fn dev_params_mut(&mut self) -> &mut DevParams;
 
     fn log_ident(&self) -> LogIdent {
         LogIdent::new(self)

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -16,10 +16,10 @@ use super::{
 };
 use crate::{
     chain::{
-        delivery_group_size, AccumulatingEvent, AckMessagePayload, Chain, DevParams, EldersChange,
-        EldersInfo, EventSigPayload, GenesisPfxInfo, IntoAccumulatingEvent, NetworkEvent,
-        NetworkParams, OnlinePayload, ParsecResetData, SectionKeyInfo, SendAckMessagePayload,
-        MIN_AGE, MIN_AGE_COUNTER,
+        delivery_group_size, AccumulatingEvent, AckMessagePayload, Chain, EldersChange, EldersInfo,
+        EventSigPayload, GenesisPfxInfo, IntoAccumulatingEvent, NetworkEvent, NetworkParams,
+        OnlinePayload, ParsecResetData, SectionKeyInfo, SendAckMessagePayload, MIN_AGE,
+        MIN_AGE_COUNTER,
     },
     error::{BootstrapResponseError, InterfaceError, RoutingError},
     event::Event,
@@ -127,7 +127,6 @@ impl Elder {
         let parsec_map = ParsecMap::default().with_init(&mut rng, full_id.clone(), &gen_pfx_info);
         let chain = Chain::new(
             network_cfg,
-            DevParams::default(),
             public_id,
             gen_pfx_info.clone(),
             first_dkg_result.secret_key_share,
@@ -187,7 +186,6 @@ impl Elder {
             timer: self.timer,
             network_cfg: self.chain.network_cfg(),
             rng: self.rng,
-            dev_params: self.chain.dev_params().clone(),
         };
         Adult::new(details, self.parsec_map, outbox).map(State::Adult)
     }
@@ -1089,14 +1087,6 @@ impl Base for Elder {
         conn_peers.sort_unstable();
         conn_peers.dedup();
         self.chain.closest_names(&name, count, &conn_peers)
-    }
-
-    fn dev_params(&self) -> &DevParams {
-        self.chain.dev_params()
-    }
-
-    fn dev_params_mut(&mut self) -> &mut DevParams {
-        self.chain.dev_params_mut()
     }
 
     fn peer_map(&self) -> &PeerMap {

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -365,7 +365,6 @@ fn new_elder_state(
     let parsec_map = ParsecMap::default().with_init(rng, full_id.clone(), gen_pfx_info);
     let chain = Chain::new(
         Default::default(),
-        Default::default(),
         public_id,
         gen_pfx_info.clone(),
         Some(secret_key_share.clone()),

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -12,7 +12,7 @@ use super::{
     common::Base,
 };
 use crate::{
-    chain::{DevParams, GenesisPfxInfo, NetworkParams},
+    chain::{GenesisPfxInfo, NetworkParams},
     error::{InterfaceError, RoutingError},
     id::{FullId, P2pNode},
     messages::{DirectMessage, HopMessage, MessageContent, RoutingMessage, SignedRoutingMessage},
@@ -43,7 +43,6 @@ pub struct JoiningPeerDetails {
     pub rng: MainRng,
     pub p2p_nodes: Vec<P2pNode>,
     pub relocate_payload: Option<RelocatePayload>,
-    pub dev_params: DevParams,
 }
 
 // State of a node after bootstrapping, while joining a section
@@ -58,7 +57,6 @@ pub struct JoiningPeer {
     p2p_nodes: Vec<P2pNode>,
     join_type: JoinType,
     network_cfg: NetworkParams,
-    dev_params: DevParams,
 }
 
 impl JoiningPeer {
@@ -82,7 +80,6 @@ impl JoiningPeer {
             p2p_nodes: details.p2p_nodes,
             join_type,
             network_cfg: details.network_cfg,
-            dev_params: details.dev_params,
         };
 
         joining_peer.send_join_requests();
@@ -106,7 +103,6 @@ impl JoiningPeer {
             timer: self.timer,
             rng: self.rng,
             network_cfg: self.network_cfg,
-            dev_params: self.dev_params,
         };
         Adult::new(details, Default::default(), outbox).map(State::Adult)
     }
@@ -121,7 +117,6 @@ impl JoiningPeer {
                 network_cfg: self.network_cfg,
                 timer: self.timer,
                 rng: self.rng,
-                dev_params: self.dev_params,
             },
         )))
     }
@@ -297,14 +292,6 @@ impl Base for JoiningPeer {
             self, routing_msg
         );
         Ok(())
-    }
-
-    fn dev_params(&self) -> &DevParams {
-        &self.dev_params
-    }
-
-    fn dev_params_mut(&mut self) -> &mut DevParams {
-        &mut self.dev_params
     }
 }
 

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -7,9 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    clear_relocation_overrides, count_sections, create_connected_nodes,
-    create_connected_nodes_until_split, current_sections, gen_range, gen_range_except,
-    poll_and_resend, verify_invariant_for_all_nodes, TestNode,
+    count_sections, create_connected_nodes, create_connected_nodes_until_split, current_sections,
+    gen_range, gen_range_except, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
 };
 use itertools::Itertools;
 use rand::Rng;
@@ -574,7 +573,6 @@ fn messages_during_churn() {
                 .map(|idx| nodes[idx].name())
                 .collect::<Vec<_>>()
         );
-        clear_relocation_overrides(&mut nodes);
         shuffle_nodes(&mut rng, &mut nodes);
 
         if !added_names.is_empty() {

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -7,13 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    add_connected_nodes_until_one_away_from_split, create_connected_nodes_until_split_with_options,
-    current_sections, nodes_with_prefix, nodes_with_prefix_mut, poll_and_resend_with_options,
-    ChurnOptions, PollOptions, TestNode, LOWERED_ELDER_SIZE,
+    add_connected_nodes_until_one_away_from_split, create_connected_nodes_until_split,
+    current_sections, nodes_with_prefix, poll_and_resend, poll_and_resend_with_options,
+    PollOptions, TestNode, LOWERED_ELDER_SIZE,
 };
 use rand::{Rand, Rng};
 use routing::{
-    mock::Network, FullId, NetworkConfig, NetworkParams, Prefix, PublicId, XorName, MIN_AGE,
+    mock::Network, FullId, NetworkConfig, NetworkParams, Prefix, PublicId, RelocationOverrides,
+    XorName, MIN_AGE,
 };
 use std::{iter, slice};
 
@@ -27,14 +28,10 @@ const NETWORK_PARAMS: NetworkParams = NetworkParams {
 #[test]
 fn relocate_without_split() {
     let network = Network::new(NETWORK_PARAMS);
+    let overrides = RelocationOverrides::new();
+
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes_until_split_with_options(
-        &network,
-        vec![1, 1],
-        ChurnOptions {
-            suppress_relocation: true,
-        },
-    );
+    let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
 
     let prefixes: Vec<_> = current_sections(&nodes).collect();
 
@@ -44,9 +41,7 @@ fn relocate_without_split() {
     let target_prefix = *choose_other_prefix(&mut rng, &prefixes, &source_prefix);
 
     let destination = target_prefix.substituted_in(rng.gen());
-    for node in nodes_with_prefix_mut(&mut nodes, &source_prefix) {
-        node.inner.set_next_relocation_dst(Some(destination));
-    }
+    overrides.set(source_prefix, destination);
 
     // Create enough churn events so that the age of the oldest node increases which causes it to
     // be relocated.
@@ -63,45 +58,37 @@ fn relocate_without_split() {
         NETWORK_PARAMS.elder_size + 2,
     );
 
-    poll_and_resend_with_options(
-        &mut nodes,
-        PollOptions::default()
-            .continue_if(move |nodes| !node_relocated(nodes, 0, &source_prefix, &target_prefix))
-            .fire_join_timeout(false),
-    )
+    poll_and_resend(&mut nodes);
+
+    // Verify the node got relocated.
+    assert!(target_prefix.matches(&nodes[0].name()));
 }
 
 #[test]
 fn relocate_causing_split() {
     // Relocate node into a section which is one node shy of splitting.
     let network = Network::new(NETWORK_PARAMS);
+    let overrides = RelocationOverrides::new();
+
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes_until_split_with_options(
-        &network,
-        vec![1, 1],
-        ChurnOptions {
-            suppress_relocation: true,
-        },
-    );
+    let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
+
     let oldest_age_counter = oldest_age_counter_after_only_adds(&nodes);
 
     let prefixes: Vec<_> = current_sections(&nodes).collect();
     let source_prefix = *find_matching_prefix(&prefixes, &nodes[0].name());
     let target_prefix = *choose_other_prefix(&mut rng, &prefixes, &source_prefix);
 
-    let _ = add_connected_nodes_until_one_away_from_split(
+    overrides.suppress(target_prefix);
+
+    let trigger_prefixes = add_connected_nodes_until_one_away_from_split(
         &network,
         &mut nodes,
         slice::from_ref(&target_prefix),
-        ChurnOptions {
-            suppress_relocation: true,
-        },
     );
 
-    let destination = target_prefix.substituted_in(rng.gen());
-    for node in nodes_with_prefix_mut(&mut nodes, &source_prefix) {
-        node.inner.set_next_relocation_dst(Some(destination));
-    }
+    let destination = trigger_prefixes[0].substituted_in(rng.gen());
+    overrides.set(source_prefix, destination);
 
     // Trigger relocation.
     let num_churns = oldest_age_counter.next_power_of_two() - oldest_age_counter;
@@ -114,12 +101,22 @@ fn relocate_causing_split() {
         NETWORK_PARAMS.elder_size + 2,
     );
 
-    poll_and_resend_with_options(
-        &mut nodes,
-        PollOptions::default()
-            .continue_if(move |nodes| !node_relocated(nodes, 0, &source_prefix, &target_prefix))
-            .fire_join_timeout(false),
-    )
+    poll_and_resend(&mut nodes);
+
+    // Verify the node got relocated.
+    assert!(target_prefix.matches(&nodes[0].name()));
+
+    // Verify the destination section split.
+    // TODO: the target section doesn't always split so this sometimes fails. Fix it.
+    for node in nodes_with_prefix(&nodes, &target_prefix) {
+        assert!(
+            node.our_prefix().is_extension_of(&target_prefix),
+            "{}: {:?} is not extension of {:?}",
+            node.name(),
+            node.our_prefix(),
+            target_prefix,
+        );
+    }
 }
 
 // This test is ignored because it currently fails in the following case:
@@ -134,14 +131,10 @@ fn relocate_causing_split() {
 fn relocate_during_split() {
     // Relocate node into a section which is undergoing split.
     let network = Network::new(NETWORK_PARAMS);
+    let overrides = RelocationOverrides::new();
+
     let mut rng = network.new_rng();
-    let mut nodes = create_connected_nodes_until_split_with_options(
-        &network,
-        vec![1, 1],
-        ChurnOptions {
-            suppress_relocation: true,
-        },
-    );
+    let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
     let oldest_age_counter = oldest_age_counter_after_only_adds(&nodes);
 
     let prefixes: Vec<_> = current_sections(&nodes).collect();
@@ -152,15 +145,10 @@ fn relocate_during_split() {
         &network,
         &mut nodes,
         slice::from_ref(&target_prefix),
-        ChurnOptions {
-            suppress_relocation: true,
-        },
     );
 
     let destination = target_prefix.substituted_in(rng.gen());
-    for node in nodes_with_prefix_mut(&mut nodes, &source_prefix) {
-        node.inner.set_next_relocation_dst(Some(destination));
-    }
+    overrides.set(source_prefix, destination);
 
     // Create churn so we are one churn away from relocation.
     let num_churns = oldest_age_counter.next_power_of_two() - oldest_age_counter - 1;
@@ -256,9 +244,6 @@ fn section_churn(
     assert!(min_section_size < max_section_size);
 
     let mut rng = network.new_rng();
-    let next_relocation_dst = unwrap!(nodes_with_prefix(nodes, prefix).next())
-        .inner
-        .next_relocation_dst();
 
     for _ in 0..count {
         let section_size = nodes_with_prefix(nodes, prefix).count();
@@ -273,10 +258,6 @@ fn section_churn(
         match churn {
             Churn::Add => {
                 add_node_to_prefix(network, nodes, prefix);
-                unwrap!(nodes.last_mut())
-                    .inner
-                    .set_next_relocation_dst(next_relocation_dst);
-
                 poll_and_resend_with_options(
                     nodes,
                     PollOptions::default()

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -340,14 +340,6 @@ pub fn remove_nodes_which_failed_to_connect(nodes: &mut Vec<TestNode>, count: us
     failed_to_join.len()
 }
 
-/// Options that control adding and removing nodes to the mock network.
-#[derive(Default, Copy, Clone)]
-pub struct ChurnOptions {
-    /// Suppress any relocations that would be caused by adding/removing a node by setting the next
-    /// relocation destination of the existing nodes to lie within their current sections.
-    pub suppress_relocation: bool,
-}
-
 pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
     let mut nodes = Vec::new();
 
@@ -397,24 +389,12 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
 }
 
 pub fn create_connected_nodes_until_split(network: &Network, prefix_lengths: Vec<usize>) -> Nodes {
-    create_connected_nodes_until_split_with_options(
-        network,
-        prefix_lengths,
-        ChurnOptions::default(),
-    )
-}
-
-pub fn create_connected_nodes_until_split_with_options(
-    network: &Network,
-    prefix_lengths: Vec<usize>,
-    options: ChurnOptions,
-) -> Nodes {
     // Start first node.
     let mut nodes = vec![TestNode::builder(network).first().create()];
     let _ = nodes[0].poll();
     expect_next_event!(nodes[0], Event::Connected);
 
-    add_connected_nodes_until_split(network, &mut nodes, prefix_lengths, options);
+    add_connected_nodes_until_split(network, &mut nodes, prefix_lengths);
     Nodes(nodes)
 }
 
@@ -432,7 +412,6 @@ pub fn add_connected_nodes_until_split(
     network: &Network,
     nodes: &mut Vec<TestNode>,
     mut prefix_lengths: Vec<usize>,
-    options: ChurnOptions,
 ) {
     // Get sorted list of prefixes to suit requested lengths.
     sanity_check(&prefix_lengths);
@@ -449,7 +428,7 @@ pub fn add_connected_nodes_until_split(
         .iter()
         .map(|prefix| (*prefix, min_split_size))
         .collect_vec();
-    add_nodes_to_prefixes(network, nodes, &prefixes_new_count, options);
+    add_nodes_to_prefixes(network, nodes, &prefixes_new_count);
 
     // If recursive splits are added to Routing (https://maidsafe.atlassian.net/browse/MAID-1861)
     // this next step can be removed.
@@ -482,7 +461,7 @@ pub fn add_connected_nodes_until_split(
             }
         }
         if let Some(prefix_to_split) = found_prefix {
-            add_node_to_section(network, nodes, &prefix_to_split, options);
+            add_node_to_section(network, nodes, &prefix_to_split);
         } else {
             break;
         }
@@ -510,7 +489,6 @@ pub fn add_connected_nodes_until_split(
         | Event::SectionSplit(..) => (),
         event => panic!("Got unexpected event: {:?}", event),
     });
-    clear_relocation_overrides(nodes);
 
     trace!("Created testnet comprising {:?}", prefixes);
 }
@@ -521,12 +499,11 @@ pub fn add_connected_nodes_until_one_away_from_split(
     network: &Network,
     nodes: &mut Vec<TestNode>,
     prefixes_to_nearly_split: &[Prefix<XorName>],
-    options: ChurnOptions,
 ) -> Vec<Prefix<XorName>> {
     let (prefixes_and_counts, prefixes_to_add_to_split) =
         prefixes_and_count_to_split_with_only_one_extra_node(nodes, prefixes_to_nearly_split);
 
-    add_connected_nodes_until_sized(network, nodes, &prefixes_and_counts, options);
+    add_connected_nodes_until_sized(network, nodes, &prefixes_and_counts);
     prefixes_to_add_to_split
 }
 
@@ -535,14 +512,10 @@ fn add_connected_nodes_until_sized(
     network: &Network,
     nodes: &mut Vec<TestNode>,
     prefixes_new_count: &[PrefixAndSize],
-    options: ChurnOptions,
 ) {
     clear_all_event_queues(nodes, |_| {});
-
-    add_nodes_to_prefixes(network, nodes, prefixes_new_count, options);
-
+    add_nodes_to_prefixes(network, nodes, prefixes_new_count);
     clear_all_event_queues(nodes, |_| {});
-    clear_relocation_overrides(nodes);
 
     trace!(
         "Filled prefixes until ready to split {:?}",
@@ -555,7 +528,6 @@ fn add_nodes_to_prefixes(
     network: &Network,
     nodes: &mut Vec<TestNode>,
     prefixes_new_count: &[PrefixAndSize],
-    options: ChurnOptions,
 ) {
     for (prefix, target_count) in prefixes_new_count {
         let num_in_section = nodes
@@ -574,7 +546,7 @@ fn add_nodes_to_prefixes(
         );
         let to_add_count = target_count - num_in_section;
         for _ in 0..to_add_count {
-            add_node_to_section(network, nodes, prefix, options);
+            add_node_to_section(network, nodes, prefix);
         }
     }
 }
@@ -585,14 +557,6 @@ fn clear_all_event_queues(nodes: &mut Vec<TestNode>, check_event: impl Fn(Event)
         while let Ok(event) = node.try_next_ev() {
             check_event(event)
         }
-    }
-}
-
-// Clear all `next_relocation_dst` / `next_relocation_interval` values.
-pub fn clear_relocation_overrides(nodes: &mut Vec<TestNode>) {
-    for node in nodes.iter_mut() {
-        node.inner.set_next_relocation_dst(None);
-        node.inner.set_next_relocation_interval(None);
     }
 }
 
@@ -949,12 +913,7 @@ fn prefixes<T: Rng>(prefix_lengths: &[usize], rng: &mut T) -> Vec<Prefix<XorName
     prefixes
 }
 
-fn add_node_to_section(
-    network: &Network,
-    nodes: &mut Vec<TestNode>,
-    prefix: &Prefix<XorName>,
-    options: ChurnOptions,
-) {
+fn add_node_to_section(network: &Network, nodes: &mut Vec<TestNode>, prefix: &Prefix<XorName>) {
     let mut rng = network.new_rng();
     let config = NetworkConfig::node().with_hard_coded_contact(nodes[0].endpoint());
     let full_id = FullId::within_range(&mut rng, &prefix.range_inclusive());
@@ -964,14 +923,6 @@ fn add_node_to_section(
             .full_id(full_id)
             .create(),
     );
-
-    if options.suppress_relocation {
-        // Send all relocations to the same section, effectively disabling them.
-        let dst = prefix.name();
-        for node in nodes_with_prefix_mut(nodes, prefix) {
-            node.inner.set_next_relocation_dst(Some(dst));
-        }
-    }
 
     // Poll until the new node transitions to the `Elder` state.
     poll_and_resend_with_options(


### PR DESCRIPTION
This PR fixes a bug in the relocation override implementation which could cause a failure in the following scenario:

1. A relocation override is set for nodes in a section
2. A node which is not elder gets relocated from that section, using (and consuming) the relocation override
3. Because that node was not an elder, it does not cause new `SectionInfo` to be voted
4. Another node joins the section and is immediately promoted to elder
5. As it is catching up to the parsec history, it encounters the event that caused the above relocation
6. It processes the relocation, but as it joined later, the relocation overrides are not set on it, so it uses different relocation destination
7. And thus the new node gets out of sync with the rest of the section

The fix is to maintain a map of `original_relocation_destination` to `overriden_relocation_destination` so nodes will always use the same overridden destination no matter when the run the calculation.

Also, this PR refactors the relocation overrides by moving all the logic into a separate `RelocationOverrides` type (backed by a thread-local storage), thus avoiding polluting the production code with test-only code.