### PR TITLE
Improve `Connected` event handling (backports from 1929)

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -57,6 +57,15 @@ pub enum ClientEvent {
     },
 }
 
+/// An Event raised as node complete joining
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ConnectEvent {
+    /// Node first joining the network
+    First,
+    /// Node relocating from one section to another
+    Relocate,
+}
+
 /// An Event raised by a `Node` or `Client` via its event sender.
 ///
 /// These are sent by routing to the library's user. It allows the user to handle requests and
@@ -86,7 +95,7 @@ pub enum Event {
     /// Our own section has been split, resulting in the included `Prefix` for our new section.
     SectionSplit(Prefix<XorName>),
     /// The client has successfully connected to a proxy node on the network.
-    Connected,
+    Connected(ConnectEvent),
     /// Disconnected or failed to connect - restart required.
     RestartRequired,
     /// Startup failed - terminate.
@@ -128,7 +137,9 @@ impl Debug for Event {
             Event::SectionSplit(ref prefix) => {
                 write!(formatter, "Event::SectionSplit({:?})", prefix)
             }
-            Event::Connected => write!(formatter, "Event::Connected"),
+            Event::Connected(ref connect_type) => {
+                write!(formatter, "Event::Connected({:?})", connect_type)
+            }
             Event::RestartRequired => write!(formatter, "Event::RestartRequired"),
             Event::Terminated => write!(formatter, "Event::Terminated"),
             Event::TimerTicked => write!(formatter, "Event::TimerTicked"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub use crate::{
 };
 pub use crate::{
     error::{InterfaceError, RoutingError},
-    event::{ClientEvent, Event},
+    event::{ClientEvent, ConnectEvent, Event},
     event_stream::EventStream,
     id::{FullId, P2pNode, PublicId},
     node::{Node, NodeBuilder},

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -82,7 +82,7 @@ impl Adult {
     pub fn new(
         mut details: AdultDetails,
         parsec_map: ParsecMap,
-        outbox: &mut dyn EventBox,
+        _outbox: &mut dyn EventBox,
     ) -> Result<Self, RoutingError> {
         let public_id = *details.full_id.public_id();
         let parsec_timer_token = details.timer.schedule(POKE_TIMEOUT);
@@ -99,8 +99,6 @@ impl Adult {
             details.gen_pfx_info.clone(),
             None,
         );
-
-        outbox.send_event(Event::Connected);
 
         let node = Self {
             chain,

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -82,7 +82,7 @@ impl Adult {
     pub fn new(
         mut details: AdultDetails,
         parsec_map: ParsecMap,
-        _outbox: &mut dyn EventBox,
+        outbox: &mut dyn EventBox,
     ) -> Result<Self, RoutingError> {
         let public_id = *details.full_id.public_id();
         let parsec_timer_token = details.timer.schedule(POKE_TIMEOUT);
@@ -99,6 +99,8 @@ impl Adult {
             details.gen_pfx_info.clone(),
             None,
         );
+
+        outbox.send_event(Event::Connected);
 
         let node = Self {
             chain,

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         MIN_AGE_COUNTER,
     },
     error::{BootstrapResponseError, InterfaceError, RoutingError},
-    event::Event,
+    event::{ConnectEvent, Event},
     id::{FullId, P2pNode, PublicId},
     messages::{
         BootstrapResponse, DirectMessage, HopMessage, MessageContent, RoutingMessage,
@@ -153,7 +153,7 @@ impl Elder {
         debug!("{} - State changed to Node.", node);
         info!("{} - Started a new network as a seed node.", node);
 
-        outbox.send_event(Event::Connected);
+        outbox.send_event(Event::Connected(ConnectEvent::First));
 
         Ok(node)
     }

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -300,8 +300,7 @@ impl Elder {
             self.chain.prefixes()
         );
 
-        // Send `Event::Connected` first and then any backlogged events from previous states.
-        for event in iter::once(Event::Connected).chain(event_backlog) {
+        for event in event_backlog {
             self.send_event(event, outbox);
         }
 

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::{
     chain::{GenesisPfxInfo, NetworkParams},
     error::{InterfaceError, RoutingError},
-    event::Event,
+    event::{ConnectEvent, Event},
     id::{FullId, P2pNode},
     messages::{DirectMessage, HopMessage, MessageContent, RoutingMessage, SignedRoutingMessage},
     outbox::EventBox,
@@ -106,7 +106,12 @@ impl JoiningPeer {
             network_cfg: self.network_cfg,
         };
         let adult = Adult::new(details, Default::default(), outbox).map(State::Adult);
-        outbox.send_event(Event::Connected);
+
+        let connect_type = match self.join_type {
+            JoinType::First { .. } => ConnectEvent::First,
+            JoinType::Relocate(_) => ConnectEvent::Relocate,
+        };
+        outbox.send_event(Event::Connected(connect_type));
         adult
     }
 

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::{
     chain::{GenesisPfxInfo, NetworkParams},
     error::{InterfaceError, RoutingError},
+    event::Event,
     id::{FullId, P2pNode},
     messages::{DirectMessage, HopMessage, MessageContent, RoutingMessage, SignedRoutingMessage},
     outbox::EventBox,
@@ -104,7 +105,9 @@ impl JoiningPeer {
             rng: self.rng,
             network_cfg: self.network_cfg,
         };
-        Adult::new(details, Default::default(), outbox).map(State::Adult)
+        let adult = Adult::new(details, Default::default(), outbox).map(State::Adult);
+        outbox.send_event(Event::Connected);
+        adult
     }
 
     pub fn rebootstrap(mut self) -> Result<State, RoutingError> {

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -164,7 +164,7 @@ fn check_added_indices(
                     failed.push(index);
                     break;
                 }
-                Ok(Event::Connected) => {
+                Ok(Event::Connected(_)) => {
                     assert!(added.insert(node.name()));
                     break;
                 }

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -11,8 +11,8 @@ use fake_clock::FakeClock;
 use itertools::Itertools;
 use rand::Rng;
 use routing::{
-    mock::Network, test_consts, Authority, Event, EventStream, FullId, NetworkConfig, Node,
-    NodeBuilder, PausedState, Prefix, PublicId, XorName, Xorable,
+    mock::Network, test_consts, Authority, ConnectEvent, Event, EventStream, FullId, NetworkConfig,
+    Node, NodeBuilder, PausedState, Prefix, PublicId, XorName, Xorable,
 };
 use std::{
     cmp,
@@ -324,7 +324,7 @@ pub fn remove_nodes_which_failed_to_connect(nodes: &mut Vec<TestNode>, count: us
         .take(count)
         .filter_map(|(index, ref mut node)| {
             while let Ok(event) = node.try_next_ev() {
-                if let Event::Connected = event {
+                if let Event::Connected(_) = event {
                     return None;
                 }
             }
@@ -361,7 +361,7 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
     let n = cmp::min(nodes.len(), network.elder_size()) - 1;
 
     for node in &mut nodes {
-        expect_next_event!(node, Event::Connected);
+        expect_next_event!(node, Event::Connected(_));
 
         let mut node_added_count = 0;
 
@@ -392,7 +392,7 @@ pub fn create_connected_nodes_until_split(network: &Network, prefix_lengths: Vec
     // Start first node.
     let mut nodes = vec![TestNode::builder(network).first().create()];
     let _ = nodes[0].poll();
-    expect_next_event!(nodes[0], Event::Connected);
+    expect_next_event!(nodes[0], Event::Connected(_));
 
     add_connected_nodes_until_split(network, &mut nodes, prefix_lengths);
     Nodes(nodes)
@@ -486,7 +486,8 @@ pub fn add_connected_nodes_until_split(
         | Event::NodeLost(..)
         | Event::TimerTicked
         | Event::ClientEvent(..)
-        | Event::SectionSplit(..) => (),
+        | Event::SectionSplit(..)
+        | Event::Connected(ConnectEvent::Relocate) => (),
         event => panic!("Got unexpected event for {}: {:?}", node.inner, event),
     });
 
@@ -554,6 +555,7 @@ fn add_nodes_to_prefixes(
 // Clear all event queues applying check_event to them.
 fn clear_all_event_queues(nodes: &mut Vec<TestNode>, check_event: impl Fn(&TestNode, Event)) {
     for node in nodes.iter_mut() {
+        trace!("Start Check with {}", node.inner);
         while let Ok(event) = node.try_next_ev() {
             check_event(node, event)
         }
@@ -936,7 +938,7 @@ fn add_node_to_section(network: &Network, nodes: &mut Vec<TestNode>, prefix: &Pr
             })
             .fire_join_timeout(false),
     );
-    expect_any_event!(unwrap!(nodes.last_mut()), Event::Connected);
+    expect_any_event!(unwrap!(nodes.last_mut()), Event::Connected(_));
     assert!(
         prefix.matches(&nodes[nodes.len() - 1].name()),
         "Prefix {:?} doesn't match the name {}!",

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -420,7 +420,7 @@ pub fn add_connected_nodes_until_split(
     let prefixes = prefixes(&prefix_lengths, &mut rng);
 
     // Cleanup the previous event queue
-    clear_all_event_queues(nodes, |_| {});
+    clear_all_event_queues(nodes, |_, _| {});
 
     // Start enough new nodes under each target prefix to trigger a split eventually.
     let min_split_size = unwrap!(nodes[0].inner.min_split_size());
@@ -481,13 +481,13 @@ pub fn add_connected_nodes_until_split(
         prefixes.iter().map(Prefix::bit_count).collect::<Vec<_>>()
     );
 
-    clear_all_event_queues(nodes, |event| match event {
+    clear_all_event_queues(nodes, |node, event| match event {
         Event::NodeAdded(..)
         | Event::NodeLost(..)
         | Event::TimerTicked
         | Event::ClientEvent(..)
         | Event::SectionSplit(..) => (),
-        event => panic!("Got unexpected event: {:?}", event),
+        event => panic!("Got unexpected event for {}: {:?}", node.inner, event),
     });
 
     trace!("Created testnet comprising {:?}", prefixes);
@@ -513,9 +513,9 @@ fn add_connected_nodes_until_sized(
     nodes: &mut Vec<TestNode>,
     prefixes_new_count: &[PrefixAndSize],
 ) {
-    clear_all_event_queues(nodes, |_| {});
+    clear_all_event_queues(nodes, |_, _| {});
     add_nodes_to_prefixes(network, nodes, prefixes_new_count);
-    clear_all_event_queues(nodes, |_| {});
+    clear_all_event_queues(nodes, |_, _| {});
 
     trace!(
         "Filled prefixes until ready to split {:?}",
@@ -552,10 +552,10 @@ fn add_nodes_to_prefixes(
 }
 
 // Clear all event queues applying check_event to them.
-fn clear_all_event_queues(nodes: &mut Vec<TestNode>, check_event: impl Fn(Event)) {
+fn clear_all_event_queues(nodes: &mut Vec<TestNode>, check_event: impl Fn(&TestNode, Event)) {
     for node in nodes.iter_mut() {
         while let Ok(event) = node.try_next_ev() {
-            check_event(event)
+            check_event(node, event)
         }
     }
 }

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -361,7 +361,7 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
     let n = cmp::min(nodes.len(), network.elder_size()) - 1;
 
     for node in &mut nodes {
-        expect_next_event!(node, Event::Connected(_));
+        expect_next_event!(node, Event::Connected(ConnectEvent::First));
 
         let mut node_added_count = 0;
 
@@ -372,7 +372,8 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
                 | Event::SectionSplit(..)
                 | Event::RestartRequired
                 | Event::ClientEvent(..)
-                | Event::TimerTicked => (),
+                | Event::TimerTicked
+                | Event::Connected(ConnectEvent::Relocate) => (),
                 event => panic!("Got unexpected event: {:?}", event),
             }
         }


### PR DESCRIPTION
Couple of commits dealing with the handling of `Event::Connected`, backported from #1929 .