### PR TITLE
fix/routing: simplify promotion/demotion and reduce number

### DIFF
--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -599,6 +599,13 @@ impl Approved for Adult {
         Ok(())
     }
 
+    fn handle_promote_and_demote_elders(
+        &mut self,
+        _new_infos: Vec<EldersInfo>,
+    ) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn handle_online_event(
         &mut self,
         payload: OnlinePayload,
@@ -613,7 +620,6 @@ impl Approved for Adult {
             self.chain.add_member(payload.p2p_node, payload.age);
             self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
             self.chain.increment_age_counters(&pub_id);
-            let _ = self.chain.promote_and_demote_elders()?;
         }
 
         Ok(())
@@ -632,7 +638,6 @@ impl Approved for Adult {
             self.chain.increment_age_counters(&pub_id);
             self.chain.remove_member(&pub_id);
             self.send_event(Event::NodeLost(*pub_id.name()), outbox);
-            let _ = self.chain.promote_and_demote_elders()?;
             self.disconnect_by_id_lookup(&pub_id);
         }
 
@@ -684,7 +689,6 @@ impl Approved for Adult {
         info!("{} - handle Relocate: {:?}.", self, details);
         self.chain.remove_member(&details.pub_id);
         self.send_event(Event::NodeLost(*details.pub_id.name()), outbox);
-        let _ = self.chain.promote_and_demote_elders()?;
         self.disconnect_by_id_lookup(&details.pub_id);
 
         Ok(())

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -40,6 +40,12 @@ pub trait Approved: Base {
     /// Handles an accumulated relocation trigger
     fn handle_relocate_polled(&mut self, details: RelocateDetails) -> Result<(), RoutingError>;
 
+    /// Handles an accumulated change to our elders
+    fn handle_promote_and_demote_elders(
+        &mut self,
+        new_infos: Vec<EldersInfo>,
+    ) -> Result<(), RoutingError>;
+
     /// Handles an accumulated `Online` event.
     fn handle_online_event(
         &mut self,
@@ -317,6 +323,9 @@ pub trait Approved: Base {
                 }
                 PollAccumulated::RelocateDetails(details) => {
                     self.handle_relocate_polled(details)?;
+                }
+                PollAccumulated::PromoteDemoteElders(new_infos) => {
+                    self.handle_promote_and_demote_elders(new_infos)?;
                 }
             }
 


### PR DESCRIPTION
We checked for promotion demotion everytime a churn event occured.
If we have some in the backlog, we risked changing multiple times in
quick sucession.

The new mechanism has multiple benefit:
 - Only update elders once if multiple node in churn backlog.
 - Clear interaction between the different polling (events, relocation,
   backloged churn, and Elder churn).
 - Avoid duplication that could break shared state in adult.
 - Shorten the flow since promote Demote does not happen as a result
   of an other event completing.

Test:
clippy + soak test