### PR TITLE
Remove SPLIT_BUFFER and safe_section size indirection.

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -37,10 +37,6 @@ use std::{
 #[cfg(feature = "mock_base")]
 use crate::crypto::Digest256;
 
-/// Amount added to `min_section_size` when deciding whether a bucket split can happen. This helps
-/// protect against rapid splitting and merging in the face of moderate churn.
-const SPLIT_BUFFER: usize = 1;
-
 /// Returns the delivery group size based on the section size `n`
 pub fn delivery_group_size(n: usize) -> usize {
     // this is an integer that is ≥ n/3
@@ -103,12 +99,6 @@ impl Chain {
             .secret_key_share
             .as_ref()
             .ok_or(RoutingError::InvalidElderDkgResult)
-    }
-
-    /// Returns the number of nodes which need to exist in each subsection of a given section to
-    /// allow it to be split.
-    pub fn min_split_size(&self) -> usize {
-        self.safe_section_size() + SPLIT_BUFFER
     }
 
     /// Collects prefixes of all sections known by the routing table into a `BTreeSet`.
@@ -1267,7 +1257,7 @@ impl Chain {
             });
 
         // If either of the two new sections will not contain enough entries, return `false`.
-        let min_split_size = self.min_split_size();
+        let min_split_size = self.safe_section_size();
         Ok(our_new_size >= min_split_size && sibling_new_size >= min_split_size)
     }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1257,8 +1257,8 @@ impl Chain {
             });
 
         // If either of the two new sections will not contain enough entries, return `false`.
-        let min_split_size = self.safe_section_size();
-        Ok(our_new_size >= min_split_size && sibling_new_size >= min_split_size)
+        let safe_section_size = self.safe_section_size();
+        Ok(our_new_size >= safe_section_size && sibling_new_size >= safe_section_size)
     }
 
     /// Splits our section and generates new elders infos for the child sections.

--- a/src/node.rs
+++ b/src/node.rs
@@ -467,7 +467,7 @@ impl Node {
     /// obtain it.
     ///
     /// Only if we have a chain (meaning we are elders) we will process this API
-    pub fn min_split_size(&self) -> Option<usize> {
+    pub fn safe_section_size(&self) -> Option<usize> {
         self.chain().map(|chain| chain.safe_section_size())
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -468,7 +468,7 @@ impl Node {
     ///
     /// Only if we have a chain (meaning we are elders) we will process this API
     pub fn min_split_size(&self) -> Option<usize> {
-        self.chain().map(|chain| chain.min_split_size())
+        self.chain().map(|chain| chain.safe_section_size())
     }
 
     /// Indicates if there are any pending observations in the parsec object

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -424,10 +424,10 @@ pub fn add_connected_nodes_until_split(
     clear_all_event_queues(nodes, |_, _| {});
 
     // Start enough new nodes under each target prefix to trigger a split eventually.
-    let min_split_size = unwrap!(nodes[0].inner.min_split_size());
+    let safe_section_size = unwrap!(nodes[0].inner.safe_section_size());
     let prefixes_new_count = prefixes
         .iter()
-        .map(|prefix| (*prefix, min_split_size))
+        .map(|prefix| (*prefix, safe_section_size))
         .collect_vec();
     add_nodes_to_prefixes(network, nodes, &prefixes_new_count);
 
@@ -536,7 +536,7 @@ fn add_nodes_to_prefixes(
             .iter()
             .filter(|node| prefix.matches(&node.name()))
             .count();
-        // To ensure you don't hit this assert, don't have more than `min_split_size()` entries in
+        // To ensure you don't hit this assert, don't have more than `safe_section_size()` entries in
         // `nodes` when calling this function.
         assert!(
             num_in_section <= *target_count,
@@ -574,12 +574,12 @@ fn prefixes_and_count_to_split_with_only_one_extra_node(
         .map(|prefix| prefix_half_with_fewer_nodes(nodes, prefix))
         .collect_vec();
 
-    let min_split_size = unwrap!(nodes[0].inner.min_split_size());
+    let safe_section_size = unwrap!(nodes[0].inner.safe_section_size());
 
     let mut prefixes_and_counts = Vec::new();
     for small_prefix in &prefixes_to_add_to_split {
-        prefixes_and_counts.push((*small_prefix, min_split_size - 1));
-        prefixes_and_counts.push((small_prefix.sibling(), min_split_size));
+        prefixes_and_counts.push((*small_prefix, safe_section_size - 1));
+        prefixes_and_counts.push((small_prefix.sibling(), safe_section_size));
     }
 
     (prefixes_and_counts, prefixes_to_add_to_split)


### PR DESCRIPTION
SPLIT_BUFFER has no meaning or purpose. When the network is going to split it will, there is no concept of buffer here. 
Also, the indirection of safe_section_size min_section_size and min_split_size has been simplified. When the RT is removed then it will be safe_section_size only 