### PR TITLE
fix/routing: treat bootstrapping to any node the same

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1534,17 +1534,6 @@ impl Chain {
         }
     }
 
-    /// Returns the total number of entries in the routing table, excluding our own name.
-    pub fn len(&self) -> usize {
-        self.state
-            .neighbour_infos
-            .values()
-            .map(|info| info.len())
-            .sum::<usize>()
-            + self.state.our_info().len()
-            - 1
-    }
-
     /// Compute an estimate of the size of the network from the size of our routing table.
     ///
     /// Return (estimate, exact), with exact = true iff we have the whole network in our
@@ -1635,6 +1624,17 @@ impl Chain {
 
 #[cfg(feature = "mock_base")]
 impl Chain {
+    /// Returns the total number of entries in the routing table, excluding our own name.
+    pub fn len(&self) -> usize {
+        self.state
+            .neighbour_infos
+            .values()
+            .map(|info| info.len())
+            .sum::<usize>()
+            + self.state.our_info().len()
+            - 1
+    }
+
     /// Returns our section info with the given hash, if it exists.
     pub fn our_info_by_hash(&self, hash: &Digest256) -> Option<&EldersInfo> {
         self.state.our_info_by_hash(hash)

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,8 +65,3 @@ pub enum RoutingError {
     #[error(display = "An Elder DKG result is invalid.")]
     InvalidElderDkgResult,
 }
-
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub enum BootstrapResponseError {
-    NotApproved,
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,5 +69,4 @@ pub enum RoutingError {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum BootstrapResponseError {
     NotApproved,
-    TooFewPeers,
 }

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -9,7 +9,7 @@
 use crate::{
     chain::{EldersInfo, GenesisPfxInfo},
     crypto::signing::Signature,
-    error::{BootstrapResponseError, RoutingError},
+    error::RoutingError,
     id::{FullId, PublicId},
     messages::SignedRoutingMessage,
     parsec,
@@ -67,8 +67,6 @@ pub enum BootstrapResponse {
     /// The new peer should retry bootstrapping with another section. The set of connection infos
     /// of the members of that section is provided.
     Rebootstrap(Vec<ConnectionInfo>),
-    /// An error has occurred
-    Error(BootstrapResponseError),
 }
 
 /// Request to join a section

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -503,15 +503,17 @@ fn when_accumulate_offline_and_start_dkg_and_section_info_then_node_is_removed_f
 }
 
 #[test]
-fn accept_previously_rejected_node_after_reaching_elder_size() {
+fn accept_node_before_and_after_reaching_elder_size() {
     // Set section size to one less than the desired number of the elders in a section. This makes
     // us reject any bootstrapping nodes.
     let mut elder_test = ElderUnderTest::new(ELDER_SIZE - 1);
-    let node = JoiningNodeInfo::with_addr(&mut elder_test.rng, "198.51.100.0:5000");
+    let node0 = JoiningNodeInfo::with_addr(&mut elder_test.rng, "198.51.100.0:5000");
 
-    // Bootstrap fails for insufficient section size.
-    elder_test.handle_bootstrap_request(*node.public_id(), node.connection_info());
-    assert!(!elder_test.is_connected(&node.connection_info().peer_addr));
+    // Bootstrap succeed even with too few elders.
+    elder_test.handle_bootstrap_request(*node0.public_id(), node0.connection_info());
+    assert!(elder_test.is_connected(&node0.connection_info().peer_addr));
+
+    let node1 = JoiningNodeInfo::with_addr(&mut elder_test.rng, "198.51.100.1:5000");
 
     // Add new section member to reach elder_size.
     let new_info = elder_test.new_elders_info_with_candidate();
@@ -519,7 +521,7 @@ fn accept_previously_rejected_node_after_reaching_elder_size() {
     elder_test.accumulate_start_dkg(&new_info);
     elder_test.accumulate_section_info_if_vote(&new_info);
 
-    // Re-bootstrap now succeeds.
-    elder_test.handle_bootstrap_request(*node.public_id(), node.connection_info());
-    assert!(elder_test.is_connected(&node.connection_info().peer_addr));
+    // Bootstrap succeeds.
+    elder_test.handle_bootstrap_request(*node1.public_id(), node1.connection_info());
+    assert!(elder_test.is_connected(&node1.connection_info().peer_addr));
 }


### PR DESCRIPTION
Addressing comment https://github.com/maidsafe/routing/pull/1954#discussion_r361638168 from PR merged as https://github.com/maidsafe/routing/pull/1983.

Remove first node special case if not enough elders.

Test:
Update unit test
soak test + clippy