### PR TITLE
Resend neighbour info we vote for

### DIFF
--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -162,7 +162,7 @@ where
         self.gossip_recipients()
             .find(|id| id == &peer_id)
             .map(|_| Request::new())
-            .ok_or(Error::InvalidSelfState)
+            .ok_or(Error::InvalidPeerState)
     }
 
     pub fn handle_request(
@@ -350,7 +350,7 @@ impl<T: NetworkEvent, P: PublicId> Response<T, P> {
 
 #[derive(Debug)]
 pub enum Error {
-    InvalidSelfState,
+    InvalidPeerState,
 }
 
 #[derive(Clone, Copy)]

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -173,9 +173,17 @@ impl ParsecMap {
         self.last_version() == msg_version
     }
 
-    pub fn create_gossip(&mut self, version: u64, target: &id::PublicId) -> Option<DirectMessage> {
-        let request = self.map.get_mut(&version)?.create_gossip(target).ok()?;
-        Some(DirectMessage::ParsecRequest(version, request))
+    pub fn create_gossip(
+        &mut self,
+        version: u64,
+        target: &id::PublicId,
+    ) -> Result<DirectMessage, CreateGossipError> {
+        let request = self
+            .map
+            .get_mut(&version)
+            .ok_or(CreateGossipError::MissingVersion)?
+            .create_gossip(target)?;
+        Ok(DirectMessage::ParsecRequest(version, request))
     }
 
     pub fn vote_for(&mut self, event: chain::NetworkEvent, log_ident: &LogIdent) {
@@ -390,6 +398,18 @@ fn create(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> 
             ConsensusMode::Single,
             Box::new(rng::new_from(rng)),
         )
+    }
+}
+
+#[derive(Debug)]
+pub enum CreateGossipError {
+    MissingVersion,
+    Other(Error),
+}
+
+impl From<Error> for CreateGossipError {
+    fn from(src: Error) -> Self {
+        Self::Other(src)
     }
 }
 

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -396,6 +396,12 @@ impl Adult {
         &mut self,
         mut signed_msg: SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
+        trace!(
+            "{} - Handle signed message: {:?}",
+            self,
+            signed_msg.routing_message()
+        );
+
         if self.in_authority(&signed_msg.routing_message().dst) {
             self.check_signed_message_integrity(&signed_msg)?;
             self.routing_msg_backlog.push(signed_msg.clone());

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -318,7 +318,7 @@ impl Adult {
     // Send signed_msg to our elders so they can route it properly.
     fn send_signed_message_to_elders(
         &mut self,
-        signed_msg: &mut SignedRoutingMessage,
+        signed_msg: &SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
         trace!(
             "{}: Forwarding message {:?} via elder targets {:?}",
@@ -394,7 +394,7 @@ impl Adult {
 
     fn handle_filtered_signed_message(
         &mut self,
-        mut signed_msg: SignedRoutingMessage,
+        signed_msg: SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
         trace!(
             "{} - Handle signed message: {:?}",
@@ -407,7 +407,7 @@ impl Adult {
             self.routing_msg_backlog.push(signed_msg.clone());
         }
 
-        self.send_signed_message_to_elders(&mut signed_msg)?;
+        self.send_signed_message_to_elders(&signed_msg)?;
         Ok(())
     }
 }
@@ -566,8 +566,8 @@ impl Base for Adult {
             return Ok(()); // Message is for us.
         }
 
-        let mut signed_msg = SignedRoutingMessage::single_source(routing_msg, self.full_id())?;
-        self.send_signed_message_to_elders(&mut signed_msg)?;
+        let signed_msg = SignedRoutingMessage::single_source(routing_msg, self.full_id())?;
+        self.send_signed_message_to_elders(&signed_msg)?;
         Ok(())
     }
 }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -202,17 +202,28 @@ pub trait Approved: Base {
             }
         };
 
-        if let Some(msg) = self
+        match self
             .parsec_map_mut()
             .create_gossip(version, gossip_target.public_id())
         {
-            trace!(
-                "{} - send parsec request v{} to {}",
-                self,
-                version,
-                gossip_target.public_id(),
-            );
-            self.send_direct_message(gossip_target.connection_info(), msg);
+            Ok(msg) => {
+                trace!(
+                    "{} - send parsec request v{} to {:?}",
+                    self,
+                    version,
+                    gossip_target,
+                );
+                self.send_direct_message(gossip_target.connection_info(), msg);
+            }
+            Err(error) => {
+                trace!(
+                    "{} - failed to send parsec request v{} to {:?}: {:?}",
+                    self,
+                    version,
+                    gossip_target,
+                    error
+                );
+            }
         }
     }
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -625,6 +625,12 @@ impl Elder {
         &mut self,
         mut signed_msg: SignedRoutingMessage,
     ) -> Result<(), RoutingError> {
+        trace!(
+            "{} - Handle signed message: {:?}",
+            self,
+            signed_msg.routing_message()
+        );
+
         if self.in_authority(&signed_msg.routing_message().dst) {
             self.check_signed_message_trust(&signed_msg)?;
             self.check_signed_message_integrity(&signed_msg)?;


### PR DESCRIPTION
Backport some item written in #1929 

Also clean up the new NeighbourInfo resend mechanism so we can eventually use it for all section messages that must result in a consensus, and simplify the resend condition to always as it should only rarely happen and message filter will help.

Note: This is needed on all membership change as one of the new elder may not have received the message and voted for it otherwise (thus malicious elders could stall that event).