### PR TITLE
Simplify feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,4 @@ libc = "~0.2.29"
 mock_base = ["lru_time_cache/fake_clock", "parsec/mock", "parsec/malice-detection", "ctrlc", "lazy_static"]
 mock_crypto = ["mock_base", "threshold_crypto/use-insecure-test-only-mock-crypto"]
 mock_parsec = ["mock_base"]
-mock_serialise = ["mock_base"]
-mock = ["mock_crypto", "mock_parsec", "mock_serialise"]
+mock = ["mock_crypto", "mock_parsec"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,4 @@ mock_base = [
     "lazy_static",
     "threshold_crypto/use-insecure-test-only-mock-crypto"
 ]
-mock_parsec = ["mock_base"]
-mock = ["mock_parsec"]
+mock = ["mock_base"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,13 @@ docopt = "~0.8.1"
 libc = "~0.2.29"
 
 [features]
-mock_base = ["lru_time_cache/fake_clock", "parsec/mock", "parsec/malice-detection", "ctrlc", "lazy_static"]
-mock_crypto = ["mock_base", "threshold_crypto/use-insecure-test-only-mock-crypto"]
+mock_base = [
+    "lru_time_cache/fake_clock",
+    "parsec/mock",
+    "parsec/malice-detection",
+    "ctrlc",
+    "lazy_static",
+    "threshold_crypto/use-insecure-test-only-mock-crypto"
+]
 mock_parsec = ["mock_base"]
-mock = ["mock_crypto", "mock_parsec"]
+mock = ["mock_parsec"]

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -5,5 +5,4 @@ set -x -e
 cargo clippy "$@" --all-targets
 cargo clippy "$@" --all-targets --features=mock_base
 cargo clippy "$@" --all-targets --features=mock_parsec
-cargo clippy "$@" --all-targets --features=mock_serialise
 cargo clippy "$@" --all-targets --features=mock

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -4,5 +4,4 @@ set -x -e
 
 cargo clippy "$@" --all-targets
 cargo clippy "$@" --all-targets --features=mock_base
-cargo clippy "$@" --all-targets --features=mock_parsec
 cargo clippy "$@" --all-targets --features=mock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,6 @@ mod macros;
 mod action;
 mod authority;
 mod chain;
-#[cfg(not(feature = "mock_base"))]
-mod crypto;
 mod error;
 mod event;
 mod event_stream;
@@ -124,6 +122,7 @@ mod messages;
 mod network_service;
 mod node;
 mod outbox;
+mod parsec;
 mod pause;
 mod peer_map;
 mod relocation;
@@ -137,16 +136,70 @@ mod types;
 mod utils;
 mod xor_space;
 
-/// Random number generation utilities.
-#[cfg(feature = "mock_base")]
-pub mod rng;
-#[cfg(not(feature = "mock_base"))]
-mod rng;
-
 /// Mocking utilities.
 #[cfg(feature = "mock_base")]
 pub mod mock;
-pub(crate) mod parsec;
+
+// Random number generation
+#[cfg(not(feature = "mock_base"))]
+mod rng;
+#[cfg(feature = "mock_base")]
+pub mod rng;
+
+// Cryptography
+#[cfg(not(feature = "mock_base"))]
+mod crypto;
+#[cfg(feature = "mock_base")]
+use self::mock::crypto;
+
+// Networking layer
+#[cfg(feature = "mock_base")]
+use self::mock::quic_p2p;
+#[cfg(not(feature = "mock_base"))]
+use quic_p2p;
+
+pub use {
+    self::{
+        authority::Authority,
+        chain::quorum_count,
+        error::{InterfaceError, RoutingError},
+        event::{ClientEvent, ConnectEvent, Event},
+        event_stream::EventStream,
+        id::{FullId, P2pNode, PublicId},
+        node::{Node, NodeBuilder},
+        pause::PausedState,
+        quic_p2p::{Config as NetworkConfig, NodeInfo as ConnectionInfo},
+        types::MessageId,
+        utils::XorTargetInterval,
+        xor_space::{Prefix, XorName, XorNameFromHexError, Xorable, XOR_NAME_BITS, XOR_NAME_LEN},
+    },
+    threshold_crypto::{
+        PublicKey as BlsPublicKey, PublicKeySet as BlsPublicKeySet,
+        PublicKeyShare as BlsPublicKeyShare, SecretKeySet as BlsSecretKeySet,
+        SecretKeyShare as BlsSecretKeyShare, Signature as BlsSignature,
+        SignatureShare as BlsSignatureShare,
+    },
+};
+
+#[cfg(feature = "mock_base")]
+pub use self::{
+    chain::{
+        delivery_group_size, elders_info_for_test, section_proof_chain_from_elders_info,
+        NetworkParams, SectionKeyShare, MIN_AGE,
+    },
+    messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
+    parsec::generate_bls_threshold_secret_key,
+    relocation::Overrides as RelocationOverrides,
+};
+
+#[cfg(feature = "mock_base")]
+#[doc(hidden)]
+pub mod test_consts {
+    pub use crate::{
+        chain::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW},
+        states::{BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT},
+    };
+}
 
 /// Quorum is defined as having strictly greater than `QUORUM_NUMERATOR / QUORUM_DENOMINATOR`
 /// agreement; using only integer arithmetic a quorum can be checked with
@@ -158,7 +211,7 @@ pub const QUORUM_DENOMINATOR: usize = 3;
 /// Default minimal section size.
 pub const MIN_SECTION_SIZE: usize = 3;
 
-/// Minimal safe section size. Routing will keep add nodes until the section reaches this size.
+/// Minimal safe section size. Routing will keep adding nodes until the section reaches this size.
 /// More nodes might be added if requested by the upper layers.
 /// This number also detemines when split happens - if both post-split sections would have at least
 /// this number of nodes.
@@ -167,68 +220,15 @@ pub const SAFE_SECTION_SIZE: usize = 100;
 /// Number of elders per section.
 pub const ELDER_SIZE: usize = 7;
 
-#[cfg(feature = "mock_base")]
-pub use crate::mock::quic_p2p;
-pub use crate::{
-    authority::Authority,
-    chain::quorum_count,
-    error::{InterfaceError, RoutingError},
-    event::{ClientEvent, ConnectEvent, Event},
-    event_stream::EventStream,
-    id::{FullId, P2pNode, PublicId},
-    node::{Node, NodeBuilder},
-    pause::PausedState,
-    types::MessageId,
-    utils::XorTargetInterval,
-    xor_space::{Prefix, XorName, XorNameFromHexError, Xorable, XOR_NAME_BITS, XOR_NAME_LEN},
-};
-#[cfg(feature = "mock_base")]
-pub use crate::{
-    chain::{
-        delivery_group_size, elders_info_for_test, section_proof_chain_from_elders_info,
-        NetworkParams, SectionKeyShare, MIN_AGE,
-    },
-    messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
-    parsec::generate_bls_threshold_secret_key,
-    relocation::Overrides as RelocationOverrides,
-};
-#[cfg(feature = "mock_base")]
-pub(crate) use chain::Chain;
-#[cfg(not(feature = "mock_base"))]
-use quic_p2p;
-
-pub use threshold_crypto::{
-    PublicKey as BlsPublicKey, PublicKeySet as BlsPublicKeySet,
-    PublicKeyShare as BlsPublicKeyShare, SecretKeySet as BlsSecretKeySet,
-    SecretKeyShare as BlsSecretKeyShare, Signature as BlsSignature,
-    SignatureShare as BlsSignatureShare,
-};
+use self::quic_p2p::Event as NetworkEvent;
+#[cfg(any(test, feature = "mock_base"))]
+use unwrap::unwrap;
 
 // Format that can be sent between peers
 #[cfg(not(feature = "mock_base"))]
-pub(crate) type NetworkBytes = bytes::Bytes;
+type NetworkBytes = bytes::Bytes;
 #[cfg(feature = "mock_base")]
-pub(crate) type NetworkBytes = std::rc::Rc<Message>;
-
-pub use self::quic_p2p::Config as NetworkConfig;
-pub use self::quic_p2p::NodeInfo as ConnectionInfo;
-pub(crate) use self::{
-    network_service::NetworkService,
-    quic_p2p::{Event as NetworkEvent, QuicP2p},
-};
-
-#[cfg(feature = "mock_base")]
-pub(crate) use self::mock::crypto;
-
-#[cfg(any(test, feature = "mock_base"))]
-pub(crate) use unwrap::unwrap;
-
-#[cfg(feature = "mock_base")]
-#[doc(hidden)]
-pub mod test_consts {
-    pub use crate::chain::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW};
-    pub use crate::states::{BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT};
-}
+type NetworkBytes = std::rc::Rc<Message>;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ mod macros;
 mod action;
 mod authority;
 mod chain;
-#[cfg(not(feature = "mock_crypto"))]
+#[cfg(not(feature = "mock_base"))]
 mod crypto;
 mod error;
 mod event;
@@ -217,7 +217,7 @@ pub(crate) use self::{
     quic_p2p::{Event as NetworkEvent, QuicP2p},
 };
 
-#[cfg(feature = "mock_crypto")]
+#[cfg(feature = "mock_base")]
 pub(crate) use self::mock::crypto;
 
 #[cfg(any(test, feature = "mock_base"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,9 +205,9 @@ pub use threshold_crypto::{
 };
 
 // Format that can be sent between peers
-#[cfg(not(feature = "mock_serialise"))]
+#[cfg(not(feature = "mock_base"))]
 pub(crate) type NetworkBytes = bytes::Bytes;
-#[cfg(feature = "mock_serialise")]
+#[cfg(feature = "mock_base")]
 pub(crate) type NetworkBytes = std::rc::Rc<Message>;
 
 pub use self::quic_p2p::Config as NetworkConfig;

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 /// Direct message content.
-#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[cfg_attr(feature = "mock_base", derive(Clone))]
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
@@ -58,7 +58,7 @@ pub enum DirectMessage {
 }
 
 /// Response to a BootstrapRequest
-#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[cfg_attr(feature = "mock_base", derive(Clone))]
 #[derive(Eq, PartialEq, Serialize, Deserialize, Debug, Hash)]
 pub enum BootstrapResponse {
     /// This response means that the new peer is clear to join the section. The connection infos of
@@ -70,7 +70,7 @@ pub enum BootstrapResponse {
 }
 
 /// Request to join a section
-#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[cfg_attr(feature = "mock_base", derive(Clone))]
 #[derive(Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct JoinRequest {
     /// The section version to join
@@ -141,7 +141,7 @@ impl Hash for DirectMessage {
     }
 }
 
-#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[cfg_attr(feature = "mock_base", derive(Clone))]
 #[derive(Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SignedDirectMessage {
     content: DirectMessage,
@@ -174,7 +174,7 @@ impl SignedDirectMessage {
     }
 
     /// Content of the message.
-    #[cfg(any(all(test, feature = "mock_base"), feature = "mock_serialise"))]
+    #[cfg(feature = "mock_base")]
     pub fn content(&self) -> &DirectMessage {
         &self.content
     }
@@ -190,7 +190,7 @@ impl Debug for SignedDirectMessage {
     }
 }
 
-#[cfg(not(feature = "mock_serialise"))]
+#[cfg(not(feature = "mock_base"))]
 mod implementation {
     use super::*;
 
@@ -215,7 +215,7 @@ mod implementation {
     }
 }
 
-#[cfg(feature = "mock_serialise")]
+#[cfg(feature = "mock_base")]
 mod implementation {
     use super::*;
     use crate::{crypto::signing::SIGNATURE_LENGTH, unwrap};

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -30,7 +30,7 @@ use std::{
 /// Wrapper of all messages.
 ///
 /// This is the only type allowed to be sent / received on the network.
-#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[cfg_attr(feature = "mock_base", derive(Clone))]
 #[derive(Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
@@ -46,7 +46,7 @@ pub enum Message {
 /// To relay a `SignedMessage` via another node, the `SignedMessage` is wrapped in a `HopMessage`.
 /// The `signature` is from the node that sends this directly to a node in its routing table. To
 /// prevent Man-in-the-middle attacks, the `content` is signed by the original sender.
-#[cfg_attr(feature = "mock_serialise", derive(Clone))]
+#[cfg_attr(feature = "mock_base", derive(Clone))]
 #[derive(Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct HopMessage {
     /// Wrapped signed message.

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 /// Mock version of Parsec.
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 pub(crate) mod parsec;
 
 /// Mock version of Quic-P2P

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -14,7 +14,6 @@ pub(crate) mod parsec;
 pub mod quic_p2p;
 
 /// Mock cryptography
-#[cfg(feature = "mock_crypto")]
 pub(crate) mod crypto;
 
 pub use self::quic_p2p::Network;

--- a/src/mock/quic_p2p/network.rs
+++ b/src/mock/quic_p2p/network.rs
@@ -7,8 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{node::Node, OurType};
-#[cfg(feature = "mock_parsec")]
-use crate::mock::parsec;
 use crate::{
     chain::NetworkParams,
     rng::{self, MainRng, Seed, SeedPrinter},
@@ -26,6 +24,9 @@ use std::{
     rc::{Rc, Weak},
     sync::Once,
 };
+
+#[cfg(feature = "mock")]
+use crate::mock::parsec;
 
 const IP_BASE: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 const PORT: u16 = 9999;
@@ -52,7 +53,7 @@ impl Network {
             }
         });
 
-        #[cfg(feature = "mock_parsec")]
+        #[cfg(feature = "mock")]
         parsec::init_mock();
 
         let seed = Seed::default();

--- a/src/mock/quic_p2p/network.rs
+++ b/src/mock/quic_p2p/network.rs
@@ -273,17 +273,6 @@ impl Inner {
     }
 }
 
-// Serialised parsec gossip messages start with these bytes.
-#[cfg(not(feature = "mock_serialise"))]
-const PARSEC_GOSSIP_MSG_TAGS: &[&[u8]] = &[
-    // ParsecPoke
-    &[0, 0, 0, 0, 5, 0, 0, 0],
-    // ParsecRequest
-    &[0, 0, 0, 0, 6, 0, 0, 0],
-    // ParsecResponse
-    &[0, 0, 0, 0, 7, 0, 0, 0],
-];
-
 #[derive(Debug)]
 pub(super) enum Packet {
     BootstrapRequest(OurType),
@@ -300,17 +289,6 @@ pub(super) enum Packet {
 
 impl Packet {
     // Returns `true` if this packet contains a Parsec request or response.
-    #[cfg(not(feature = "mock_serialise"))]
-    pub fn is_parsec_gossip(&self) -> bool {
-        match self {
-            Packet::Message(bytes, _) if bytes.len() >= 8 => {
-                PARSEC_GOSSIP_MSG_TAGS.contains(&&bytes[..8])
-            }
-            _ => false,
-        }
-    }
-
-    #[cfg(feature = "mock_serialise")]
     pub fn is_parsec_gossip(&self) -> bool {
         use crate::messages::{DirectMessage, Message};
 

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -377,94 +377,6 @@ fn drop_disconnects() {
     b.expect_connection_failure(&a_addr);
 }
 
-#[test]
-#[cfg(not(feature = "mock_serialise"))]
-fn packet_is_parsec_gossip() {
-    use super::network::Packet;
-    use crate::{
-        id::FullId,
-        messages::{
-            DirectMessage, HopMessage, Message, MessageContent, RoutingMessage,
-            SignedDirectMessage, SignedRoutingMessage,
-        },
-        parsec::{Request, Response},
-        rng, Authority,
-    };
-
-    use maidsafe_utilities::serialisation;
-    use rand::Rng;
-    use serde::Serialize;
-
-    let mut rng = rng::new();
-    let full_id = FullId::gen(&mut rng);
-
-    fn serialise<T: Serialize>(msg: &T) -> Vec<u8> {
-        unwrap!(serialisation::serialise(&msg))
-    }
-
-    let make_message =
-        |content| Message::Direct(unwrap!(SignedDirectMessage::new(content, &full_id)));
-
-    // Parsec doesn't provide constructors for requests and responses, but they have the same
-    // representation as a `Vec`, or a `()` in real or mock Parsec respectively.
-    #[allow(clippy::let_unit_value)]
-    let (req, rsp): (Request, Response) = {
-        #[cfg(feature = "mock_parsec")]
-        let repr = ();
-        #[cfg(not(feature = "mock_parsec"))]
-        let repr = Vec::<u64>::new();
-
-        (
-            unwrap!(serialisation::deserialise(&serialise(&repr))),
-            unwrap!(serialisation::deserialise(&serialise(&repr))),
-        )
-    };
-
-    let msgs = [
-        make_message(DirectMessage::ParsecPoke(23)),
-        make_message(DirectMessage::ParsecRequest(42, req)),
-        make_message(DirectMessage::ParsecResponse(1337, rsp)),
-    ];
-    for msg in &msgs {
-        assert!(Packet::Message(NetworkBytes::from(serialise(msg)), 0).is_parsec_gossip());
-    }
-
-    // No other direct message types contain a Parsec request or response.
-    let msgs = [
-        make_message(DirectMessage::BootstrapRequest(rng.gen())),
-        make_message(DirectMessage::ConnectionResponse),
-    ];
-    for msg in &msgs {
-        assert!(!Packet::Message(NetworkBytes::from(serialise(msg)), 0).is_parsec_gossip());
-    }
-
-    // A hop message never contains a Parsec message.
-    let msg = RoutingMessage {
-        src: Authority::Section(rand::random()),
-        dst: Authority::Section(rand::random()),
-        content: MessageContent::UserMessage(vec![rand::random(), rand::random(), rand::random()]),
-    };
-    let msg = SignedRoutingMessage::insecure(msg);
-    let msg = unwrap!(HopMessage::new(msg));
-    let msg = Message::Hop(msg);
-    assert!(!Packet::Message(NetworkBytes::from(serialise(&msg)), 0).is_parsec_gossip());
-
-    // No packet types other than `Message` represent a Parsec request or response.
-    let packets = [
-        Packet::BootstrapRequest(OurType::Client),
-        Packet::BootstrapSuccess,
-        Packet::BootstrapFailure,
-        Packet::ConnectRequest(OurType::Client),
-        Packet::ConnectSuccess,
-        Packet::ConnectFailure,
-        Packet::MessageFailure(NetworkBytes::from_static(b"hello"), 0),
-        Packet::Disconnect,
-    ];
-    for packet in &packets {
-        assert!(!packet.is_parsec_gossip());
-    }
-}
-
 struct Agent {
     inner: QuicP2p,
     rx: Receiver<Event>,
@@ -682,31 +594,24 @@ fn assert_connected_to_node(event: Event, addr: &SocketAddr) {
 
 // Generate unique message.
 fn gen_message() -> NetworkBytes {
+    use crate::{
+        id::FullId,
+        messages::{DirectMessage, Message, SignedDirectMessage},
+        rng,
+    };
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let num = COUNTER.fetch_add(1, Ordering::Relaxed);
 
-    #[cfg(feature = "mock_serialise")]
-    {
-        use crate::{
-            id::FullId,
-            messages::{DirectMessage, Message, SignedDirectMessage},
-            rng,
-        };
-
-        thread_local! {
-            static FULL_ID: FullId = FullId::gen(&mut rng::new());
-        }
-
-        // The actual content of the message doesn't matter for the purposes of these tests, only
-        // that it is unique. Let's use `DirectMessage::ParsecPoke` as it is the simplest message
-        // that carries some data.
-        let content = DirectMessage::ParsecPoke(num as u64);
-        let message = FULL_ID.with(|full_id| unwrap!(SignedDirectMessage::new(content, full_id)));
-        NetworkBytes::new(Message::Direct(message))
+    thread_local! {
+        static FULL_ID: FullId = FullId::gen(&mut rng::new());
     }
 
-    #[cfg(not(feature = "mock_serialise"))]
-    bytes::Bytes::from(format!("message {}", num))
+    // The actual content of the message doesn't matter for the purposes of these tests, only
+    // that it is unique. Let's use `DirectMessage::ParsecPoke` as it is the simplest message
+    // that carries some data.
+    let content = DirectMessage::ParsecPoke(num as u64);
+    let message = FULL_ID.with(|full_id| unwrap!(SignedDirectMessage::new(content, full_id)));
+    NetworkBytes::new(Message::Direct(message))
 }

--- a/src/network_service/mod.rs
+++ b/src/network_service/mod.rs
@@ -10,9 +10,9 @@ mod sending_targets_cache;
 
 use crate::{
     peer_map::PeerMap,
-    quic_p2p::{Builder, Error, Peer, Token},
+    quic_p2p::{Builder, Error, Peer, QuicP2p, Token},
     utils::LogIdent,
-    ConnectionInfo, NetworkBytes, NetworkConfig, NetworkEvent, QuicP2p,
+    ConnectionInfo, NetworkBytes, NetworkConfig, NetworkEvent,
 };
 use crossbeam_channel::Sender;
 use std::net::SocketAddr;

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,7 +26,10 @@ use std::{net::SocketAddr, sync::mpsc};
 
 #[cfg(feature = "mock_base")]
 use {
-    crate::{chain::SectionProofChain, Chain, Prefix},
+    crate::{
+        chain::{Chain, SectionProofChain},
+        Prefix,
+    },
     std::{
         collections::{BTreeMap, BTreeSet},
         fmt::{self, Display, Formatter},

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 use crate::crypto;
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 use crate::mock::parsec as inner;
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 use crate::unwrap;
 use crate::{
     chain::{self, GenesisPfxInfo},
@@ -22,20 +22,20 @@ use crate::{
 };
 use log::LogLevel;
 use maidsafe_utilities::serialisation;
-#[cfg(not(feature = "mock_parsec"))]
+#[cfg(not(feature = "mock"))]
 use parsec as inner;
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 use std::collections::BTreeSet;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt, mem,
 };
 
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 pub use crate::mock::parsec::{
     init_mock, ConsensusMode, Error, NetworkEvent, Observation, Proof, PublicId, SecretId,
 };
-#[cfg(not(feature = "mock_parsec"))]
+#[cfg(not(feature = "mock"))]
 pub use parsec::{ConsensusMode, Error, NetworkEvent, Observation, Proof, PublicId, SecretId};
 
 pub type Block = inner::Block<chain::NetworkEvent, id::PublicId>;
@@ -48,13 +48,13 @@ pub use inner::{DkgResult, DkgResultWrapper};
 const MAX_PARSECS: usize = 10;
 
 // Limit in production
-#[cfg(all(not(feature = "mock_parsec"), not(feature = "mock_base")))]
+#[cfg(not(feature = "mock_base"))]
 const PARSEC_SIZE_LIMIT: u64 = 1_000_000_000;
 // Limit in integration tests
-#[cfg(all(feature = "mock_base", not(feature = "mock_parsec")))]
+#[cfg(all(feature = "mock_base", not(feature = "mock")))]
 const PARSEC_SIZE_LIMIT: u64 = 20_000_000;
 // Limit for integration tests with mock-parsec
-#[cfg(feature = "mock_parsec")]
+#[cfg(feature = "mock")]
 const PARSEC_SIZE_LIMIT: u64 = 500;
 
 // Keep track of size in case we need to prune.
@@ -198,7 +198,7 @@ impl ParsecMap {
     }
 
     // Enable test to simulate other members voting
-    #[cfg(feature = "mock_parsec")]
+    #[cfg(feature = "mock")]
     pub fn vote_for_as(
         &mut self,
         obs: Observation<chain::NetworkEvent, id::PublicId>,
@@ -210,7 +210,7 @@ impl ParsecMap {
     }
 
     // Enable test to simulate other members signing and getting the right pk_set
-    #[cfg(feature = "mock_parsec")]
+    #[cfg(feature = "mock")]
     pub fn get_dkg_result_as(
         &mut self,
         participants: BTreeSet<id::PublicId>,
@@ -254,7 +254,7 @@ impl ParsecMap {
             .flatten()
     }
 
-    #[cfg(feature = "mock_parsec")]
+    #[cfg(feature = "mock")]
     pub fn unpolled_observations_string(&self) -> String {
         let parsec = if let Some(parsec) = self.map.values().last() {
             parsec
@@ -265,7 +265,7 @@ impl ParsecMap {
         parsec.unpolled_observations_string()
     }
 
-    #[cfg(all(not(feature = "mock_parsec"), feature = "mock_base"))]
+    #[cfg(all(not(feature = "mock"), feature = "mock_base"))]
     pub fn unpolled_observations_string(&self) -> String {
         use itertools::Itertools;
 
@@ -275,7 +275,7 @@ impl ParsecMap {
             return String::new();
         };
 
-        // This doesn't contain as much info as the `mock_parsec` version but it's better than
+        // This doesn't contain as much info as the `mock` version but it's better than
         // nothing.
         format!(
             "our_unpolled_observations: {:?}",
@@ -373,7 +373,7 @@ pub fn generate_bls_threshold_secret_key(
 
 /// Create Parsec instance.
 fn create(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> Parsec {
-    #[cfg(feature = "mock_parsec")]
+    #[cfg(feature = "mock")]
     let hash = {
         let fields = (gen_pfx_info.first_info.hash(), gen_pfx_info.parsec_version);
         crypto::sha3_256(&unwrap!(serialisation::serialise(&fields)))
@@ -381,7 +381,7 @@ fn create(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> 
 
     if gen_pfx_info.first_info.is_member(full_id.public_id()) {
         Parsec::from_genesis(
-            #[cfg(feature = "mock_parsec")]
+            #[cfg(feature = "mock")]
             hash,
             full_id,
             &gen_pfx_info.first_info.member_ids().copied().collect(),
@@ -391,7 +391,7 @@ fn create(rng: &mut MainRng, full_id: FullId, gen_pfx_info: &GenesisPfxInfo) -> 
         )
     } else {
         Parsec::from_existing(
-            #[cfg(feature = "mock_parsec")]
+            #[cfg(feature = "mock")]
             hash,
             full_id,
             &gen_pfx_info.first_info.member_ids().copied().collect(),
@@ -414,7 +414,7 @@ impl From<Error> for CreateGossipError {
     }
 }
 
-#[cfg(all(test, feature = "mock_parsec"))]
+#[cfg(all(test, feature = "mock"))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -10,10 +10,11 @@ use crate::{
     chain::{Chain, GenesisPfxInfo},
     id::{FullId, P2pNode},
     messages::{DirectMessage, SignedRoutingMessage},
+    network_service::NetworkService,
     parsec::ParsecMap,
     routing_message_filter::RoutingMessageFilter,
     signature_accumulator::SignatureAccumulator,
-    NetworkEvent, NetworkService,
+    NetworkEvent,
 };
 use crossbeam_channel as mpmc;
 use std::collections::VecDeque;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+//! Random number generation utilities.
+
 pub use self::implementation::{new, new_from, MainRng};
 #[cfg(any(feature = "mock_base"))]
 pub use self::seed_printer::SeedPrinter;

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -12,6 +12,7 @@ use crate::{
     error::{InterfaceError, RoutingError},
     id::{P2pNode, PublicId},
     network_service::NetworkBuilder,
+    network_service::NetworkService,
     outbox::EventBox,
     pause::PausedState,
     relocation::{RelocatePayload, SignedRelocateDetails},
@@ -19,10 +20,10 @@ use crate::{
     states::{Adult, BootstrappingPeer, Elder, JoiningPeer},
     timer::Timer,
     xor_space::{Prefix, XorName},
-    ConnectionInfo, NetworkConfig, NetworkEvent, NetworkService,
+    ConnectionInfo, NetworkConfig, NetworkEvent,
 };
 #[cfg(feature = "mock_base")]
-use crate::{rng::MainRng, Authority, Chain};
+use crate::{chain::Chain, rng::MainRng, Authority};
 use crossbeam_channel as mpmc;
 #[cfg(feature = "mock_base")]
 use std::net::SocketAddr;

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -22,6 +22,7 @@ use crate::{
     messages::{
         BootstrapResponse, DirectMessage, HopMessage, RoutingMessage, SignedRoutingMessage,
     },
+    network_service::NetworkService,
     outbox::EventBox,
     parsec::{DkgResultWrapper, ParsecMap},
     pause::PausedState,
@@ -35,7 +36,7 @@ use crate::{
     timer::Timer,
     utils::LogIdent,
     xor_space::{Prefix, XorName},
-    Authority, BlsSignature, ConnectionInfo, NetworkService,
+    Authority, BlsSignature, ConnectionInfo,
 };
 use itertools::Itertools;
 use std::{

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -13,6 +13,7 @@ use crate::{
     event::Event,
     id::{FullId, P2pNode},
     messages::{BootstrapResponse, DirectMessage, HopMessage, RoutingMessage},
+    network_service::NetworkService,
     outbox::EventBox,
     peer_map::PeerMap,
     relocation::{RelocatePayload, SignedRelocateDetails},
@@ -21,7 +22,7 @@ use crate::{
     states::JoiningPeer,
     timer::Timer,
     xor_space::{Prefix, XorName},
-    Authority, ConnectionInfo, NetworkService,
+    Authority, ConnectionInfo,
 };
 use log::LogLevel;
 use std::{

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -456,22 +456,22 @@ pub trait Base: Display {
 pub fn to_network_bytes(
     message: &Message,
 ) -> Result<NetworkBytes, (serialisation::SerialisationError, &Message)> {
-    #[cfg(not(feature = "mock_serialise"))]
+    #[cfg(not(feature = "mock_base"))]
     let result = Ok(NetworkBytes::from(
         serialisation::serialise(message).map_err(|err| (err, message))?,
     ));
 
-    #[cfg(feature = "mock_serialise")]
+    #[cfg(feature = "mock_base")]
     let result = Ok(NetworkBytes::new(message.clone()));
 
     result
 }
 
 pub fn from_network_bytes(data: NetworkBytes) -> Result<Message, RoutingError> {
-    #[cfg(not(feature = "mock_serialise"))]
+    #[cfg(not(feature = "mock_base"))]
     let result = serialisation::deserialise(&data[..]).map_err(RoutingError::SerialisationError);
 
-    #[cfg(feature = "mock_serialise")]
+    #[cfg(feature = "mock_base")]
     let result = Ok((*data).clone());
 
     result

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -14,6 +14,7 @@ use crate::{
         DirectMessage, HopMessage, Message, RoutingMessage, SignedDirectMessage,
         SignedRoutingMessage,
     },
+    network_service::NetworkService,
     outbox::EventBox,
     peer_map::PeerMap,
     quic_p2p::{Peer, Token},
@@ -22,7 +23,7 @@ use crate::{
     timer::Timer,
     utils::LogIdent,
     xor_space::XorName,
-    Authority, ClientEvent, ConnectionInfo, NetworkBytes, NetworkEvent, NetworkService,
+    Authority, ClientEvent, ConnectionInfo, NetworkBytes, NetworkEvent,
 };
 use log::LogLevel;
 use maidsafe_utilities::serialisation;

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -28,6 +28,7 @@ use crate::{
         BootstrapResponse, DirectMessage, HopMessage, JoinRequest, MessageContent, RoutingMessage,
         SecurityMetadata, SignedRoutingMessage,
     },
+    network_service::NetworkService,
     outbox::EventBox,
     parsec::{self, generate_first_dkg_result, DkgResultWrapper, ParsecMap},
     pause::PausedState,
@@ -41,7 +42,7 @@ use crate::{
     time::Duration,
     timer::Timer,
     xor_space::{Prefix, XorName, Xorable},
-    Authority, BlsPublicKey, BlsPublicKeySet, BlsSignature, ConnectionInfo, NetworkService,
+    Authority, BlsPublicKey, BlsPublicKeySet, BlsSignature, ConnectionInfo,
 };
 use itertools::Itertools;
 use log::LogLevel;

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(all(test, feature = "mock_parsec"))]
+#[cfg(all(test, feature = "mock"))]
 mod tests;
 
 use super::{

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -19,10 +19,11 @@ use crate::{
     generate_bls_threshold_secret_key,
     messages::DirectMessage,
     mock::Network,
+    network_service::NetworkService,
     outbox::EventBox,
     rng::{self, MainRng},
     state_machine::{State, StateMachine, Transition},
-    unwrap, BlsSecretKeyShare, NetworkConfig, NetworkParams, NetworkService, ELDER_SIZE,
+    unwrap, BlsSecretKeyShare, NetworkConfig, NetworkParams, ELDER_SIZE,
 };
 use std::{iter, net::SocketAddr};
 

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -20,6 +20,7 @@ use crate::{
         BootstrapResponse, DirectMessage, HopMessage, JoinRequest, MessageContent, RoutingMessage,
         SignedRoutingMessage,
     },
+    network_service::NetworkService,
     outbox::EventBox,
     peer_map::PeerMap,
     relocation::RelocatePayload,
@@ -28,7 +29,7 @@ use crate::{
     state_machine::{State, Transition},
     timer::Timer,
     xor_space::XorName,
-    Authority, NetworkService,
+    Authority,
 };
 use log::LogLevel;
 use std::{

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -222,7 +222,7 @@ fn node_joins_in_front() {
 // This would not be an issue if Joining did not time out, or if elder processed them quicker.
 // This should be solved by Taking on all queued Adults before processing Elder change.
 #[test]
-#[cfg_attr(not(feature = "mock_parsec"), ignore)]
+#[cfg_attr(not(feature = "mock"), ignore)]
 fn multiple_joining_nodes() {
     let network = Network::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,


### PR DESCRIPTION
This PR simplifies the feature flags to just these two:

- `mock_base`: mock network, mock crypto and mock serialisation
- `mock`: everything from `mock_base` plus mock Parsec.

This PR also cleans up lib.rs by mostly moving some declarations around for better readability.