### PR TITLE
Re-enable drops in churn tests

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -661,6 +661,12 @@ impl Chain {
         self.state.split_in_progress
     }
 
+    /// Returns whether a membership change is in progress (a node leaving, joining or being
+    /// relocated).
+    pub fn membership_change_in_progress(&self) -> bool {
+        self.churn_in_progress || self.relocation_in_progress
+    }
+
     /// Neighbour infos signed by our section
     pub fn neighbour_infos(&self) -> impl Iterator<Item = &EldersInfo> {
         self.state.neighbour_infos.values()
@@ -901,11 +907,6 @@ impl Chain {
     pub fn check_vote_status(&mut self) -> BTreeSet<PublicId> {
         let members = self.our_info().member_ids();
         self.chain_accumulator.check_vote_status(members)
-    }
-
-    /// Returns whether a churning is in progress.
-    pub fn is_churn_in_progress(&self) -> bool {
-        self.churn_in_progress
     }
 
     /// Returns `true` if the given `NetworkEvent` is already accumulated and can be skipped.

--- a/src/chain/elders_info.rs
+++ b/src/chain/elders_info.rs
@@ -178,9 +178,9 @@ impl Debug for EldersInfo {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "EldersInfo(prefix: {:?}, members: {:?}, prev_hash_len: {}, version: {})",
+            "EldersInfo(prefix: {:?}, members: {{{:?}}}, prev_hash_len: {}, version: {})",
             self.prefix,
-            self.members,
+            self.member_nodes().format(", "),
             self.prev_hash.len(),
             self.version
         )

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -394,16 +394,6 @@ impl SharedState {
     /// Returns the index of the public key in our_history that will be trusted by the target
     /// Authority
     pub fn proving_index(&self, target: &Authority<XorName>) -> u64 {
-        if let Authority::Node(name) = target {
-            if let Some(info) = self.our_members.get(name) {
-                if let MemberState::Relocating { node_knowledge } = info.state {
-                    // Relocating node, or adult nodes need to be special cased:
-                    // Use the proving index we last know for them.
-                    return node_knowledge;
-                }
-            }
-        }
-
         let (prefix, &index) = if let Some(pair) = self
             .their_knowledge
             .iter()

--- a/src/node.rs
+++ b/src/node.rs
@@ -490,7 +490,7 @@ impl Node {
     /// Provide a SectionProofChain that proves the given signature to the section with a given
     /// prefix
     pub fn prove(&self, target: &Authority<XorName>) -> Option<SectionProofChain> {
-        self.chain().map(|chain| chain.prove(target))
+        self.chain().map(|chain| chain.prove(target, None))
     }
 
     /// Checks whether the given authority represents self.

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -681,6 +681,7 @@ impl Approved for Adult {
         &mut self,
         _details: RelocateDetails,
         _signature: BlsSignature,
+        _node_knowledge: u64,
         _outbox: &mut dyn EventBox,
     ) {
     }

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -682,8 +682,7 @@ impl Approved for Adult {
         _details: RelocateDetails,
         _signature: BlsSignature,
         _outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        Ok(())
+    ) {
     }
 
     fn handle_dkg_result_event(

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -9,8 +9,8 @@
 use super::Base;
 use crate::{
     chain::{
-        AccumulatedEvent, AccumulatingEvent, Chain, EldersChange, EldersInfo, OnlinePayload,
-        PollAccumulated, Proof, ProofSet, SectionKeyInfo, SendAckMessagePayload,
+        AccumulatedEvent, AccumulatingEvent, Chain, EldersChange, EldersInfo, MemberState,
+        OnlinePayload, PollAccumulated, Proof, ProofSet, SectionKeyInfo, SendAckMessagePayload,
     },
     error::RoutingError,
     event::Event,
@@ -65,6 +65,7 @@ pub trait Approved: Base {
         &mut self,
         payload: RelocateDetails,
         signature: BlsSignature,
+        node_knowledge: u64,
         outbox: &mut dyn EventBox,
     );
 
@@ -468,7 +469,7 @@ pub trait Approved: Base {
             info!("{} - handle Offline: {}.", self, pub_id);
 
             self.chain_mut().increment_age_counters(&pub_id);
-            self.chain_mut().remove_member(&pub_id);
+            let _ = self.chain_mut().remove_member(&pub_id);
             self.disconnect_by_id_lookup(&pub_id);
             self.handle_member_removed(pub_id, outbox)?;
         }
@@ -506,12 +507,20 @@ pub trait Approved: Base {
         } else {
             info!("{} - handle Relocate: {:?}.", self, details);
 
-            // Note: it is important that `handle_member_relocated` is called before the member is
-            // actually removed. This is because the member info of the relocated node might still
-            // be needed by `handle_member_relocated`.
-            let pub_id = details.pub_id;
-            self.handle_member_relocated(details, signature, outbox);
-            self.chain_mut().remove_member(&pub_id);
+            match self.chain_mut().remove_member(&details.pub_id) {
+                MemberState::Relocating { node_knowledge } => {
+                    self.handle_member_relocated(details, signature, node_knowledge, outbox);
+                }
+                state => {
+                    log_or_panic!(
+                        LogLevel::Error,
+                        "{} - Expected the state of {} to be Relocating, but was {:?}",
+                        self,
+                        details.pub_id,
+                        state,
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1637,10 +1637,10 @@ impl Approved for Elder {
         details: RelocateDetails,
         signature: BlsSignature,
         _outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
+    ) {
         if &details.pub_id == self.id() {
             // Do not send the message to ourselves.
-            return Ok(());
+            return;
         }
 
         // We need proof that is valid for both the relocating node and the target section. To
@@ -1668,8 +1668,6 @@ impl Approved for Elder {
                 DirectMessage::Relocate(SignedRelocateDetails::new(details, proof, signature));
             self.send_direct_message(&conn_info, message);
         }
-
-        Ok(())
     }
 
     fn handle_dkg_result_event(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1700,14 +1700,15 @@ impl Approved for Elder {
             );
             return Ok(());
         }
-        if self.chain.is_churn_in_progress() {
-            debug!(
-                "{} - Trying to carry out parsec pruning during churning.",
+        if self.chain.membership_change_in_progress() {
+            trace!(
+                "{} - ignore ParsecPrune - membership change in progress.",
                 self
             );
             return Ok(());
         }
-        info!("{} - handle parsec prune.", self);
+
+        info!("{} - handle ParsecPrune", self);
         let complete_data = self.prepare_reset_parsec()?;
         self.reset_parsec_with_data(complete_data.gen_pfx_info, complete_data.to_vote_again)?;
         self.send_genesis_updates();

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -20,11 +20,15 @@ use routing::{
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-/// Randomly removes some nodes, but <1/3 from each section and never node 0.
-/// Never trigger merge: never remove enough nodes to drop to `elder_size`.
-/// max_per_pfx: limits dropping to the specified count per pfx. It would also
-/// skip prefixes randomly allowing sections to split if this is executed in the same
-/// iteration as `add_nodes_and_poll`.
+/// Randomly removes some nodes.
+///
+/// Limits the number of nodes simultaneously dropped from a section such that the section still
+/// remains functional (capable of reaching consensus), also accounting for the fact that any
+/// dropped node might trigger relocation of other nodes. This limit is currently possibly too
+/// conservative and might change in the future, but it still allows removing at least one node per
+/// section.
+///
+/// If `max_per_pfx` is set, never drops more than that number of nodes per section.
 ///
 /// Note: it's necessary to call `poll_all` afterwards, as this function doesn't call it itself.
 fn drop_random_nodes<R: Rng>(
@@ -32,53 +36,91 @@ fn drop_random_nodes<R: Rng>(
     nodes: &mut Vec<TestNode>,
     max_per_pfx: Option<usize>,
 ) -> BTreeSet<XorName> {
-    let mut dropped_nodes = BTreeSet::new();
-    let elder_size = |node: &TestNode| unwrap!(node.inner.elder_size());
-    let node_section_size = |node: &TestNode| {
-        node.inner
-            .section_elders(unwrap!(node.inner.our_prefix(), "{}", node.inner))
-            .len()
+    #[derive(Default)]
+    struct SectionInfo {
+        initial_elder_count: usize,
+        initial_other_count: usize,
+        dropped_elder_count: usize,
+        dropped_other_count: usize,
     };
-    let sections: BTreeMap<_, _> = nodes
-        .iter()
-        .map(|node| {
-            let initial_size = node_section_size(node);
-            let min_size = elder_size(node);
-            let max_drop = initial_size.saturating_sub(min_size);
-            (*node.our_prefix(), (initial_size, max_drop))
-        })
-        .collect();
-    let mut drop_count: BTreeMap<_, _> = sections.keys().map(|pfx| (*pfx, 0)).collect();
-    loop {
-        let i = gen_range(rng, 1, nodes.len());
-        let pfx = nodes[i].our_prefix();
-        let (initial_size, max_drop) = sections[&pfx];
-        if drop_count.is_empty() {
-            break;
-        } else if drop_count.get(&pfx).is_none() {
+
+    // 10% probability that a node will be dropped.
+    let drop_probability = 0.1;
+
+    let mut sections = HashMap::<_, SectionInfo>::new();
+    for node in nodes.iter() {
+        let prefix = *node.our_prefix();
+        let info = sections.entry(prefix).or_default();
+        if node.inner.is_elder() {
+            info.initial_elder_count += 1;
+        } else {
+            info.initial_other_count += 1;
+        }
+    }
+
+    let mut dropped_indices = Vec::new();
+    let mut dropped_names = BTreeSet::new();
+
+    for (index, node) in nodes.iter().enumerate() {
+        if rng.gen_range(0.0, 1.0) >= drop_probability {
             continue;
         }
 
-        let early_terminate = max_per_pfx.map_or(false, |n| {
-            drop_count[&pfx] >= n || rng.gen_weighted_bool(drop_count.keys().len() as u32)
-        });
-        let normal_terminate =
-            ((drop_count[&pfx] + 1) * 3 >= initial_size) || (drop_count[&pfx] >= max_drop);
-        if early_terminate || normal_terminate {
-            let _ = drop_count.remove(&pfx);
+        let section = unwrap!(sections.get_mut(node.our_prefix()));
+        let elder_size = unwrap!(node.inner.elder_size());
+        let remaining = section.initial_elder_count + section.initial_other_count
+            - section.dropped_other_count
+            - section.dropped_elder_count;
+        let dropped = section.dropped_elder_count + section.dropped_other_count;
+
+        // Check the optional additional drop limit.
+        if let Some(max_per_pfx) = max_per_pfx {
+            if dropped + 1 > max_per_pfx {
+                continue;
+            }
+        }
+
+        // Don't drop any other node if an elder is already scheduled for drop.
+        if section.dropped_elder_count > 0 {
             continue;
         }
 
-        *unwrap!(drop_count.get_mut(&pfx)) += 1;
-        let dropped = nodes.remove(i);
-        assert!(dropped_nodes.insert(dropped.name()));
+        // Don't drop below elder_size nodes.
+        if remaining <= elder_size {
+            continue;
+        }
+
+        // If there already are other drops scheduled, make sure we remain with at least one
+        // more node above elder_size. This is because one of those other drops might trigger
+        // relocation of one of the existing elders and we wouldn't have anyone to replace it with
+        // otherwise.
+        if dropped > 0 && remaining <= elder_size + 1 {
+            continue;
+        }
+
+        if node.inner.is_elder() {
+            // Don't drop elder if a non-elder is already scheduled for drop.
+            if section.dropped_other_count > 0 {
+                continue;
+            }
+
+            section.dropped_elder_count += 1;
+        } else {
+            section.dropped_other_count += 1;
+        }
+
+        info!("Dropping {}: {}/{}", node.inner, remaining, elder_size);
+
+        dropped_indices.push(index);
     }
 
-    if !dropped_nodes.is_empty() {
-        warn!("    dropping {:?}", dropped_nodes);
+    // Must drop from the end, so the indices are not invalidated.
+    dropped_indices.sort();
+    for index in dropped_indices.into_iter().rev() {
+        assert!(dropped_names.insert(nodes.remove(index).name()));
     }
 
-    dropped_nodes
+    dropped_names
 }
 
 /// Adds node per existing prefix using a random proxy. Returns new node indices.

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -109,8 +109,6 @@ fn drop_random_nodes<R: Rng>(
             section.dropped_other_count += 1;
         }
 
-        info!("Dropping {}: {}/{}", node.inner, remaining, elder_size);
-
         dropped_indices.push(index);
     }
 


### PR DESCRIPTION
This PR fixes an accidental disabling of node drops in the churn tests. That uncovered some issues which this PR also fixes.