### PR TITLE
fix/routing: handle recursive split and remove test work around.

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -152,6 +152,8 @@ impl Chain {
         _group: &BTreeSet<PublicId>,
         related_info: &[u8],
     ) -> Result<(), RoutingError> {
+        // On split membership may need to be checked again.
+        self.members_changed = true;
         self.state
             .update_with_genesis_related_info(related_info, &LogIdent::new(self))
     }

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -211,6 +211,16 @@ mod overrides {
             self.set(src_prefix, src_prefix.name())
         }
 
+        /// Suppress relocations from the given source prefix and its parent prefixes.
+        pub fn suppress_self_and_parents(&mut self, mut src_prefix: Prefix<XorName>) {
+            self.suppress(src_prefix);
+
+            while !src_prefix.is_empty() {
+                src_prefix = src_prefix.popped();
+                self.suppress(src_prefix);
+            }
+        }
+
         /// Clear all relocation overrides set by this instance.
         pub fn clear(&mut self) {
             OVERRIDES.with(|map| {


### PR DESCRIPTION
add_connected_nodes_until_split add all the nodes of leaf prefixes, thus
triggering recursive prefix case. Ensure that this split is not delayed
until the next online/offline event.

It is now trivial to handle recursive split in code, so remove the work
arround that was adding more nodes than needed, leaving additional split
yet to occur.

Fix the relocation suppression when adding node to section so it handle
prefix for which only a parent exists.

Test:
Run soak test + clippy.
Verify messages_during_churn [2481487885, 755787713, 2183041345, 3896795195]
does not fail, and still split properly (no relocation occur anymore).