### PR TITLE
Revert some changes to allow safe_vault test to pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,7 @@ mock_base = [
     "lazy_static",
     "bls/use-insecure-test-only-mock-crypto"
 ]
-mock = ["mock_base"]
+mock_parsec = ["mock_base"]
+mock_serialise = ["mock_base"]
+mock = ["mock_parsec", "mock_serialise"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ mock_base = [
     "lazy_static",
     "bls/use-insecure-test-only-mock-crypto"
 ]
-mock_parsec = ["mock_base"]
 mock_serialise = ["mock_base"]
-mock = ["mock_parsec", "mock_serialise"]
+mock = ["mock_base"]
 

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -4,4 +4,6 @@ set -x -e
 
 cargo clippy "$@" --all-targets
 cargo clippy "$@" --all-targets --features=mock_base
+cargo clippy "$@" --all-targets --features=mock_parsec
+cargo clippy "$@" --all-targets --features=mock_serialise
 cargo clippy "$@" --all-targets --features=mock

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -4,6 +4,5 @@ set -x -e
 
 cargo clippy "$@" --all-targets
 cargo clippy "$@" --all-targets --features=mock_base
-cargo clippy "$@" --all-targets --features=mock_parsec
 cargo clippy "$@" --all-targets --features=mock_serialise
 cargo clippy "$@" --all-targets --features=mock

--- a/src/event.rs
+++ b/src/event.rs
@@ -103,6 +103,9 @@ pub enum Event {
     RestartRequired,
     /// Startup failed - terminate.
     Terminated,
+    // TODO: Find a better solution for periodic tasks.
+    /// This event is sent periodically every time Routing sends the `Heartbeat` messages.
+    TimerTicked,
     /// Consensus on a custom event.
     Consensus(Vec<u8>),
 }
@@ -142,6 +145,7 @@ impl Debug for Event {
             }
             Self::RestartRequired => write!(formatter, "Event::RestartRequired"),
             Self::Terminated => write!(formatter, "Event::Terminated"),
+            Self::TimerTicked => write!(formatter, "Event::TimerTicked"),
             Self::Consensus(ref payload) => {
                 write!(formatter, "Event::Consensus({:<8})", HexFmt(payload))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub mod mock;
 #[cfg(feature = "mock_base")]
 pub mod rng;
 
+/// Mock network
 #[cfg(feature = "mock_base")]
 pub use self::{
     authority::Authority,
@@ -110,6 +111,7 @@ pub use self::{
         section_proof_chain_from_elders_info, NetworkParams, SectionKeyShare, MIN_AGE,
     },
     messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
+    mock::quic_p2p,
     parsec::generate_bls_threshold_secret_key,
     relocation::Overrides as RelocationOverrides,
     xor_space::Xorable,
@@ -161,12 +163,6 @@ mod crypto;
 #[cfg(feature = "mock_base")]
 use self::mock::crypto;
 
-// Networking layer
-#[cfg(feature = "mock_base")]
-use self::mock::quic_p2p;
-#[cfg(not(feature = "mock_base"))]
-use quic_p2p;
-
 /// Quorum is defined as having strictly greater than `QUORUM_NUMERATOR / QUORUM_DENOMINATOR`
 /// agreement; using only integer arithmetic a quorum can be checked with
 /// `votes * QUORUM_DENOMINATOR > voters * QUORUM_NUMERATOR`.
@@ -184,6 +180,8 @@ const SAFE_SECTION_SIZE: usize = 100;
 const ELDER_SIZE: usize = 7;
 
 use self::quic_p2p::Event as NetworkEvent;
+#[cfg(not(feature = "mock_base"))]
+use quic_p2p;
 #[cfg(any(test, feature = "mock_base"))]
 use unwrap::unwrap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,9 @@ use quic_p2p;
 use unwrap::unwrap;
 
 // Format that can be sent between peers
-#[cfg(not(feature = "mock_base"))]
+#[cfg(not(feature = "mock_serialise"))]
 type NetworkBytes = bytes::Bytes;
-#[cfg(feature = "mock_base")]
+#[cfg(feature = "mock_serialise")]
 type NetworkBytes = std::rc::Rc<Message>;
 
 #[cfg(test)]

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 /// Direct message content.
-#[cfg_attr(feature = "mock_base", derive(Clone))]
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
@@ -58,7 +58,7 @@ pub enum DirectMessage {
 }
 
 /// Response to a BootstrapRequest
-#[cfg_attr(feature = "mock_base", derive(Clone))]
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Eq, PartialEq, Serialize, Deserialize, Debug, Hash)]
 pub enum BootstrapResponse {
     /// This response means that the new peer is clear to join the section. The connection infos of
@@ -70,7 +70,7 @@ pub enum BootstrapResponse {
 }
 
 /// Request to join a section
-#[cfg_attr(feature = "mock_base", derive(Clone))]
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct JoinRequest {
     /// The section version to join
@@ -141,7 +141,7 @@ impl Hash for DirectMessage {
     }
 }
 
-#[cfg_attr(feature = "mock_base", derive(Clone))]
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SignedDirectMessage {
     content: DirectMessage,
@@ -174,7 +174,7 @@ impl SignedDirectMessage {
     }
 
     /// Content of the message.
-    #[cfg(feature = "mock_base")]
+    #[cfg(any(all(test, feature = "mock_base"), feature = "mock_serialise"))]
     pub fn content(&self) -> &DirectMessage {
         &self.content
     }
@@ -190,7 +190,7 @@ impl Debug for SignedDirectMessage {
     }
 }
 
-#[cfg(not(feature = "mock_base"))]
+#[cfg(not(feature = "mock_serialise"))]
 mod implementation {
     use super::*;
 
@@ -215,7 +215,7 @@ mod implementation {
     }
 }
 
-#[cfg(feature = "mock_base")]
+#[cfg(feature = "mock_serialise")]
 mod implementation {
     use super::*;
     use crate::{crypto::signing::SIGNATURE_LENGTH, unwrap};

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -30,7 +30,7 @@ use std::{
 /// Wrapper of all messages.
 ///
 /// This is the only type allowed to be sent / received on the network.
-#[cfg_attr(feature = "mock_base", derive(Clone))]
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
 #[allow(clippy::large_enum_variant)]
@@ -46,7 +46,7 @@ pub enum Message {
 /// To relay a `SignedMessage` via another node, the `SignedMessage` is wrapped in a `HopMessage`.
 /// The `signature` is from the node that sends this directly to a node in its routing table. To
 /// prevent Man-in-the-middle attacks, the `content` is signed by the original sender.
-#[cfg_attr(feature = "mock_base", derive(Clone))]
+#[cfg_attr(feature = "mock_serialise", derive(Clone))]
 #[derive(Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct HopMessage {
     /// Wrapped signed message.

--- a/src/mock/quic_p2p/network.rs
+++ b/src/mock/quic_p2p/network.rs
@@ -274,6 +274,17 @@ impl Inner {
     }
 }
 
+// Serialised parsec gossip messages start with these bytes.
+#[cfg(not(feature = "mock_serialise"))]
+const PARSEC_GOSSIP_MSG_TAGS: &[&[u8]] = &[
+    // ParsecPoke
+    &[0, 0, 0, 0, 5, 0, 0, 0],
+    // ParsecRequest
+    &[0, 0, 0, 0, 6, 0, 0, 0],
+    // ParsecResponse
+    &[0, 0, 0, 0, 7, 0, 0, 0],
+];
+
 #[derive(Debug)]
 pub(super) enum Packet {
     BootstrapRequest(OurType),
@@ -290,6 +301,17 @@ pub(super) enum Packet {
 
 impl Packet {
     // Returns `true` if this packet contains a Parsec request or response.
+    #[cfg(not(feature = "mock_serialise"))]
+    pub fn is_parsec_gossip(&self) -> bool {
+        match self {
+            Packet::Message(bytes, _) if bytes.len() >= 8 => {
+                PARSEC_GOSSIP_MSG_TAGS.contains(&&bytes[..8])
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg(feature = "mock_serialise")]
     pub fn is_parsec_gossip(&self) -> bool {
         use crate::messages::{DirectMessage, Message};
 

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -405,13 +405,10 @@ fn packet_is_parsec_gossip() {
     let make_message =
         |content| Message::Direct(unwrap!(SignedDirectMessage::new(content, &full_id)));
 
-    // Parsec doesn't provide constructors for requests and responses, but they have the same
-    // representation as a `Vec`, or a `()` in real or mock Parsec respectively.
-    #[allow(clippy::let_unit_value)]
+    // Real parsec doesn't provide constructors for requests and responses, but they have the same
+    // representation as a `Vec`.
+    #[cfg(not(feature = "mock_parsec"))]
     let (req, rsp): (Request, Response) = {
-        #[cfg(feature = "mock_parsec")]
-        let repr = ();
-        #[cfg(not(feature = "mock_parsec"))]
         let repr = Vec::<u64>::new();
 
         (
@@ -419,6 +416,9 @@ fn packet_is_parsec_gossip() {
             unwrap!(serialisation::deserialise(&serialise(&repr))),
         )
     };
+
+    #[cfg(feature = "mock_parsec")]
+    let (req, rsp) = (Request::new(), Response::new());
 
     let msgs = [
         make_message(DirectMessage::ParsecPoke(23)),

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -377,6 +377,94 @@ fn drop_disconnects() {
     b.expect_connection_failure(&a_addr);
 }
 
+#[test]
+#[cfg(not(feature = "mock_serialise"))]
+fn packet_is_parsec_gossip() {
+    use super::network::Packet;
+    use crate::{
+        id::FullId,
+        messages::{
+            DirectMessage, HopMessage, Message, MessageContent, RoutingMessage,
+            SignedDirectMessage, SignedRoutingMessage,
+        },
+        parsec::{Request, Response},
+        rng, Authority,
+    };
+
+    use maidsafe_utilities::serialisation;
+    use rand::Rng;
+    use serde::Serialize;
+
+    let mut rng = rng::new();
+    let full_id = FullId::gen(&mut rng);
+
+    fn serialise<T: Serialize>(msg: &T) -> Vec<u8> {
+        unwrap!(serialisation::serialise(&msg))
+    }
+
+    let make_message =
+        |content| Message::Direct(unwrap!(SignedDirectMessage::new(content, &full_id)));
+
+    // Parsec doesn't provide constructors for requests and responses, but they have the same
+    // representation as a `Vec`, or a `()` in real or mock Parsec respectively.
+    #[allow(clippy::let_unit_value)]
+    let (req, rsp): (Request, Response) = {
+        #[cfg(feature = "mock_parsec")]
+        let repr = ();
+        #[cfg(not(feature = "mock_parsec"))]
+        let repr = Vec::<u64>::new();
+
+        (
+            unwrap!(serialisation::deserialise(&serialise(&repr))),
+            unwrap!(serialisation::deserialise(&serialise(&repr))),
+        )
+    };
+
+    let msgs = [
+        make_message(DirectMessage::ParsecPoke(23)),
+        make_message(DirectMessage::ParsecRequest(42, req)),
+        make_message(DirectMessage::ParsecResponse(1337, rsp)),
+    ];
+    for msg in &msgs {
+        assert!(Packet::Message(NetworkBytes::from(serialise(msg)), 0).is_parsec_gossip());
+    }
+
+    // No other direct message types contain a Parsec request or response.
+    let msgs = [
+        make_message(DirectMessage::BootstrapRequest(rng.gen())),
+        make_message(DirectMessage::ConnectionResponse),
+    ];
+    for msg in &msgs {
+        assert!(!Packet::Message(NetworkBytes::from(serialise(msg)), 0).is_parsec_gossip());
+    }
+
+    // A hop message never contains a Parsec message.
+    let msg = RoutingMessage {
+        src: Authority::Section(rand::random()),
+        dst: Authority::Section(rand::random()),
+        content: MessageContent::UserMessage(vec![rand::random(), rand::random(), rand::random()]),
+    };
+    let msg = SignedRoutingMessage::insecure(msg);
+    let msg = unwrap!(HopMessage::new(msg));
+    let msg = Message::Hop(msg);
+    assert!(!Packet::Message(NetworkBytes::from(serialise(&msg)), 0).is_parsec_gossip());
+
+    // No packet types other than `Message` represent a Parsec request or response.
+    let packets = [
+        Packet::BootstrapRequest(OurType::Client),
+        Packet::BootstrapSuccess,
+        Packet::BootstrapFailure,
+        Packet::ConnectRequest(OurType::Client),
+        Packet::ConnectSuccess,
+        Packet::ConnectFailure,
+        Packet::MessageFailure(NetworkBytes::from_static(b"hello"), 0),
+        Packet::Disconnect,
+    ];
+    for packet in &packets {
+        assert!(!packet.is_parsec_gossip());
+    }
+}
+
 struct Agent {
     inner: QuicP2p,
     rx: Receiver<Event>,
@@ -594,24 +682,31 @@ fn assert_connected_to_node(event: Event, addr: &SocketAddr) {
 
 // Generate unique message.
 fn gen_message() -> NetworkBytes {
-    use crate::{
-        id::FullId,
-        messages::{DirectMessage, Message, SignedDirectMessage},
-        rng,
-    };
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let num = COUNTER.fetch_add(1, Ordering::Relaxed);
 
-    thread_local! {
-        static FULL_ID: FullId = FullId::gen(&mut rng::new());
+    #[cfg(feature = "mock_serialise")]
+    {
+        use crate::{
+            id::FullId,
+            messages::{DirectMessage, Message, SignedDirectMessage},
+            rng,
+        };
+
+        thread_local! {
+            static FULL_ID: FullId = FullId::gen(&mut rng::new());
+        }
+
+        // The actual content of the message doesn't matter for the purposes of these tests, only
+        // that it is unique. Let's use `DirectMessage::ParsecPoke` as it is the simplest message
+        // that carries some data.
+        let content = DirectMessage::ParsecPoke(num as u64);
+        let message = FULL_ID.with(|full_id| unwrap!(SignedDirectMessage::new(content, full_id)));
+        NetworkBytes::new(Message::Direct(message))
     }
 
-    // The actual content of the message doesn't matter for the purposes of these tests, only
-    // that it is unique. Let's use `DirectMessage::ParsecPoke` as it is the simplest message
-    // that carries some data.
-    let content = DirectMessage::ParsecPoke(num as u64);
-    let message = FULL_ID.with(|full_id| unwrap!(SignedDirectMessage::new(content, full_id)));
-    NetworkBytes::new(Message::Direct(message))
+    #[cfg(not(feature = "mock_serialise"))]
+    bytes::Bytes::from(format!("message {}", num))
 }

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -407,7 +407,7 @@ fn packet_is_parsec_gossip() {
 
     // Real parsec doesn't provide constructors for requests and responses, but they have the same
     // representation as a `Vec`.
-    #[cfg(not(feature = "mock_parsec"))]
+    #[cfg(not(feature = "mock"))]
     let (req, rsp): (Request, Response) = {
         let repr = Vec::<u64>::new();
 
@@ -417,7 +417,7 @@ fn packet_is_parsec_gossip() {
         )
     };
 
-    #[cfg(feature = "mock_parsec")]
+    #[cfg(feature = "mock")]
     let (req, rsp) = (Request::new(), Response::new());
 
     let msgs = [

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -458,22 +458,22 @@ pub trait Base: Display {
 pub fn to_network_bytes(
     message: &Message,
 ) -> Result<NetworkBytes, (serialisation::SerialisationError, &Message)> {
-    #[cfg(not(feature = "mock_base"))]
+    #[cfg(not(feature = "mock_serialise"))]
     let result = Ok(NetworkBytes::from(
         serialisation::serialise(message).map_err(|err| (err, message))?,
     ));
 
-    #[cfg(feature = "mock_base")]
+    #[cfg(feature = "mock_serialise")]
     let result = Ok(NetworkBytes::new(message.clone()));
 
     result
 }
 
 pub fn from_network_bytes(data: NetworkBytes) -> Result<Message, RoutingError> {
-    #[cfg(not(feature = "mock_base"))]
+    #[cfg(not(feature = "mock_serialise"))]
     let result = serialisation::deserialise(&data[..]).map_err(RoutingError::SerialisationError);
 
-    #[cfg(feature = "mock_base")]
+    #[cfg(feature = "mock_serialise")]
     let result = Ok((*data).clone());
 
     result

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -59,6 +59,8 @@ use std::{
 #[cfg(feature = "mock_base")]
 use crate::messages::Message;
 
+/// Time after which a `Ticked` event is sent.
+const TICK_TIMEOUT: Duration = Duration::from_secs(15);
 /// Time after which an Elder should send a new Gossip.
 const GOSSIP_TIMEOUT: Duration = Duration::from_secs(2);
 /// Number of RelocatePrepare to consensus before actually relocating a node.
@@ -112,6 +114,7 @@ pub struct Elder {
     direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
     routing_msg_filter: RoutingMessageFilter,
     sig_accumulator: SignatureAccumulator,
+    tick_timer_token: u64,
     timer: Timer,
     parsec_map: ParsecMap,
     gen_pfx_info: GenesisPfxInfo,
@@ -262,6 +265,7 @@ impl Elder {
 
     fn new(details: ElderDetails) -> Self {
         let timer = details.timer;
+        let tick_timer_token = timer.schedule(TICK_TIMEOUT);
         let gossip_timer_token = timer.schedule(GOSSIP_TIMEOUT);
 
         Self {
@@ -272,6 +276,7 @@ impl Elder {
             direct_msg_backlog: details.direct_msg_backlog,
             routing_msg_filter: details.routing_msg_filter,
             sig_accumulator: details.sig_accumulator,
+            tick_timer_token,
             timer,
             parsec_map: details.parsec_map,
             gen_pfx_info: details.gen_pfx_info,
@@ -1312,7 +1317,12 @@ impl Base for Elder {
     }
 
     fn handle_timeout(&mut self, token: u64, outbox: &mut dyn EventBox) -> Transition {
-        if self.gossip_timer_token == token {
+        if self.tick_timer_token == token {
+            // TODO: we no longer need tick for any internal purposes. Verify it is not needed by
+            // the upper layers and remove it.
+            self.tick_timer_token = self.timer.schedule(TICK_TIMEOUT);
+            outbox.send_event(Event::TimerTicked);
+        } else if self.gossip_timer_token == token {
             self.gossip_timer_token = self.timer.schedule(GOSSIP_TIMEOUT);
 
             // If we're the only node then invoke parsec_poll directly

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -375,6 +375,7 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
                 | Event::SectionSplit(..)
                 | Event::RestartRequired
                 | Event::ClientEvent(..)
+                | Event::TimerTicked
                 | Event::Connected(ConnectEvent::Relocate) => (),
                 event => panic!("Got unexpected event: {:?}", event),
             }
@@ -450,6 +451,7 @@ pub fn add_connected_nodes_until_split(
     clear_all_event_queues(nodes, |node, event| match event {
         Event::NodeAdded(..)
         | Event::NodeLost(..)
+        | Event::TimerTicked
         | Event::ClientEvent(..)
         | Event::SectionSplit(..)
         | Event::Connected(ConnectEvent::Relocate) => (),

--- a/tests/mock_network_tests.rs
+++ b/tests/mock_network_tests.rs
@@ -71,6 +71,7 @@ macro_rules! expect_next_event {
         loop {
             match $node.inner.try_next_ev() {
                 Ok($pattern) => break,
+                Ok(Event::TimerTicked) => (),
                 other => panic!(
                     "Expected Ok({}) at {}, got {:?}",
                     stringify!($pattern),
@@ -110,6 +111,7 @@ macro_rules! expect_any_event {
 macro_rules! expect_no_event {
     ($node:expr) => {{
         match $node.inner.try_next_ev() {
+            Ok(Event::TimerTicked) => (),
             Err(crossbeam_channel::TryRecvError::Empty) => (),
             other => panic!("Expected no event at {}, got {:?}", $node.name(), other),
         }


### PR DESCRIPTION
Some of these should be re-applied together with fix with safe_vault if needed.
Take some commits from https://github.com/maidsafe/routing/pull/1994

Test:
Verify safe_vault test pass with small modification to cargo.toml