### PR TITLE
resend Join bootstrap response if outdated elder version

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -576,6 +576,11 @@ impl Chain {
         self.state.neighbour_infos.keys().cloned().collect()
     }
 
+    /// Neighbour infos signed by our section
+    pub fn get_neighbour_info(&self, prefix: &Prefix<XorName>) -> Option<&EldersInfo> {
+        self.state.neighbour_infos.get(prefix)
+    }
+
     /// Check if the given `PublicId` is a member of our section.
     pub fn is_peer_our_member(&self, pub_id: &PublicId) -> bool {
         self.state

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -7,13 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
+    chain::EldersInfo,
     crypto::signing::Signature,
     error::{BootstrapResponseError, RoutingError},
-    id::{FullId, P2pNode, PublicId},
+    id::{FullId, PublicId},
     messages::SignedRoutingMessage,
     parsec,
     relocation::{RelocatePayload, SignedRelocateDetails},
-    routing_table::Prefix,
     xor_name::XorName,
     ConnectionInfo,
 };
@@ -62,10 +62,7 @@ pub enum DirectMessage {
 pub enum BootstrapResponse {
     /// This response means that the new peer is clear to join the section. The connection infos of
     /// the section elders and the section prefix are provided.
-    Join {
-        prefix: Prefix<XorName>,
-        p2p_nodes: Vec<P2pNode>,
-    },
+    Join(EldersInfo),
     /// The new peer should retry bootstrapping with another section. The set of connection infos
     /// of the members of that section is provided.
     Rebootstrap(Vec<ConnectionInfo>),

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -41,8 +41,7 @@ pub enum DirectMessage {
     BootstrapResponse(BootstrapResponse),
     /// Sent from a bootstrapping peer to the section that responded with a
     /// `BootstrapResponse::Join` to its `BootstrapRequest`.
-    /// If the peer is being relocated, contains `RelocatePayload`. Otherwise contains `None`.
-    JoinRequest(Option<RelocatePayload>),
+    JoinRequest(JoinRequest),
     /// Sent from members of a section to a joining node in response to `ConnectionRequest` (which is
     /// a routing message)
     ConnectionResponse,
@@ -70,6 +69,16 @@ pub enum BootstrapResponse {
     Error(BootstrapResponseError),
 }
 
+/// Request to join a section
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub struct JoinRequest {
+    /// The section version to join
+    pub elders_version: u64,
+    /// If the peer is being relocated, contains `RelocatePayload`. Otherwise contains `None`.
+    pub relocate_payload: Option<RelocatePayload>,
+}
+
 impl Debug for DirectMessage {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         use self::DirectMessage::*;
@@ -77,10 +86,12 @@ impl Debug for DirectMessage {
             MessageSignature(msg) => write!(formatter, "MessageSignature ({:?})", msg),
             BootstrapRequest(name) => write!(formatter, "BootstrapRequest({})", name),
             BootstrapResponse(response) => write!(formatter, "BootstrapResponse({:?})", response),
-            JoinRequest(relocate_details) => write!(
+            JoinRequest(join_request) => write!(
                 formatter,
-                "JoinRequest({:?})",
-                relocate_details
+                "JoinRequest({}, {:?})",
+                join_request.elders_version,
+                join_request
+                    .relocate_payload
                     .as_ref()
                     .map(|payload| payload.details.content())
             ),
@@ -108,7 +119,7 @@ impl Hash for DirectMessage {
             MessageSignature(msg) => msg.hash(state),
             BootstrapRequest(name) => name.hash(state),
             BootstrapResponse(response) => response.hash(state),
-            JoinRequest(payload) => payload.hash(state),
+            JoinRequest(join_request) => join_request.hash(state),
             ConnectionResponse => (),
             ParsecPoke(version) => version.hash(state),
             ParsecRequest(version, request) => {

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -8,7 +8,7 @@
 
 mod direct;
 
-pub use self::direct::{BootstrapResponse, DirectMessage, SignedDirectMessage};
+pub use self::direct::{BootstrapResponse, DirectMessage, JoinRequest, SignedDirectMessage};
 use crate::{
     chain::{
         Chain, EldersInfo, GenesisPfxInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain,

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     action::Action,
-    chain::GenesisPfxInfo,
+    chain::{EldersInfo, GenesisPfxInfo},
     error::{InterfaceError, RoutingError},
     id::{P2pNode, PublicId},
     network_service::NetworkBuilder,
@@ -297,7 +297,7 @@ pub enum Transition {
     Stay,
     // `BootstrappingPeer` state transitioning to `JoiningPeer`
     IntoJoining {
-        p2p_nodes: Vec<P2pNode>,
+        info: EldersInfo,
         relocate_payload: Option<RelocatePayload>,
     },
     // `JoiningPeer` failing to join and transitioning back to `BootstrappingPeer`
@@ -437,12 +437,10 @@ impl StateMachine {
                 return;
             }
             IntoJoining {
-                p2p_nodes,
+                info,
                 relocate_payload,
             } => self.state.replace_with(|state| match state {
-                State::BootstrappingPeer(src) => {
-                    src.into_joining(p2p_nodes, relocate_payload, outbox)
-                }
+                State::BootstrappingPeer(src) => src.into_joining(info, relocate_payload, outbox),
                 _ => unreachable!(),
             }),
             Rebootstrap => self.state.replace_with(|state| match state {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -381,35 +381,38 @@ impl Elder {
         self.send_direct_message(node.connection_info(), DirectMessage::ConnectionResponse);
     }
 
-    fn reset_parsec_with_data(&mut self, reset_data: ParsecResetData) -> Result<(), RoutingError> {
-        let drained_obs: Vec<_> = self
-            .parsec_map
-            .our_unpolled_observations()
-            .cloned()
-            .collect();
+    fn append_our_unpolled_observations(
+        &mut self,
+        mut reset_data: ParsecResetData,
+    ) -> ParsecResetData {
+        reset_data.cached_events.extend(
+            self.parsec_map
+                .our_unpolled_observations()
+                .filter_map(|obs| match obs {
+                    parsec::Observation::OpaquePayload(event) => Some(event),
 
+                    parsec::Observation::Genesis { .. }
+                    | parsec::Observation::Add { .. }
+                    | parsec::Observation::Remove { .. }
+                    | parsec::Observation::Accusation { .. }
+                    | parsec::Observation::StartDkg(_)
+                    | parsec::Observation::DkgResult { .. }
+                    | parsec::Observation::DkgMessage(_) => None,
+                })
+                .cloned(),
+        );
+        reset_data
+    }
+
+    fn reset_parsec_with_data(&mut self, reset_data: ParsecResetData) -> Result<(), RoutingError> {
         let ParsecResetData {
             gen_pfx_info,
-            mut cached_events,
+            cached_events,
             completed_events,
         } = reset_data;
         self.gen_pfx_info = gen_pfx_info;
         self.init_parsec(); // We don't reset the chain on prefix change.
 
-        for obs in drained_obs {
-            let event = match obs {
-                parsec::Observation::OpaquePayload(event) => event,
-
-                parsec::Observation::Genesis { .. }
-                | parsec::Observation::Add { .. }
-                | parsec::Observation::Remove { .. }
-                | parsec::Observation::Accusation { .. }
-                | parsec::Observation::StartDkg(_)
-                | parsec::Observation::DkgResult { .. }
-                | parsec::Observation::DkgMessage(_) => continue,
-            };
-            let _ = cached_events.insert(event);
-        }
         let our_pfx = *self.our_prefix();
 
         cached_events
@@ -456,6 +459,7 @@ impl Elder {
         let reset_data = self
             .chain
             .prepare_parsec_reset(self.parsec_map.last_version().saturating_add(1))?;
+        let reset_data = self.append_our_unpolled_observations(reset_data);
         self.reset_parsec_with_data(reset_data)
     }
 
@@ -463,6 +467,7 @@ impl Elder {
         let reset_data = self
             .chain
             .finalise_prefix_change(self.parsec_map.last_version().saturating_add(1))?;
+        let reset_data = self.append_our_unpolled_observations(reset_data);
         self.reset_parsec_with_data(reset_data)?;
         self.send_event(Event::SectionSplit(*self.our_prefix()), outbox);
         Ok(())

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -731,10 +731,7 @@ impl Elder {
     fn respond_to_bootstrap_request(&mut self, p2p_node: &P2pNode, name: &XorName) {
         let response = if self.our_prefix().matches(name) {
             debug!("{} - Sending BootstrapResponse::Join to {}", self, p2p_node);
-            BootstrapResponse::Join {
-                prefix: *self.our_prefix(),
-                p2p_nodes: self.chain.our_elders().cloned().collect(),
-            }
+            BootstrapResponse::Join(self.chain.our_info().clone())
         } else {
             let conn_infos: Vec<_> = self
                 .closest_known_elders_to(name)

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -12,7 +12,7 @@ use super::{
     common::Base,
 };
 use crate::{
-    chain::{GenesisPfxInfo, NetworkParams},
+    chain::{EldersInfo, GenesisPfxInfo, NetworkParams},
     error::{InterfaceError, RoutingError},
     event::{ConnectEvent, Event},
     id::{FullId, P2pNode},
@@ -42,7 +42,7 @@ pub struct JoiningPeerDetails {
     pub network_cfg: NetworkParams,
     pub timer: Timer,
     pub rng: MainRng,
-    pub p2p_nodes: Vec<P2pNode>,
+    pub elders_info: EldersInfo,
     pub relocate_payload: Option<RelocatePayload>,
 }
 
@@ -55,7 +55,7 @@ pub struct JoiningPeer {
     full_id: FullId,
     timer: Timer,
     rng: MainRng,
-    p2p_nodes: Vec<P2pNode>,
+    elders_info: EldersInfo,
     join_type: JoinType,
     network_cfg: NetworkParams,
 }
@@ -78,7 +78,7 @@ impl JoiningPeer {
             full_id: details.full_id,
             timer: details.timer,
             rng: details.rng,
-            p2p_nodes: details.p2p_nodes,
+            elders_info: details.elders_info,
             join_type,
             network_cfg: details.network_cfg,
         };
@@ -130,7 +130,7 @@ impl JoiningPeer {
     }
 
     fn send_join_requests(&mut self) {
-        for dst in self.p2p_nodes.clone() {
+        for dst in self.elders_info.clone().member_nodes() {
             info!("{} - Sending JoinRequest to {}", self, dst.public_id());
 
             let relocate_payload = match &self.join_type {

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -16,7 +16,10 @@ use crate::{
     error::{InterfaceError, RoutingError},
     event::{ConnectEvent, Event},
     id::{FullId, P2pNode},
-    messages::{DirectMessage, HopMessage, MessageContent, RoutingMessage, SignedRoutingMessage},
+    messages::{
+        DirectMessage, HopMessage, JoinRequest, MessageContent, RoutingMessage,
+        SignedRoutingMessage,
+    },
     outbox::EventBox,
     peer_map::PeerMap,
     relocation::RelocatePayload,
@@ -130,6 +133,7 @@ impl JoiningPeer {
     }
 
     fn send_join_requests(&mut self) {
+        let elders_version = self.elders_info.version();
         for dst in self.elders_info.clone().member_nodes() {
             info!("{} - Sending JoinRequest to {}", self, dst.public_id());
 
@@ -137,10 +141,14 @@ impl JoiningPeer {
                 JoinType::First { .. } => None,
                 JoinType::Relocate(payload) => Some(payload.clone()),
             };
+            let join_request = JoinRequest {
+                elders_version,
+                relocate_payload,
+            };
 
             self.send_direct_message(
                 dst.connection_info(),
-                DirectMessage::JoinRequest(relocate_payload),
+                DirectMessage::JoinRequest(join_request),
             );
         }
     }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -39,7 +39,7 @@ fn drop_random_nodes<R: Rng>(
     let elder_size = |node: &TestNode| unwrap!(node.inner.elder_size());
     let node_section_size = |node: &TestNode| {
         node.inner
-            .section_elders(unwrap!(node.inner.our_prefix()))
+            .section_elders(unwrap!(node.inner.our_prefix(), "{}", node.inner))
             .len()
     };
     let sections: BTreeMap<_, _> = nodes


### PR DESCRIPTION
Refactor code to allow post - processing events
Refactor code to have EldersInfo in BootstrapResponse::Join
Refactor code to have EldersInfo version in JoinRequest
Ensure new name match the same prefix has relocation destination even if split occur
JoiningPeer update and resend JoinRequest if receive BootstrapResponse::Join with newer info (could be the first responder was lagging, or the section updated).
Resend BootstrapResponse::Join if churn, or if receive JoinRequest that could have been for us in a previous section.

Commit comments have more details.

May address issue #1861 

Test:
Verify the fix address the issue found soak testing PR #1929 