### PR TITLE
Don't suppress parsec prune when relocation is in progress

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -661,10 +661,9 @@ impl Chain {
         self.state.split_in_progress
     }
 
-    /// Returns whether a membership change is in progress (a node leaving, joining or being
-    /// relocated).
-    pub fn membership_change_in_progress(&self) -> bool {
-        self.churn_in_progress || self.relocation_in_progress
+    /// Returns whether a churn (elders change) is in progress.
+    pub fn churn_in_progress(&self) -> bool {
+        self.churn_in_progress
     }
 
     /// Neighbour infos signed by our section


### PR DESCRIPTION
Closes #1963 .

Also includes a tiny refactoring.