### PR TITLE
backport increase age even for infant from #1929

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -426,6 +426,8 @@ impl Chain {
             return None;
         }
 
+        trace!("{} - relocating member {}", self, details.pub_id);
+
         Some(details)
     }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -357,6 +357,10 @@ impl Chain {
                 relocation::compute_destination(&our_prefix, name, trigger_node.name());
             if our_prefix.matches(&destination) {
                 // Relocation destination inside the current section - ignoring.
+                trace!(
+                    "increment_age_counters: Ignoring relocation for {:?}",
+                    member_info.p2p_node.public_id()
+                );
                 continue;
             }
 
@@ -367,6 +371,8 @@ impl Chain {
                 age: member_info.age() + 1,
             })
         }
+
+        trace!("increment_age_counters: {:?}", self.state.our_members);
 
         for details in details_to_add {
             trace!("{} - Change state to Relocating {}", self, details.pub_id);

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -336,8 +336,16 @@ impl Chain {
                 .map(|persona| persona == MemberPersona::Infant)
                 .unwrap_or(true)
         {
-            // Do nothing for infants and unknown nodes
-            return;
+            // FIXME: skipping infants churn for ageing breaks tests for node ageing, as once a
+            // section reaches a safe size, nodes stop ageing at all, because all churn in tests
+            // is Infant churn.
+            // Temporarily ignore until we either find a better way of preventing churn spam,
+            // or we change the tests to provide some Adult churn at all times.
+            trace!(
+                "{} FIXME: should do nothing for infants and unknown nodes {:?}",
+                self,
+                trigger_node
+            );
         }
 
         let our_prefix = *self.state.our_prefix();

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1425,6 +1425,17 @@ impl Chain {
             );
         }
     }
+
+    /// Check if we know this node but have not yet processed it.
+    pub fn is_in_online_backlog(&self, pub_id: &PublicId) -> bool {
+        self.state.churn_event_backlog.iter().any(|evt| {
+            if let AccumulatingEvent::Online(payload) = evt {
+                payload.p2p_node.public_id() == pub_id
+            } else {
+                false
+            }
+        })
+    }
 }
 
 /// The outcome of a prefix change.

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -718,13 +718,6 @@ impl Chain {
         self.neighbour_infos().flat_map(EldersInfo::member_nodes)
     }
 
-    /// Returns all members of our section that have state == `Joined`.
-    pub fn our_joined_members(&self) -> impl Iterator<Item = &P2pNode> {
-        self.state
-            .our_joined_members()
-            .map(|(_, info)| &info.p2p_node)
-    }
-
     /// Returns an iterator over the members that have not state == `Left`.
     pub fn our_active_members(&self) -> impl Iterator<Item = &P2pNode> {
         self.state

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -656,7 +656,7 @@ impl Chain {
     }
 
     pub fn find_p2p_node_from_addr(&self, socket_addr: &SocketAddr) -> Option<&P2pNode> {
-        self.elders()
+        self.known_nodes()
             .find(|p2p_node| p2p_node.peer_addr() == socket_addr)
     }
 
@@ -723,6 +723,19 @@ impl Chain {
         self.state
             .our_joined_members()
             .map(|(_, info)| &info.p2p_node)
+    }
+
+    /// Returns an iterator over the members that have not state == `Left`.
+    pub fn our_active_members(&self) -> impl Iterator<Item = &P2pNode> {
+        self.state
+            .our_active_members()
+            .map(|(_, info)| &info.p2p_node)
+    }
+
+    /// Returns the members in our section and elders we know.
+    pub fn known_nodes(&self) -> impl Iterator<Item = &P2pNode> {
+        self.our_active_members()
+            .chain(self.neighbour_elder_nodes())
     }
 
     /// Return the keys we know

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -241,6 +241,13 @@ impl SharedState {
         self.our_infos.iter().find(|info| info.hash() == hash)
     }
 
+    /// Returns an iterator over the members that have not state == `Left`.
+    pub fn our_active_members(&self) -> impl Iterator<Item = (&XorName, &MemberInfo)> {
+        self.our_members
+            .iter()
+            .filter(|(_, member)| member.state != MemberState::Left)
+    }
+
     /// Returns an iterator over the members that have state == `Joined`.
     pub fn our_joined_members(&self) -> impl Iterator<Item = (&XorName, &MemberInfo)> {
         self.our_members

--- a/src/mock/parsec/key_gen.rs
+++ b/src/mock/parsec/key_gen.rs
@@ -42,4 +42,10 @@ impl<P: PublicId> KeyGen<P> {
         let secret_key_share = index.map(|index| secret_key_set.secret_key_share(index));
         DkgResult::new(secret_key_set.public_keys(), secret_key_share)
     }
+
+    pub fn contains_participant(&self, our_id: &P) -> bool {
+        self.instances
+            .keys()
+            .any(|participants| participants.contains(our_id))
+    }
 }

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -225,7 +225,21 @@ where
         unimplemented!()
     }
 
+    fn is_valid_gossip_recipient(&self) -> bool {
+        if self.peer_list.contains(self.our_id.public_id()) {
+            return true;
+        }
+
+        state::with::<T, S::PublicId, _, _>(self.section_hash, |state| {
+            state.dkg_participant(self.our_id.public_id())
+        })
+    }
+
     pub fn has_unpolled_observations(&self) -> bool {
+        if !self.is_valid_gossip_recipient() {
+            return false;
+        }
+
         state::with::<T, S::PublicId, _, _>(self.section_hash, |state| {
             state
                 .unconsensused_observations_for_peers(&self.peer_list)

--- a/src/mock/parsec/state.rs
+++ b/src/mock/parsec/state.rs
@@ -112,6 +112,10 @@ impl<T: NetworkEvent, P: PublicId> SectionState<T, P> {
     ) -> DkgResult {
         self.key_gen.get_or_generate(rng, our_id, participants)
     }
+
+    pub fn dkg_participant(&self, our_id: &P) -> bool {
+        self.key_gen.contains_participant(our_id)
+    }
 }
 
 pub(super) type BlockInfo<'a, T, P> = (&'a Block<T, P>, &'a ObservationHolder<T, P>);

--- a/src/node.rs
+++ b/src/node.rs
@@ -424,6 +424,11 @@ impl Node {
         self.chain().into_iter().flat_map(Chain::elders)
     }
 
+    /// Returns the members in our section and elders we know.
+    pub fn known_nodes(&self) -> impl Iterator<Item = &P2pNode> {
+        self.chain().into_iter().flat_map(Chain::known_nodes)
+    }
+
     /// Returns whether the given `PublicId` is a member of our section.
     pub fn is_peer_our_member(&self, id: &PublicId) -> bool {
         self.chain()

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -313,7 +313,6 @@ impl Adult {
             p2p_node.connection_info(),
             DirectMessage::BootstrapResponse(response),
         );
-        self.disconnect(p2p_node.peer_addr());
     }
 
     // Send signed_msg to our elders so they can route it properly.

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -603,16 +603,16 @@ impl Approved for Adult {
     ) -> Result<(), RoutingError> {
         if !self.chain.can_add_member(payload.p2p_node.public_id()) {
             info!("{} - ignore Online: {:?}.", self, payload);
-            return Ok(());
+        } else {
+            info!("{} - handle Online: {:?}.", self, payload);
+
+            let pub_id = *payload.p2p_node.public_id();
+            self.chain.add_member(payload.p2p_node, payload.age);
+            self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
+            self.chain.increment_age_counters(&pub_id);
+            let _ = self.chain.promote_and_demote_elders()?;
         }
 
-        info!("{} - handle Online: {:?}.", self, payload);
-
-        let pub_id = *payload.p2p_node.public_id();
-        self.chain.add_member(payload.p2p_node, payload.age);
-        self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-        self.chain.increment_age_counters(&pub_id);
-        let _ = self.chain.promote_and_demote_elders()?;
         let _ = self.chain.poll_relocation();
 
         Ok(())
@@ -625,15 +625,15 @@ impl Approved for Adult {
     ) -> Result<(), RoutingError> {
         if !self.chain.can_remove_member(&pub_id) {
             info!("{} - ignore Offline: {}.", self, pub_id);
-            return Ok(());
-        }
+        } else {
+            info!("{} - handle Offline: {}.", self, pub_id);
 
-        info!("{} - handle Offline: {}.", self, pub_id);
-        self.chain.increment_age_counters(&pub_id);
-        self.chain.remove_member(&pub_id);
-        self.send_event(Event::NodeLost(*pub_id.name()), outbox);
-        let _ = self.chain.promote_and_demote_elders()?;
-        self.disconnect_by_id_lookup(&pub_id);
+            self.chain.increment_age_counters(&pub_id);
+            self.chain.remove_member(&pub_id);
+            self.send_event(Event::NodeLost(*pub_id.name()), outbox);
+            let _ = self.chain.promote_and_demote_elders()?;
+            self.disconnect_by_id_lookup(&pub_id);
+        }
         let _ = self.chain.poll_relocation();
 
         Ok(())

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -293,7 +293,10 @@ impl Base for BootstrappingPeer {
 
         match msg {
             DirectMessage::BootstrapResponse(BootstrapResponse::Join(info)) => {
-                info!("{} - Joining a section {:?}", self, info);
+                info!(
+                    "{} - Joining a section {:?} (given by {:?})",
+                    self, info, p2p_node
+                );
                 self.join_section(info)
             }
             DirectMessage::BootstrapResponse(BootstrapResponse::Rebootstrap(new_conn_infos)) => {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -873,6 +873,14 @@ impl Elder {
             return;
         }
 
+        if self.chain.is_in_online_backlog(&pub_id) {
+            debug!(
+                "{} - Ignoring JoinRequest from {} - already in backlog.",
+                self, pub_id
+            );
+            return;
+        }
+
         // This joining node is being relocated to us.
         let age = if let Some(payload) = join_request.relocate_payload {
             if !payload.verify_identity(&pub_id) {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -353,16 +353,16 @@ impl Elder {
     // to and disconnect from peers that are no longer elders of neighbour sections.
     fn update_peer_connections(&mut self, change: EldersChange) {
         if !self.chain.split_in_progress() {
-            let our_member_connections: HashSet<_> = self
+            let our_needed_connections: HashSet<_> = self
                 .chain
-                .our_joined_members()
+                .known_nodes()
                 .map(|node| *node.peer_addr())
                 .collect();
 
             for p2p_node in change.removed {
                 // The peer might have been relocated from a neighbour to us - in that case do not
                 // disconnect from them.
-                if our_member_connections.contains(p2p_node.peer_addr()) {
+                if our_needed_connections.contains(p2p_node.peer_addr()) {
                     continue;
                 }
 

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -180,8 +180,9 @@ impl JoiningPeer {
 
     fn handle_node_approval(&mut self, gen_pfx_info: GenesisPfxInfo) -> Transition {
         info!(
-            "{} - This node has been approved to join the network!",
-            self
+            "{} - This node has been approved to join the network at {:?}!",
+            self,
+            gen_pfx_info.latest_info.prefix(),
         );
         Transition::IntoAdult { gen_pfx_info }
     }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -18,10 +18,7 @@ use routing::{
     Authority, Event, EventStream, NetworkConfig, NetworkParams, XorName, QUORUM_DENOMINATOR,
     QUORUM_NUMERATOR,
 };
-use std::{
-    cmp,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// Randomly removes some nodes, but <1/3 from each section and never node 0.
 /// Never trigger merge: never remove enough nodes to drop to `elder_size`.
@@ -308,23 +305,28 @@ impl Expectations {
     }
 
     /// Verifies that all sent messages have been received by the appropriate nodes.
-    fn verify(mut self, nodes: &mut [TestNode]) {
+    fn verify(mut self, nodes: &mut [TestNode], new_to_old_map: &BTreeMap<XorName, XorName>) {
         // The minimum of the section lengths when sending and now. If a churn event happened, both
         // cases are valid: that the message was received before or after that. The number of
-        // recipients thus only needs to reach a quorum for the smaller of the section sizes.
-        let section_sizes: HashMap<_, _> = self
+        // recipients thus only needs to reach a quorum for the minimum number of node at one point.
+        let section_size_added_removed: HashMap<_, _> = self
             .sections
             .iter_mut()
             .map(|(dst, section)| {
                 let is_recipient = |n: &&TestNode| n.is_recipient(dst);
-                let new_section = nodes
+                let old_section = section.clone();
+                let new_section: HashSet<_> = nodes
                     .iter()
                     .filter(is_recipient)
                     .map(TestNode::name)
-                    .collect_vec();
-                let count = cmp::min(section.len(), new_section.len());
-                section.extend(new_section);
-                (*dst, count)
+                    .collect();
+                section.extend(new_section.clone());
+
+                let added: BTreeSet<_> = new_section.difference(&old_section).copied().collect();
+                let removed: BTreeSet<_> = old_section.difference(&new_section).copied().collect();
+                let count = old_section.len() - removed.len();
+
+                (*dst, (count, added, removed))
             })
             .collect();
         let mut section_msgs_received = HashMap::new(); // The count of received section messages.
@@ -355,7 +357,17 @@ impl Expectations {
                             *section_msgs_received.entry(key).or_insert(0usize) += 1;
                         }
                     } else {
-                        assert_eq!(node.name(), dst.name());
+                        let node_name = node.name();
+                        let original_node_name =
+                            new_to_old_map.get(&node_name).copied().unwrap_or(node_name);
+                        assert_eq!(
+                            original_node_name,
+                            dst.name(),
+                            "Receiver does not match destination {}: {:?}, {:?}",
+                            node.inner,
+                            original_node_name,
+                            dst.name()
+                        );
                         assert!(
                             self.messages.remove(&key),
                             "Unexpected request for node {}: {:?}",
@@ -370,13 +382,17 @@ impl Expectations {
         for key in self.messages {
             // All received messages for single nodes were removed: if any are left, they failed.
             assert!(key.dst.is_multiple(), "Failed to receive request {:?}", key);
-            let section_size = section_sizes[&key.dst];
+
+            let (section_size, added, removed) = &section_size_added_removed[&key.dst];
+
             let count = section_msgs_received.remove(&key).unwrap_or(0);
             assert!(
                 count * QUORUM_DENOMINATOR > section_size * QUORUM_NUMERATOR,
-                "Only received {} out of {} messages {:?}.",
+                "Only received {} out of {} (added: {:?}, removed: {:?}) messages {:?}.",
                 count,
                 section_size,
+                added,
+                removed,
                 key
             );
         }
@@ -417,7 +433,7 @@ fn send_and_receive<R: Rng>(rng: &mut R, nodes: &mut [TestNode], elder_size: usi
 
     poll_and_resend(nodes);
 
-    expectations.verify(nodes);
+    expectations.verify(nodes, &Default::default());
 }
 
 #[test]
@@ -546,6 +562,7 @@ fn messages_during_churn() {
         let auth_s1 = Authority::Section(!section_name);
 
         let mut expectations = Expectations::default();
+        let initial_names = nodes.iter().map(|node| node.name()).collect_vec();
 
         // Test messages from a node to itself, another node, a group and a section...
         expectations.send_and_expect(&content, auth_n0, auth_n0, &mut nodes, elder_size);
@@ -564,6 +581,13 @@ fn messages_during_churn() {
         expectations.send_and_expect(&content, auth_s0, auth_n0, &mut nodes, elder_size);
 
         poll_and_resend(&mut nodes);
+        let new_to_old_map: BTreeMap<XorName, XorName> = nodes
+            .iter()
+            .zip(initial_names.iter())
+            .map(|(node, old_name)| (node.name(), *old_name))
+            .filter(|(new_name, old_name)| old_name != new_name)
+            .collect();
+
         let (added_names, failed_indices) = check_added_indices(&mut nodes, new_indices);
         assert!(
             failed_indices.is_empty(),
@@ -578,7 +602,7 @@ fn messages_during_churn() {
         if !added_names.is_empty() {
             warn!("Added nodes: {:?}", added_names);
         }
-        expectations.verify(&mut nodes);
+        expectations.verify(&mut nodes, &new_to_old_map);
         verify_invariant_for_all_nodes(&network, &mut nodes);
     }
 }

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -231,6 +231,7 @@ fn multiple_joining_nodes() {
     let mut nodes = create_connected_nodes(&network, LOWERED_ELDER_SIZE);
 
     while nodes.len() < 25 {
+        let initial_size = nodes.len();
         info!("Size {}", nodes.len());
 
         let mut count_if_split_node = count_sections_members_if_split(&nodes);
@@ -259,6 +260,7 @@ fn multiple_joining_nodes() {
                 }
             }
         }
+        let count = nodes.len() - initial_size;
 
         poll_and_resend(&mut nodes);
         let removed_count = remove_nodes_which_failed_to_connect(&mut nodes, count);

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -311,7 +311,7 @@ fn simultaneous_joining_nodes(
     let mut rng = network.new_rng();
     rng.shuffle(&mut nodes);
 
-    let overrides = RelocationOverrides::new();
+    let mut overrides = RelocationOverrides::new();
 
     let mut nodes_to_add = Vec::new();
     for setup in nodes_to_add_setup {

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -513,8 +513,12 @@ fn check_section_info_ack() {
     //
     // Assert
     //
-    let expected_all: Vec<_> = nodes.iter().map(|node| node.id()).collect();
-    assert_eq!(node_with_sibling_knowledge, expected_all);
+    let expected_all_elder: Vec<_> = nodes
+        .iter()
+        .filter(|node| node.inner.is_elder())
+        .map(|node| node.id())
+        .collect();
+    assert_eq!(node_with_sibling_knowledge, expected_all_elder);
 }
 
 #[test]

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -28,7 +28,7 @@ const NETWORK_PARAMS: NetworkParams = NetworkParams {
 #[test]
 fn relocate_without_split() {
     let network = Network::new(NETWORK_PARAMS);
-    let overrides = RelocationOverrides::new();
+    let mut overrides = RelocationOverrides::new();
 
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
@@ -71,7 +71,7 @@ fn relocate_causing_split() {
 
     // Relocate node into a section which is one node shy of splitting.
     let network = Network::new(NETWORK_PARAMS);
-    let overrides = RelocationOverrides::new();
+    let mut overrides = RelocationOverrides::new();
 
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);
@@ -127,7 +127,7 @@ fn relocate_causing_split() {
 fn relocate_during_split() {
     // Relocate node into a section which is undergoing split.
     let network = Network::new(NETWORK_PARAMS);
-    let overrides = RelocationOverrides::new();
+    let mut overrides = RelocationOverrides::new();
 
     let mut rng = network.new_rng();
     let mut nodes = create_connected_nodes_until_split(&network, vec![1, 1]);

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -665,6 +665,10 @@ pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
     }
 
     let neighbour_prefixes = node.inner.neighbour_prefixes();
+    if !node.inner.is_elder() {
+        assert!(neighbour_prefixes.is_empty(), "No neighbour info for Adults");
+        return;
+    }
 
     if let Some(compatible_prefix) = neighbour_prefixes
         .iter()
@@ -711,13 +715,6 @@ pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
         .neighbour_prefixes()
         .iter()
         .all(|prefix| our_prefix.is_neighbour(prefix));
-    let all_neighbours_covered = {
-        (0..our_prefix.bit_count()).all(|i| {
-            our_prefix
-                .with_flipped_bit(i)
-                .is_covered_by(&neighbour_prefixes)
-        })
-    };
     if !all_are_neighbours {
         panic!(
             "{} Some sections in the chain aren't neighbours of our section: {:?}",
@@ -727,6 +724,14 @@ pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
                 .collect::<Vec<_>>()
         );
     }
+
+    let all_neighbours_covered = {
+        (0..our_prefix.bit_count()).all(|i| {
+            our_prefix
+                .with_flipped_bit(i)
+                .is_covered_by(&neighbour_prefixes)
+        })
+    };
     if !all_neighbours_covered {
         panic!(
             "{} Some neighbours aren't fully covered by the chain: {:?}",

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -858,7 +858,7 @@ pub fn verify_invariant_for_all_nodes(network: &Network, nodes: &mut [TestNode])
         if !missing_peers.is_empty() {
             error!(
                 "verify_invariant_for_all_nodes: node {}: missing: {:?}",
-                our_id, &missing_peers
+                node.inner, &missing_peers
             );
             all_missing_peers.extend(missing_peers);
         }

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -666,7 +666,10 @@ pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
 
     let neighbour_prefixes = node.inner.neighbour_prefixes();
     if !node.inner.is_elder() {
-        assert!(neighbour_prefixes.is_empty(), "No neighbour info for Adults");
+        assert!(
+            neighbour_prefixes.is_empty(),
+            "No neighbour info for Adults"
+        );
         return;
     }
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -849,7 +849,7 @@ pub fn verify_invariant_for_all_nodes(network: &Network, nodes: &mut [TestNode])
         let our_id = unwrap!(node.inner.id());
         let missing_peers = node
             .inner
-            .elder_nodes()
+            .known_nodes()
             .filter(|p2p_node| p2p_node.public_id() != &our_id)
             .filter(|p2p_node| !node.inner.is_connected(p2p_node.peer_addr()))
             .map(|p2p_node| p2p_node.public_id())


### PR DESCRIPTION
Backport a number of fixes from #1929 that stand alone.
The main item is always increase age even for infant as that was leading to stall in test otherwise. 
A number of related fixes are also included as well as the fixes necessary for soak test to pass.

Note:
The relocation_in_progress, churn_in_progress and split_in_progress could probably be improved but is left outside of the scope of that PR.