### PR TITLE
Improve churn tests

### DIFF
--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -137,14 +137,7 @@ fn count_nodes_by_section(nodes: &[TestNode]) -> HashMap<Prefix<XorName>, Sectio
 }
 
 /// Adds node per existing prefix using a random proxy. Returns new node indices.
-/// skip_some_prefixes: skip adding to prefixes randomly to allowing sections to merge
-/// when this is executed in the same iteration as `drop_random_nodes`.
-fn add_nodes<R: Rng>(
-    rng: &mut R,
-    network: &Network,
-    nodes: &mut Vec<TestNode>,
-    skip_some_prefixes: bool,
-) -> BTreeSet<usize> {
+fn add_nodes<R: Rng>(rng: &mut R, network: &Network, nodes: &mut Vec<TestNode>) -> BTreeSet<usize> {
     let mut prefixes: BTreeSet<_> = nodes
         .iter()
         .filter_map(|node| node.inner.our_prefix())
@@ -165,9 +158,6 @@ fn add_nodes<R: Rng>(
             .create();
         if let Some(&pfx) = prefixes.iter().find(|pfx| pfx.matches(&node.name())) {
             assert!(prefixes.remove(&pfx));
-            if skip_some_prefixes && !rng.gen_weighted_bool(prefixes.len() as u32) {
-                continue;
-            }
             added_nodes.push(node);
         }
     }
@@ -236,23 +226,22 @@ fn shuffle_nodes<R: Rng>(rng: &mut R, nodes: &mut Vec<TestNode>) {
 fn add_nodes_and_poll<R: Rng>(
     rng: &mut R,
     network: &Network,
-    mut nodes: &mut Vec<TestNode>,
-    allow_add_failure: bool,
+    nodes: &mut Vec<TestNode>,
 ) -> BTreeSet<XorName> {
-    let new_indices = add_nodes(rng, &network, nodes, allow_add_failure);
-    poll_and_resend(&mut nodes);
+    let new_indices = add_nodes(rng, &network, nodes);
+    poll_and_resend(nodes);
     let (added_names, failed_indices) = check_added_indices(nodes, new_indices);
 
-    if !allow_add_failure && !failed_indices.is_empty() {
-        panic!("Unable to add new nodes. {} failed.", failed_indices.len());
-    }
+    assert!(
+        failed_indices.is_empty(),
+        "Unable to add new nodes: {}",
+        failed_indices
+            .iter()
+            .map(|index| nodes[*index].name())
+            .format(", ")
+    );
 
-    // Drop failed_indices and poll remaining nodes to clear pending states.
-    for index in failed_indices.into_iter().rev() {
-        drop(nodes.remove(index));
-    }
-
-    poll_and_resend(&mut nodes);
+    poll_and_resend(nodes);
     shuffle_nodes(rng, nodes);
 
     added_names
@@ -273,7 +262,7 @@ fn random_churn<R: Rng>(
 
     let section_count = count_sections(nodes);
     if section_count < max_prefixes_len {
-        return add_nodes(rng, &network, nodes, false);
+        return add_nodes(rng, &network, nodes);
     }
 
     // Use elder_size rather than section size to prevent collapsing any groups.
@@ -510,7 +499,7 @@ fn aggressive_churn() {
 
     // Add nodes to trigger splits.
     while count_sections(&nodes) < target_section_num || nodes.len() < target_network_size {
-        let added = add_nodes_and_poll(&mut rng, &network, &mut nodes, false);
+        let added = add_nodes_and_poll(&mut rng, &network, &mut nodes);
         if !added.is_empty() {
             warn!("Added {:?}. Total: {}", added, nodes.len());
         } else {
@@ -535,7 +524,7 @@ fn aggressive_churn() {
         // making the 1/3rd calculation in drop_random_nodes incorrect for the split pfx when we poll.
         let max_drop = 1;
         let dropped = drop_random_nodes(&mut rng, &mut nodes, Some(max_drop));
-        let added = add_nodes_and_poll(&mut rng, &network, &mut nodes, true);
+        let added = add_nodes_and_poll(&mut rng, &network, &mut nodes);
         warn!("Simultaneously added {:?} and dropped {:?}", added, dropped);
 
         verify_invariant_for_all_nodes(&network, &mut nodes);

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -126,7 +126,7 @@ struct Params {
     grow_target_section_num: usize,
     // Maximum number of iterations for the churn phase.
     churn_max_iterations: usize,
-    // Probability that churn occurs for each iteration of the churn phase.
+    // Probability that any churn occurs for each iteration of the churn phase.
     churn_probability: f64,
     // During the churn phase, if the number of sections is more than this number, no more nodes
     // are added, only dropped.
@@ -538,6 +538,8 @@ struct Expectations {
     messages: HashSet<MessageKey>,
     /// The section or section members of receiving groups or sections, at the time of sending.
     sections: HashMap<Authority<XorName>, HashSet<XorName>>,
+    /// Helper to build the map of new names to old names by which we can track even relocated
+    /// nodes.
     relocation_map_builder: RelocationMapBuilder,
 }
 

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -244,15 +244,15 @@ fn random_churn<R: Rng>(
     rng: &mut R,
     network: &Network,
     nodes: &mut Vec<TestNode>,
-    max_prefixes_len: usize,
+    churn_probability: f64,
+    max_section_num: usize,
 ) -> BTreeSet<usize> {
-    // 20% chance to not churn.
-    if rng.gen_weighted_bool(5) {
+    if rng.gen_range(0.0, 1.0) > churn_probability {
         return BTreeSet::new();
     }
 
     let section_count = count_sections(nodes);
-    if section_count < max_prefixes_len {
+    if section_count < max_section_num {
         return add_nodes(rng, &network, nodes);
     }
 
@@ -497,10 +497,27 @@ impl RelocationMapBuilder {
 
 #[test]
 fn aggressive_churn() {
+    // Network params
     let elder_size = 4;
     let safe_section_size = 4;
-    let target_section_num = 5;
-    let target_network_size = 35;
+
+    // The test runs in three phases:
+    // 1. In the grow phase nodes are only added.
+    // 2. In the churn phase nodes are added and removed
+    // 3. In the shrink phase nodes are only dropped
+
+    // Parameters for the grow phase. When the network reaches at least `grow_target_section_num`
+    // sections and `grow_target_network_size` nodes, the grow phase ends.
+    let grow_target_section_num = 5;
+    let grow_target_network_size = 35;
+
+    // Parameters for the churn phase. When the number of nodes drops below `churn_min_network_size`
+    // of the number of iterations exceeds `churn_max_iterations`, the churn phase ends.
+    let churn_min_network_size = grow_target_network_size / 2;
+    let churn_max_iterations = 15;
+
+    // There are no parameters for the shrink phase - it ends when no more nodes can be dropped.
+
     let network = Network::new(NetworkParams {
         elder_size,
         safe_section_size,
@@ -518,7 +535,8 @@ fn aggressive_churn() {
     );
 
     // Add nodes to trigger splits.
-    while count_sections(&nodes) < target_section_num || nodes.len() < target_network_size {
+    while count_sections(&nodes) < grow_target_section_num || nodes.len() < grow_target_network_size
+    {
         let added = add_nodes_and_poll(&mut rng, &network, &mut nodes);
         if !added.is_empty() {
             warn!("Added {:?}. Total: {}", added, nodes.len());
@@ -536,12 +554,13 @@ fn aggressive_churn() {
         nodes.len(),
         count_sections(&nodes)
     );
-    let mut count = 0;
-    while nodes.len() > target_network_size / 2 && count < 15 {
-        count += 1;
+    let mut iteration = 0;
+    while nodes.len() > churn_min_network_size && iteration < churn_max_iterations {
+        iteration += 1;
 
         // Only max drop a node per pfx as the node added in this iteration could split a pfx
         // making the 1/3rd calculation in drop_random_nodes incorrect for the split pfx when we poll.
+        // TODO: verify this is still needed.
         let max_drop = 1;
         let dropped = drop_random_nodes(&mut rng, &mut nodes, Some(max_drop));
         let added = add_nodes_and_poll(&mut rng, &network, &mut nodes);
@@ -588,24 +607,40 @@ fn aggressive_churn() {
 
 #[test]
 fn messages_during_churn() {
+    // Network params
     let elder_size = 4;
     let safe_section_size = 4;
+
+    // The network starts with sections whose prefixes have these lengths.
+    let initial_prefix_lens = vec![2, 2, 2, 3, 3];
+    // Probability of churn in each iteration.
+    let churn_probability = 0.8;
+    // If the number of section in the network reaches this number, no new nodes will be added.
+    let max_section_num = initial_prefix_lens.len() * 2;
+    // How many iterations will the test run for.
+    let max_iterations = 50;
+
     let network = Network::new(NetworkParams {
         elder_size,
         safe_section_size,
     });
     let mut rng = network.new_rng();
-    let prefixes = vec![2, 2, 2, 3, 3];
-    let max_prefixes_len = prefixes.len() * 2;
-    let mut nodes = create_connected_nodes_until_split(&network, prefixes);
+    let mut nodes = create_connected_nodes_until_split(&network, initial_prefix_lens);
 
-    for i in 0..50 {
+    for i in 0..max_iterations {
         warn!(
-            "Iteration {}. Prefixes: {{{:?}}}",
+            "Iteration {}/{}. Prefixes: {{{:?}}}",
             i,
+            max_iterations,
             current_sections(&nodes).format(", ")
         );
-        let new_indices = random_churn(&mut rng, &network, &mut nodes, max_prefixes_len);
+        let new_indices = random_churn(
+            &mut rng,
+            &network,
+            &mut nodes,
+            churn_probability,
+            max_section_num,
+        );
         let relocation_map = RelocationMapBuilder::new(&nodes);
         let expectations = setup_expectations(&mut rng, &mut nodes, elder_size);
 

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -182,22 +182,21 @@ fn add_nodes<R: Rng>(rng: &mut R, network: &Network, nodes: &mut Vec<TestNode>) 
 }
 
 /// Checks if the given indices have been accepted to the network.
-/// Returns the names of added nodes and indices of failed nodes.
+/// Returns the names of added nodes.
 fn check_added_indices(
     nodes: &mut Vec<TestNode>,
     new_indices: BTreeSet<usize>,
-) -> (BTreeSet<XorName>, Vec<usize>) {
+) -> BTreeSet<XorName> {
     let mut added = BTreeSet::new();
     let mut failed = Vec::new();
-    for (index, node) in nodes.iter_mut().enumerate() {
-        if !new_indices.contains(&index) {
-            continue;
-        }
+
+    for index in new_indices {
+        let node = &mut nodes[index];
 
         loop {
             match node.inner.try_next_ev() {
                 Err(_) => {
-                    failed.push(index);
+                    failed.push(node.name());
                     break;
                 }
                 Ok(Event::Connected(_)) => {
@@ -209,7 +208,9 @@ fn check_added_indices(
         }
     }
 
-    (added, failed)
+    assert!(failed.is_empty(), "Unable to add new nodes: {:?}", failed);
+
+    added
 }
 
 // Shuffle nodes excluding the first node
@@ -230,17 +231,7 @@ fn add_nodes_and_poll<R: Rng>(
 ) -> BTreeSet<XorName> {
     let new_indices = add_nodes(rng, &network, nodes);
     poll_and_resend(nodes);
-    let (added_names, failed_indices) = check_added_indices(nodes, new_indices);
-
-    assert!(
-        failed_indices.is_empty(),
-        "Unable to add new nodes: {}",
-        failed_indices
-            .iter()
-            .map(|index| nodes[*index].name())
-            .format(", ")
-    );
-
+    let added_names = check_added_indices(nodes, new_indices);
     poll_and_resend(nodes);
     shuffle_nodes(rng, nodes);
 
@@ -438,7 +429,11 @@ impl Expectations {
     }
 }
 
-fn send_and_receive<R: Rng>(rng: &mut R, nodes: &mut [TestNode], elder_size: usize) {
+fn setup_expectations<R: Rng>(
+    rng: &mut R,
+    nodes: &mut [TestNode],
+    elder_size: usize,
+) -> Expectations {
     // Create random content and pick random sending and receiving nodes.
     let content: Vec<_> = rng.gen_iter().take(100).collect();
     let index0 = gen_elder_index(rng, nodes);
@@ -470,9 +465,34 @@ fn send_and_receive<R: Rng>(rng: &mut R, nodes: &mut [TestNode], elder_size: usi
     expectations.send_and_expect(&content, auth_s0, auth_g0, nodes, elder_size);
     expectations.send_and_expect(&content, auth_s0, auth_n0, nodes, elder_size);
 
-    poll_and_resend(nodes);
+    expectations
+}
 
+fn send_and_receive<R: Rng>(rng: &mut R, nodes: &mut [TestNode], elder_size: usize) {
+    let expectations = setup_expectations(rng, nodes, elder_size);
+    poll_and_resend(nodes);
     expectations.verify(nodes, &Default::default());
+}
+
+// Helper to build a map of new names to old names.
+struct RelocationMapBuilder {
+    initial_names: Vec<XorName>,
+}
+
+impl RelocationMapBuilder {
+    fn new(nodes: &[TestNode]) -> Self {
+        let initial_names = nodes.iter().map(|node| node.name()).collect();
+        Self { initial_names }
+    }
+
+    fn build(self, nodes: &[TestNode]) -> BTreeMap<XorName, XorName> {
+        nodes
+            .iter()
+            .zip(self.initial_names)
+            .map(|(node, old_name)| (node.name(), old_name))
+            .filter(|(new_name, old_name)| old_name != new_name)
+            .collect()
+    }
 }
 
 #[test]
@@ -586,62 +606,21 @@ fn messages_during_churn() {
             current_sections(&nodes).format(", ")
         );
         let new_indices = random_churn(&mut rng, &network, &mut nodes, max_prefixes_len);
-
-        // Create random data and pick random sending and receiving nodes.
-        let content: Vec<_> = rng.gen_iter().take(100).collect();
-        let index0 = gen_elder_index(&mut rng, &nodes);
-        let index1 = gen_elder_index(&mut rng, &nodes);
-        let auth_n0 = Authority::Node(nodes[index0].name());
-        let auth_n1 = Authority::Node(nodes[index1].name());
-        let auth_g0 = Authority::Section(rng.gen());
-        let auth_g1 = Authority::Section(rng.gen());
-        let section_name: XorName = rng.gen();
-        let auth_s0 = Authority::Section(section_name);
-        // this makes sure we have two different sections if there exists more than one
-        let auth_s1 = Authority::Section(!section_name);
-
-        let mut expectations = Expectations::default();
-        let initial_names = nodes.iter().map(|node| node.name()).collect_vec();
-
-        // Test messages from a node to itself, another node, a group and a section...
-        expectations.send_and_expect(&content, auth_n0, auth_n0, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_n0, auth_n1, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_n0, auth_g0, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_n0, auth_s0, &mut nodes, elder_size);
-        // ... and from a group to itself, another group, a section and a node...
-        expectations.send_and_expect(&content, auth_g0, auth_g0, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_g0, auth_g1, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_g0, auth_s0, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_g0, auth_n0, &mut nodes, elder_size);
-        // ... and from a section to itself, another section, a group and a node...
-        expectations.send_and_expect(&content, auth_s0, auth_s0, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_s0, auth_s1, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_s0, auth_g0, &mut nodes, elder_size);
-        expectations.send_and_expect(&content, auth_s0, auth_n0, &mut nodes, elder_size);
+        let relocation_map = RelocationMapBuilder::new(&nodes);
+        let expectations = setup_expectations(&mut rng, &mut nodes, elder_size);
 
         poll_and_resend(&mut nodes);
-        let new_to_old_map: BTreeMap<XorName, XorName> = nodes
-            .iter()
-            .zip(initial_names.iter())
-            .map(|(node, old_name)| (node.name(), *old_name))
-            .filter(|(new_name, old_name)| old_name != new_name)
-            .collect();
 
-        let (added_names, failed_indices) = check_added_indices(&mut nodes, new_indices);
-        assert!(
-            failed_indices.is_empty(),
-            "Non-empty set of failed nodes! Failed nodes: {:?}",
-            failed_indices
-                .into_iter()
-                .map(|idx| nodes[idx].name())
-                .collect::<Vec<_>>()
-        );
-        shuffle_nodes(&mut rng, &mut nodes);
+        let relocation_map = relocation_map.build(&nodes);
 
+        let added_names = check_added_indices(&mut nodes, new_indices);
         if !added_names.is_empty() {
             warn!("Added nodes: {:?}", added_names);
         }
-        expectations.verify(&mut nodes, &new_to_old_map);
+
+        shuffle_nodes(&mut rng, &mut nodes);
+
+        expectations.verify(&mut nodes, &relocation_map);
         verify_invariant_for_all_nodes(&network, &mut nodes);
     }
 }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -28,7 +28,7 @@ fn aggressive_churn() {
     churn(Params {
         message_schedule: MessageSchedule::AfterChurn,
         grow_target_section_num: 5,
-        churn_max_iterations: 15,
+        churn_max_iterations: 20,
         ..Default::default()
     });
 }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -14,8 +14,9 @@ use itertools::Itertools;
 use rand::Rng;
 use routing::{
     mock::Network,
+    rng::MainRng,
     test_consts::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW},
-    Authority, Event, EventStream, NetworkConfig, NetworkParams, Prefix, XorName,
+    Authority, Event, EventStream, FullId, NetworkConfig, NetworkParams, Prefix, XorName,
     QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
 };
 use std::{
@@ -42,6 +43,7 @@ fn messages_during_churn() {
         churn_probability: 0.8,
         churn_max_section_num: 10,
         churn_max_iterations: 50,
+        shrink_drop_probability: 0.0,
         ..Default::default()
     });
 }
@@ -111,6 +113,8 @@ fn remove_unresponsive_node() {
 // 1. In the grow phase nodes are only added.
 // 2. In the churn phase nodes are added and removed
 // 3. In the shrink phase nodes are only dropped
+//
+// Note: probabilities are expressed as a number in the 0..1 interval, e.g. 80% == 0.8.
 struct Params {
     // Network params
     network: NetworkParams,
@@ -119,20 +123,28 @@ struct Params {
     initial_prefix_lens: Vec<usize>,
     // When are messages sent during each iteration.
     message_schedule: MessageSchedule,
-    // Probability that a node is dropped during a single iteration of the churn and shrink phases
-    // (evaluated per each node).
-    drop_probability: f64,
+    // Probability that a node is added to a section during a single iteration of the grow phase.
+    // Evaluated per each section.
+    grow_add_probability: f64,
     // The grow phase lasts until the number of sections reaches this number.
     grow_target_section_num: usize,
     // Maximum number of iterations for the churn phase.
     churn_max_iterations: usize,
-    // Probability that any churn occurs for each iteration of the churn phase.
+    // Probability that any churn occurs for each iteration of the churn phase. Evaluated once per
+    // iteration.
     churn_probability: f64,
+    // Probability that a node is added to a section during a single iteration of the churn phases.
+    // Evaluated per each section.
+    churn_add_probability: f64,
+    // Probability that a node is dropped during a single iteration of the churn phase.
+    // Evaluated per each node.
+    churn_drop_probability: f64,
     // During the churn phase, if the number of sections is more than this number, no more nodes
     // are added, only dropped.
     churn_max_section_num: usize,
-    // If true, the shrink phase is performed, otherwise it is skipped.
-    shrink: bool,
+    // Probability that a node is dropped during a single iteration of the shrink phase.
+    // Evaluated per each node. If zero, the shrink phase is skipped.
+    shrink_drop_probability: f64,
 }
 
 impl Default for Params {
@@ -144,12 +156,14 @@ impl Default for Params {
             },
             initial_prefix_lens: vec![],
             message_schedule: MessageSchedule::AfterChurn,
-            drop_probability: 0.1,
+            grow_add_probability: 1.0,
             grow_target_section_num: 5,
             churn_max_iterations: 20,
             churn_probability: 1.0,
+            churn_add_probability: 0.2,
+            churn_drop_probability: 0.1,
             churn_max_section_num: usize::MAX,
-            shrink: false,
+            shrink_drop_probability: 0.1,
         }
     }
 }
@@ -183,7 +197,7 @@ fn churn(params: Params) {
             break;
         }
 
-        let added_indices = add_nodes(&mut rng, &network, &mut nodes);
+        let added_indices = add_nodes(&mut rng, &network, &mut nodes, params.grow_add_probability);
         progress_and_verify(
             &mut rng,
             &network,
@@ -205,15 +219,20 @@ fn churn(params: Params) {
     for i in 0..params.churn_max_iterations {
         warn!("Iteration {}/{}", i, params.churn_max_iterations);
 
-        let (added_indices, dropped_names) = random_churn(
-            &mut rng,
-            &network,
-            &mut nodes,
-            params.churn_probability,
-            params.drop_probability,
-            params.grow_target_section_num,
-            params.churn_max_section_num,
-        );
+        let (added_indices, dropped_names) = if rng.gen_range(0.0, 1.0) < params.churn_probability {
+            random_churn(
+                &mut rng,
+                &network,
+                &mut nodes,
+                params.churn_add_probability,
+                params.churn_drop_probability,
+                params.grow_target_section_num,
+                params.churn_max_section_num,
+            )
+        } else {
+            (BTreeSet::new(), BTreeSet::new())
+        };
+
         progress_and_verify(
             &mut rng,
             &network,
@@ -232,14 +251,15 @@ fn churn(params: Params) {
     //
     // Shrink phase - dropping nodes
     //
-    if params.shrink {
+    if params.shrink_drop_probability > 0.0 {
         warn!(
             "Churn [{} nodes, {} sections]: dropping nodes",
             nodes.len(),
             count_sections(&nodes)
         );
         loop {
-            let dropped_names = drop_random_nodes(&mut rng, &mut nodes, params.drop_probability);
+            let dropped_names =
+                drop_random_nodes(&mut rng, &mut nodes, params.shrink_drop_probability);
             if dropped_names.is_empty() {
                 break;
             }
@@ -371,30 +391,33 @@ fn count_nodes_by_section(nodes: &[TestNode]) -> HashMap<Prefix<XorName>, Sectio
     output
 }
 
-/// Adds node per existing prefix using a random proxy. Returns new node indices.
-fn add_nodes<R: Rng>(rng: &mut R, network: &Network, nodes: &mut Vec<TestNode>) -> BTreeSet<usize> {
-    let mut prefixes: BTreeSet<_> = nodes
-        .iter()
-        .filter_map(|node| node.inner.our_prefix())
-        .copied()
-        .collect();
-
+/// Adds node per existing prefix with the given probability. Returns new node indices.
+fn add_nodes(
+    rng: &mut MainRng,
+    network: &Network,
+    nodes: &mut Vec<TestNode>,
+    add_probability: f64,
+) -> BTreeSet<usize> {
     let mut added_nodes = Vec::new();
-    while !prefixes.is_empty() {
-        let proxy_index = if nodes.len() > unwrap!(nodes[0].inner.elder_size()) {
+    let prefixes: Vec<_> = current_sections(nodes).collect();
+
+    for prefix in prefixes {
+        if rng.gen_range(0.0, 1.0) >= add_probability {
+            continue;
+        }
+
+        let bootstrap_index = if nodes.len() > unwrap!(nodes[0].inner.elder_size()) {
             gen_elder_index(rng, nodes)
         } else {
             0
         };
         let network_config =
-            NetworkConfig::node().with_hard_coded_contact(nodes[proxy_index].endpoint());
+            NetworkConfig::node().with_hard_coded_contact(nodes[bootstrap_index].endpoint());
         let node = TestNode::builder(network)
             .network_config(network_config)
+            .full_id(FullId::within_range(rng, &prefix.range_inclusive()))
             .create();
-        if let Some(&pfx) = prefixes.iter().find(|pfx| pfx.matches(&node.name())) {
-            assert!(prefixes.remove(&pfx));
-            added_nodes.push(node);
-        }
+        added_nodes.push(node);
     }
 
     let mut min_index = 1;
@@ -445,21 +468,16 @@ fn shuffle_nodes<R: Rng>(rng: &mut R, nodes: &mut [TestNode]) {
 
 // Churns the given network randomly. Returns any newly added indices and the
 // dropped node names.
-// If introducing churn, would either drop/add nodes in each prefix.
-fn random_churn<R: Rng>(
-    rng: &mut R,
+fn random_churn(
+    rng: &mut MainRng,
     network: &Network,
     nodes: &mut Vec<TestNode>,
-    churn_probability: f64,
+    add_probability: f64,
     drop_probability: f64,
     min_section_num: usize,
     max_section_num: usize,
 ) -> (BTreeSet<usize>, BTreeSet<XorName>) {
     assert!(min_section_num <= max_section_num);
-
-    if rng.gen_range(0.0, 1.0) > churn_probability {
-        return (BTreeSet::new(), BTreeSet::new());
-    }
 
     let section_num = count_sections(nodes);
 
@@ -470,7 +488,7 @@ fn random_churn<R: Rng>(
     };
 
     let added_indices = if section_num < max_section_num {
-        add_nodes(rng, &network, nodes)
+        add_nodes(rng, &network, nodes, add_probability)
     } else {
         BTreeSet::new()
     };

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -28,14 +28,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 /// conservative and might change in the future, but it still allows removing at least one node per
 /// section.
 ///
-/// If `max_drops_per_section` is set, never drops more than that number of nodes per section.
-///
 /// Note: it's necessary to call `poll_all` afterwards, as this function doesn't call it itself.
-fn drop_random_nodes<R: Rng>(
-    rng: &mut R,
-    nodes: &mut Vec<TestNode>,
-    max_drops_per_section: Option<usize>,
-) -> BTreeSet<XorName> {
+fn drop_random_nodes<R: Rng>(rng: &mut R, nodes: &mut Vec<TestNode>) -> BTreeSet<XorName> {
     // 10% probability that a node will be dropped.
     let drop_probability = 0.1;
 
@@ -50,13 +44,6 @@ fn drop_random_nodes<R: Rng>(
 
         let elder_size = unwrap!(node.inner.elder_size());
         let section = unwrap!(sections.get_mut(node.our_prefix()));
-
-        // Check the optional additional drop limit.
-        if let Some(max_drops) = max_drops_per_section {
-            if section.all_dropped() >= max_drops {
-                continue;
-            }
-        }
 
         // Don't drop any other node if an elder is already scheduled for drop.
         if section.dropped_elder_count > 0 {
@@ -256,12 +243,7 @@ fn random_churn<R: Rng>(
         return add_nodes(rng, &network, nodes);
     }
 
-    // Use elder_size rather than section size to prevent collapsing any groups.
-    let max_drop = (unwrap!(nodes[0].inner.elder_size()) - 1)
-        * (QUORUM_DENOMINATOR - QUORUM_NUMERATOR)
-        / QUORUM_DENOMINATOR;
-    assert!(max_drop > 0);
-    let dropped_nodes = drop_random_nodes(rng, nodes, Some(max_drop));
+    let dropped_nodes = drop_random_nodes(rng, nodes);
     warn!("Dropping nodes: {:?}", dropped_nodes);
     BTreeSet::new()
 }
@@ -558,11 +540,7 @@ fn aggressive_churn() {
     while nodes.len() > churn_min_network_size && iteration < churn_max_iterations {
         iteration += 1;
 
-        // Only max drop a node per pfx as the node added in this iteration could split a pfx
-        // making the 1/3rd calculation in drop_random_nodes incorrect for the split pfx when we poll.
-        // TODO: verify this is still needed.
-        let max_drop = 1;
-        let dropped = drop_random_nodes(&mut rng, &mut nodes, Some(max_drop));
+        let dropped = drop_random_nodes(&mut rng, &mut nodes);
         let added = add_nodes_and_poll(&mut rng, &network, &mut nodes);
         warn!("Simultaneously added {:?} and dropped {:?}", added, dropped);
 
@@ -582,7 +560,7 @@ fn aggressive_churn() {
         count_sections(&nodes)
     );
     loop {
-        let dropped_nodes = drop_random_nodes(&mut rng, &mut nodes, None);
+        let dropped_nodes = drop_random_nodes(&mut rng, &mut nodes);
         if dropped_nodes.is_empty() {
             break;
         }

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -397,13 +397,6 @@ fn add_nodes<R: Rng>(rng: &mut R, network: &Network, nodes: &mut Vec<TestNode>) 
         }
     }
 
-    if !added_nodes.is_empty() {
-        warn!(
-            "    adding {{{}}}",
-            added_nodes.iter().map(|node| node.name()).format(", ")
-        );
-    }
-
     let mut min_index = 1;
     let mut added_indices = BTreeSet::new();
     for added_node in added_nodes {
@@ -493,10 +486,6 @@ fn progress_and_verify<R: Rng>(
     added_indices: BTreeSet<usize>,
     dropped_names: BTreeSet<XorName>,
 ) {
-    if !dropped_names.is_empty() {
-        warn!("Dropping {:?}", dropped_names);
-    }
-
     let expectations = match message_schedule {
         MessageSchedule::AfterChurn => {
             poll_after_churn(nodes, added_indices, dropped_names);
@@ -521,21 +510,19 @@ fn poll_after_churn(
     added_indices: BTreeSet<usize>,
     dropped_names: BTreeSet<XorName>,
 ) {
+    trace!(
+        "Adding {{{:?}}}, dropping {:?}",
+        added_indices
+            .iter()
+            .map(|index| nodes[*index].name())
+            .format(", "),
+        dropped_names
+    );
+
     poll_and_resend(nodes);
     let added_names = check_added_indices(nodes, added_indices);
 
-    if !added_names.is_empty() {
-        if !dropped_names.is_empty() {
-            warn!(
-                "Simultaneously added {:?} and dropped {:?}",
-                added_names, dropped_names
-            );
-        } else {
-            warn!("Added {:?}, dropped none", added_names);
-        }
-    } else if !dropped_names.is_empty() {
-        warn!("Added none, dropped {:?}", dropped_names);
-    }
+    warn!("Added {:?}, dropped {:?}", added_names, dropped_names);
 }
 
 #[derive(Eq, PartialEq, Hash, Debug)]


### PR DESCRIPTION
This PR improves and refactors the churn tests.

- Remove code duplication and increase code reuse
- Extract parameters to allow more configurability of the churn tests
- Make the churn tests more strict 
- Increase the number of iterations to make it more likely that interesting cases are hit
