### PR TITLE
Clean member change

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -405,13 +405,9 @@ impl Chain {
                 continue;
             }
 
-            //if our_section_size >= safe_section_size {
             if !member_info.increment_age_counter() {
                 continue;
             }
-            // } else {
-            //     member_info.increment_age();
-            // }
 
             let destination =
                 relocation::compute_destination(&our_prefix, name, trigger_node.name());

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -489,12 +489,12 @@ impl Chain {
     }
 
     /// Validate if can call add_member on this node.
-    pub fn can_add_member(&mut self, pub_id: &PublicId) -> bool {
+    pub fn can_add_member(&self, pub_id: &PublicId) -> bool {
         self.our_prefix().matches(pub_id.name()) && !self.is_peer_our_member(pub_id)
     }
 
     /// Validate if can call remove_member on this node.
-    pub fn can_remove_member(&mut self, pub_id: &PublicId) -> bool {
+    pub fn can_remove_member(&self, pub_id: &PublicId) -> bool {
         self.is_peer_our_member(pub_id)
     }
 

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -79,12 +79,6 @@ impl MemberInfo {
         self.age_counter.increment()
     }
 
-    // Increment the age.
-    #[allow(unused)]
-    pub fn increment_age(&mut self) {
-        self.age_counter = AgeCounter::from_age(self.age().saturating_add(1));
-    }
-
     pub fn is_mature(&self) -> bool {
         self.age_counter >= AgeCounter(2u32.pow(MAX_INFANT_AGE + 1))
     }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -660,45 +660,19 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_online_event(
+    fn handle_member_added(
         &mut self,
-        payload: OnlinePayload,
+        _payload: OnlinePayload,
         _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        if !self.chain.can_add_member(payload.p2p_node.public_id()) {
-            info!("{} - ignore Online: {:?}.", self, payload);
-        } else {
-            info!("{} - handle Online: {:?}.", self, payload);
-
-            let pub_id = *payload.p2p_node.public_id();
-            self.chain.add_member(payload.p2p_node, payload.age);
-            self.chain.increment_age_counters(&pub_id);
-
-            // FIXME: send appropriate events
-            // self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-        }
-
         Ok(())
     }
 
-    fn handle_offline_event(
+    fn handle_member_removed(
         &mut self,
-        pub_id: PublicId,
+        _pub_id: PublicId,
         _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        if !self.chain.can_remove_member(&pub_id) {
-            info!("{} - ignore Offline: {}.", self, pub_id);
-        } else {
-            info!("{} - handle Offline: {}.", self, pub_id);
-
-            self.chain.increment_age_counters(&pub_id);
-            self.chain.remove_member(&pub_id);
-            self.disconnect_by_id_lookup(&pub_id);
-
-            // FIXME: send appropriate events
-            // self.send_event(Event::NodeLost(*pub_id.name()), outbox);
-        }
-
         Ok(())
     }
 
@@ -733,20 +707,12 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_relocate_event(
+    fn handle_member_relocated(
         &mut self,
-        details: RelocateDetails,
+        _details: RelocateDetails,
         _signature: BlsSignature,
         _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        if !self.chain.can_remove_member(&details.pub_id) {
-            info!("{} - ignore Relocate: {:?} - not a member", self, details);
-            return Ok(());
-        }
-
-        info!("{} - handle Relocate: {:?}.", self, details);
-        self.chain.remove_member(&details.pub_id);
-
         Ok(())
     }
 
@@ -773,7 +739,7 @@ impl Approved for Adult {
         Ok(())
     }
 
-    fn handle_prune(&mut self) -> Result<(), RoutingError> {
+    fn handle_prune_event(&mut self) -> Result<(), RoutingError> {
         debug!("{} - Unhandled ParsecPrune event", self);
         Ok(())
     }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -676,6 +676,15 @@ impl Approved for Adult {
         Ok(())
     }
 
+    fn handle_member_relocated(
+        &mut self,
+        _details: RelocateDetails,
+        _signature: BlsSignature,
+        _outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn handle_dkg_result_event(
         &mut self,
         _participants: &BTreeSet<PublicId>,
@@ -703,15 +712,6 @@ impl Approved for Adult {
         &mut self,
         _elders_info: EldersInfo,
         _neighbour_change: EldersChange,
-    ) -> Result<(), RoutingError> {
-        Ok(())
-    }
-
-    fn handle_member_relocated(
-        &mut self,
-        _details: RelocateDetails,
-        _signature: BlsSignature,
-        _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
         Ok(())
     }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -60,6 +60,14 @@ pub trait Approved: Base {
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError>;
 
+    /// Handle a member relocated.
+    fn handle_member_relocated(
+        &mut self,
+        payload: RelocateDetails,
+        signature: BlsSignature,
+        outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError>;
+
     /// Handles a completed DKG.
     fn handle_dkg_result_event(
         &mut self,
@@ -90,14 +98,6 @@ pub trait Approved: Base {
     fn handle_send_ack_message_event(
         &mut self,
         ack_payload: SendAckMessagePayload,
-    ) -> Result<(), RoutingError>;
-
-    /// Handle a member relocated.
-    fn handle_member_relocated(
-        &mut self,
-        payload: RelocateDetails,
-        signature: BlsSignature,
-        outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError>;
 
     /// Handles an accumulated `Offline` event.

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -46,15 +46,15 @@ pub trait Approved: Base {
         new_infos: Vec<EldersInfo>,
     ) -> Result<(), RoutingError>;
 
-    /// Handles an accumulated `Online` event.
-    fn handle_online_event(
+    /// Handles a member added.
+    fn handle_member_added(
         &mut self,
         payload: OnlinePayload,
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError>;
 
-    /// Handles an accumulated `Offline` event.
-    fn handle_offline_event(
+    /// Handles a member removed.
+    fn handle_member_removed(
         &mut self,
         pub_id: PublicId,
         outbox: &mut dyn EventBox,
@@ -92,8 +92,8 @@ pub trait Approved: Base {
         ack_payload: SendAckMessagePayload,
     ) -> Result<(), RoutingError>;
 
-    /// Handle an accumulated `Relocate` event
-    fn handle_relocate_event(
+    /// Handle a member relocated.
+    fn handle_member_relocated(
         &mut self,
         payload: RelocateDetails,
         signature: BlsSignature,
@@ -119,7 +119,7 @@ pub trait Approved: Base {
     }
 
     /// Handles an accumulated `ParsecPrune` event.
-    fn handle_prune(&mut self) -> Result<(), RoutingError>;
+    fn handle_prune_event(&mut self) -> Result<(), RoutingError>;
 
     fn handle_parsec_request(
         &mut self,
@@ -397,7 +397,7 @@ pub trait Approved: Base {
             AccumulatingEvent::SendAckMessage(payload) => {
                 self.handle_send_ack_message_event(payload)?
             }
-            AccumulatingEvent::ParsecPrune => self.handle_prune()?,
+            AccumulatingEvent::ParsecPrune => self.handle_prune_event()?,
             AccumulatingEvent::Relocate(payload) => {
                 self.invoke_handle_relocate_event(payload, event.signature, outbox)?
             }
@@ -437,6 +437,45 @@ pub trait Approved: Base {
         };
     }
 
+    fn handle_online_event(
+        &mut self,
+        payload: OnlinePayload,
+        outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError> {
+        if !self.chain().can_add_member(payload.p2p_node.public_id()) {
+            info!("{} - ignore Online: {:?}.", self, payload);
+        } else {
+            info!("{} - handle Online: {:?}.", self, payload);
+
+            let pub_id = *payload.p2p_node.public_id();
+            self.chain_mut()
+                .add_member(payload.p2p_node.clone(), payload.age);
+            self.chain_mut().increment_age_counters(&pub_id);
+            self.handle_member_added(payload, outbox)?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_offline_event(
+        &mut self,
+        pub_id: PublicId,
+        outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError> {
+        if !self.chain().can_remove_member(&pub_id) {
+            info!("{} - ignore Offline: {}.", self, pub_id);
+        } else {
+            info!("{} - handle Offline: {}.", self, pub_id);
+
+            self.chain_mut().increment_age_counters(&pub_id);
+            self.chain_mut().remove_member(&pub_id);
+            self.disconnect_by_id_lookup(&pub_id);
+            self.handle_member_removed(pub_id, outbox)?;
+        }
+
+        Ok(())
+    }
+
     fn invoke_handle_relocate_event(
         &mut self,
         details: RelocateDetails,
@@ -454,6 +493,23 @@ pub trait Approved: Base {
             );
             Err(RoutingError::FailedSignature)
         }
+    }
+
+    fn handle_relocate_event(
+        &mut self,
+        details: RelocateDetails,
+        signature: BlsSignature,
+        outbox: &mut dyn EventBox,
+    ) -> Result<(), RoutingError> {
+        if !self.chain().can_remove_member(&details.pub_id) {
+            info!("{} - ignore Relocate: {:?} - not a member", self, details);
+        } else {
+            info!("{} - handle Relocate: {:?}.", self, details);
+            self.chain_mut().remove_member(&details.pub_id);
+            self.handle_member_relocated(details, signature, outbox)?;
+        }
+
+        Ok(())
     }
 
     fn check_signed_relocation_details(&self, details: &SignedRelocateDetails) -> bool {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1611,41 +1611,21 @@ impl Approved for Elder {
         Ok(())
     }
 
-    fn handle_online_event(
+    fn handle_member_added(
         &mut self,
         payload: OnlinePayload,
         outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        if !self.chain.can_add_member(payload.p2p_node.public_id()) {
-            info!("{} - ignore Online: {:?}.", self, payload);
-        } else {
-            info!("{} - handle Online: {:?}.", self, payload);
-
-            let pub_id = *payload.p2p_node.public_id();
-            self.chain.add_member(payload.p2p_node.clone(), payload.age);
-            self.chain.increment_age_counters(&pub_id);
-            self.handle_candidate_approval(payload.p2p_node, outbox);
-            self.print_rt_size();
-        }
-
+        self.handle_candidate_approval(payload.p2p_node, outbox);
+        self.print_rt_size();
         Ok(())
     }
 
-    fn handle_offline_event(
+    fn handle_member_removed(
         &mut self,
-        pub_id: PublicId,
+        _pub_id: PublicId,
         _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        if !self.chain.can_remove_member(&pub_id) {
-            info!("{} - ignore Offline: {}.", self, pub_id);
-        } else {
-            info!("{} - handle Offline: {}.", self, pub_id);
-
-            self.chain.increment_age_counters(&pub_id);
-            self.chain.remove_member(&pub_id);
-            self.disconnect_by_id_lookup(&pub_id);
-        }
-
         Ok(())
     }
 
@@ -1668,7 +1648,7 @@ impl Approved for Elder {
         Ok(())
     }
 
-    fn handle_prune(&mut self) -> Result<(), RoutingError> {
+    fn handle_prune_event(&mut self) -> Result<(), RoutingError> {
         if self.chain.split_in_progress() {
             log_or_panic!(
                 LogLevel::Warn,
@@ -1794,47 +1774,42 @@ impl Approved for Elder {
         self.send_routing_message(RoutingMessage { src, dst, content })
     }
 
-    fn handle_relocate_event(
+    fn handle_member_relocated(
         &mut self,
         details: RelocateDetails,
         signature: BlsSignature,
         _outbox: &mut dyn EventBox,
     ) -> Result<(), RoutingError> {
-        if !self.chain.can_remove_member(&details.pub_id) {
-            info!("{} - ignore Relocate: {:?} - not a member", self, details);
+        if &details.pub_id == self.id() {
+            // Do not send the message to ourselves.
             return Ok(());
         }
 
-        info!("{} - handle Relocate: {:?}.", self, details);
+        // We need proof that is valid for both the relocating node and the target section. To
+        // construct such proof, we create one proof for the relocating node and one for the target
+        // section and then take the longer of the two. This works because the longer proof is a
+        // superset of the shorter one. We need to do this because in rare cases, the relocating
+        // node might be lagging behind the target section in the knowledge of the source section.
+        let proof = {
+            let proof_for_source = self.chain.prove(&Authority::Node(*details.pub_id.name()));
+            let proof_for_target = self.chain.prove(&Authority::Section(details.destination));
 
-        let pub_id = details.pub_id;
-
-        // Do not send the message to ourselves.
-        if pub_id != *self.id() {
-            // We need proof that is valid for both the relocating node and the target section. To
-            // construct such proof, we create one proof for the relocating node and one for the target
-            // section and then take the longer of the two. This works because the longer proof is a
-            // superset of the shorter one. We need to do this because in rare cases, the relocating
-            // node might be lagging behind the target section in the knowledge of the source section.
-            let proof = {
-                let proof_for_source = self.chain.prove(&Authority::Node(*details.pub_id.name()));
-                let proof_for_target = self.chain.prove(&Authority::Section(details.destination));
-
-                if proof_for_source.blocks_len() > proof_for_target.blocks_len() {
-                    proof_for_source
-                } else {
-                    proof_for_target
-                }
-            };
-
-            if let Some(conn_info) = self.chain.get_member_connection_info(&pub_id).cloned() {
-                let message =
-                    DirectMessage::Relocate(SignedRelocateDetails::new(details, proof, signature));
-                self.send_direct_message(&conn_info, message);
+            if proof_for_source.blocks_len() > proof_for_target.blocks_len() {
+                proof_for_source
+            } else {
+                proof_for_target
             }
-        }
+        };
 
-        self.chain.remove_member(&pub_id);
+        if let Some(conn_info) = self
+            .chain
+            .get_member_connection_info(&details.pub_id)
+            .cloned()
+        {
+            let message =
+                DirectMessage::Relocate(SignedRelocateDetails::new(details, proof, signature));
+            self.send_direct_message(&conn_info, message);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Avoid code duplication when member change between adults and Elders.
Remove comment about NodeAdded/NodeLost now tracked by https://github.com/maidsafe/routing/issues/1950

Also remove dead code now tracked by https://github.com/maidsafe/routing/issues/1953