### PR TITLE
Only combine valid sigs for accumulated events

### DIFF
--- a/src/chain/chain_accumulator.rs
+++ b/src/chain/chain_accumulator.rs
@@ -228,10 +228,11 @@ impl AccumulatingProof {
         self.sig_shares
     }
 
-    pub fn combine_signatures(
+    pub fn check_and_combine_signatures(
         self,
         elder_info: &EldersInfo,
         pk_set: &BlsPublicKeySet,
+        signed_bytes: &[u8],
     ) -> Option<BlsSignature> {
         let fr_and_shares = elder_info
             .member_ids()
@@ -240,6 +241,11 @@ impl AccumulatingProof {
                 self.sig_shares
                     .get(pub_id)
                     .map(|sig_payload| (index, &sig_payload.sig_share))
+            })
+            .filter(|&(index, sig_share)| {
+                pk_set
+                    .public_key_share(index)
+                    .verify(sig_share, signed_bytes)
             });
         pk_set.combine_signatures(fr_and_shares).ok()
     }

--- a/src/chain/elders_info.rs
+++ b/src/chain/elders_info.rs
@@ -126,8 +126,7 @@ impl EldersInfo {
 
     /// Returns `true` if the proofs are from a quorum of this section.
     pub fn is_quorum(&self, proofs: &ProofSet) -> bool {
-        proofs.ids().filter(|id| self.is_member(id)).count() * QUORUM_DENOMINATOR
-            > self.len() * QUORUM_NUMERATOR
+        proofs.ids().filter(|id| self.is_member(id)).count() >= quorum_count(self.len())
     }
 
     /// Returns `true` if the proofs are from all members of this section.
@@ -200,4 +199,10 @@ impl Display for EldersInfo {
         )?;
         writeln!(formatter, "\t}}")
     }
+}
+
+/// Returns the number of vote for a quorum of this section such that:
+/// quorum_count * QUORUM_DENOMINATOR > elder_size * QUORUM_NUMERATOR
+pub fn quorum_count(elder_size: usize) -> usize {
+    1 + (elder_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
     chain::{delivery_group_size, Chain, ParsecResetData, PollAccumulated, SectionKeyShare},
     chain_accumulator::AccumulatingProof,
     config::NetworkParams,
-    elders_info::EldersInfo,
+    elders_info::{quorum_count, EldersInfo},
     member_info::{AgeCounter, MemberInfo, MemberPersona, MemberState, MIN_AGE, MIN_AGE_COUNTER},
     network_event::{
         AccumulatedEvent, AccumulatingEvent, AckMessagePayload, EldersChange, EventSigPayload,

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,8 @@ pub enum RoutingError {
     UntrustedMessage,
     #[error(display = "A new SectionInfo is invalid.")]
     InvalidNewSectionInfo,
+    #[error(display = "A Relocation is invalid.")]
+    InvalidRelocation,
     #[error(display = "An Elder DKG result is invalid.")]
     InvalidElderDkgResult,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,17 +169,8 @@ pub const ELDER_SIZE: usize = 7;
 
 #[cfg(feature = "mock_base")]
 pub use crate::mock::quic_p2p;
-#[cfg(feature = "mock_base")]
 pub use crate::{
-    chain::{
-        delivery_group_size, elders_info_for_test, section_proof_chain_from_elders_info,
-        NetworkParams, SectionKeyShare, MIN_AGE,
-    },
-    messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
-    parsec::generate_bls_threshold_secret_key,
-    relocation::Overrides as RelocationOverrides,
-};
-pub use crate::{
+    chain::quorum_count,
     error::{InterfaceError, RoutingError},
     event::{ClientEvent, ConnectEvent, Event},
     event_stream::EventStream,
@@ -191,6 +182,16 @@ pub use crate::{
     types::MessageId,
     utils::XorTargetInterval,
     xor_name::{XorName, XorNameFromHexError, XOR_NAME_BITS, XOR_NAME_LEN},
+};
+#[cfg(feature = "mock_base")]
+pub use crate::{
+    chain::{
+        delivery_group_size, elders_info_for_test, section_proof_chain_from_elders_info,
+        NetworkParams, SectionKeyShare, MIN_AGE,
+    },
+    messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
+    parsec::generate_bls_threshold_secret_key,
+    relocation::Overrides as RelocationOverrides,
 };
 #[cfg(feature = "mock_base")]
 pub(crate) use chain::Chain;

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -8,16 +8,13 @@
 
 use super::{create_connected_nodes, gen_elder_index, poll_all};
 use rand::Rng;
-use routing::{
-    mock::Network, Authority, Event, EventStream, NetworkParams, QUORUM_DENOMINATOR,
-    QUORUM_NUMERATOR,
-};
+use routing::{mock::Network, quorum_count, Authority, Event, EventStream, NetworkParams};
 
 #[test]
 fn send() {
     let elder_size = 8;
     let safe_section_size = 8;
-    let quorum = 1 + (elder_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
+    let quorum = quorum_count(elder_size);
     let network = Network::new(NetworkParams {
         elder_size,
         safe_section_size,
@@ -65,7 +62,7 @@ fn send() {
 fn send_and_receive() {
     let elder_size = 8;
     let safe_section_size = 8;
-    let quorum = 1 + (elder_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
+    let quorum = quorum_count(elder_size);
     let network = Network::new(NetworkParams {
         elder_size,
         safe_section_size,


### PR DESCRIPTION
We need to create a valid signature. With an accumulated event, we will
always have threshold + 1 valid signature share. We may have invalid
shares as well that we need to ignore when combining signature to get
a valid signature.

Resolves #1917 
Superseed https://github.com/maidsafe/routing/pull/1921