### PR TITLE
clean up timer to avoid work arround in safe_vault

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -103,9 +103,6 @@ pub enum Event {
     RestartRequired,
     /// Startup failed - terminate.
     Terminated,
-    // TODO: Find a better solution for periodic tasks.
-    /// This event is sent periodically every time Routing sends the `Heartbeat` messages.
-    TimerTicked,
     /// Consensus on a custom event.
     Consensus(Vec<u8>),
 }
@@ -145,7 +142,6 @@ impl Debug for Event {
             }
             Self::RestartRequired => write!(formatter, "Event::RestartRequired"),
             Self::Terminated => write!(formatter, "Event::Terminated"),
-            Self::TimerTicked => write!(formatter, "Event::TimerTicked"),
             Self::Consensus(ref payload) => {
                 write!(formatter, "Event::Consensus({:<8})", HexFmt(payload))
             }

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -478,6 +478,10 @@ impl StateMachine {
 
     /// Register the state machine event channels with the provided [selector](mpmc::Select).
     pub fn register<'a>(&'a mut self, select: &mut mpmc::Select<'a>) {
+        // Populate action_rx timeouts
+        #[cfg(feature = "mock_base")]
+        self.state.process_timers();
+
         let network_rx_idx = select.recv(&self.network_rx);
         let action_rx_idx = select.recv(&self.action_rx);
         self.network_rx_idx = network_rx_idx;

--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -467,8 +467,8 @@ impl Adult {
         &self.chain
     }
 
-    pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
-        self.timer.get_timed_out_tokens()
+    pub fn process_timers(&mut self) {
+        self.timer.process_timers()
     }
 
     pub fn has_unpolled_observations(&self) -> bool {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1512,8 +1512,8 @@ impl Elder {
         &self.chain
     }
 
-    pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
-        self.timer.get_timed_out_tokens()
+    pub fn process_timers(&mut self) {
+        self.timer.process_timers()
     }
 
     pub fn has_unpolled_observations(&self) -> bool {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -59,8 +59,6 @@ use std::{
 #[cfg(feature = "mock_base")]
 use crate::messages::Message;
 
-/// Time after which a `Ticked` event is sent.
-const TICK_TIMEOUT: Duration = Duration::from_secs(15);
 /// Time after which an Elder should send a new Gossip.
 const GOSSIP_TIMEOUT: Duration = Duration::from_secs(2);
 /// Number of RelocatePrepare to consensus before actually relocating a node.
@@ -114,7 +112,6 @@ pub struct Elder {
     direct_msg_backlog: Vec<(P2pNode, DirectMessage)>,
     routing_msg_filter: RoutingMessageFilter,
     sig_accumulator: SignatureAccumulator,
-    tick_timer_token: u64,
     timer: Timer,
     parsec_map: ParsecMap,
     gen_pfx_info: GenesisPfxInfo,
@@ -265,7 +262,6 @@ impl Elder {
 
     fn new(details: ElderDetails) -> Self {
         let timer = details.timer;
-        let tick_timer_token = timer.schedule(TICK_TIMEOUT);
         let gossip_timer_token = timer.schedule(GOSSIP_TIMEOUT);
 
         Self {
@@ -276,7 +272,6 @@ impl Elder {
             direct_msg_backlog: details.direct_msg_backlog,
             routing_msg_filter: details.routing_msg_filter,
             sig_accumulator: details.sig_accumulator,
-            tick_timer_token,
             timer,
             parsec_map: details.parsec_map,
             gen_pfx_info: details.gen_pfx_info,
@@ -1317,12 +1312,7 @@ impl Base for Elder {
     }
 
     fn handle_timeout(&mut self, token: u64, outbox: &mut dyn EventBox) -> Transition {
-        if self.tick_timer_token == token {
-            // TODO: we no longer need tick for any internal purposes. Verify it is not needed by
-            // the upper layers and remove it.
-            self.tick_timer_token = self.timer.schedule(TICK_TIMEOUT);
-            outbox.send_event(Event::TimerTicked);
-        } else if self.gossip_timer_token == token {
+        if self.gossip_timer_token == token {
             self.gossip_timer_token = self.timer.schedule(GOSSIP_TIMEOUT);
 
             // If we're the only node then invoke parsec_poll directly

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -189,8 +189,8 @@ impl JoiningPeer {
     }
 
     #[cfg(feature = "mock_base")]
-    pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
-        self.timer.get_timed_out_tokens()
+    pub fn process_timers(&mut self) {
+        self.timer.process_timers()
     }
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -6,257 +6,233 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-pub use self::implementation::Timer;
-
+use crate::{
+    action::Action,
+    time::{Duration, Instant},
+};
+use crossbeam_channel as mpmc;
+use itertools::Itertools;
 #[cfg(not(feature = "mock_base"))]
-mod implementation {
-    use crate::{
-        action::Action,
-        time::{Duration, Instant},
-    };
-    use crossbeam_channel as mpmc;
-    use itertools::Itertools;
-    use maidsafe_utilities::thread::{self, Joiner};
-    use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::mpsc};
+use maidsafe_utilities::thread::{self, Joiner};
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::mpsc};
 
-    struct Detail {
-        expiry: Instant,
-        token: u64,
-    }
+struct Detail {
+    expiry: Instant,
+    token: u64,
+}
 
-    /// Simple timer.
-    #[derive(Clone)]
-    pub struct Timer {
-        inner: Rc<RefCell<Inner>>,
-    }
+/// Simple timer.
+#[derive(Clone)]
+pub struct Timer {
+    inner: Rc<RefCell<Inner>>,
+}
 
-    struct Inner {
-        next_token: u64,
-        tx: mpsc::SyncSender<Detail>,
-        _worker: Joiner,
-    }
+struct Inner {
+    next_token: u64,
 
-    impl Timer {
-        /// Creates a new timer, passing a channel sender used to send `Timeout` events.
-        pub fn new(sender: mpmc::Sender<Action>) -> Self {
+    #[cfg(not(feature = "mock_base"))]
+    tx: mpsc::SyncSender<Detail>,
+    #[cfg(not(feature = "mock_base"))]
+    _worker: Joiner,
+
+    #[cfg(feature = "mock_base")]
+    tx: mpsc::Sender<Detail>,
+    #[cfg(feature = "mock_base")]
+    _worker: Box<dyn FnMut()>,
+}
+
+impl Timer {
+    /// Creates a new timer, passing a channel sender used to send `Timeout` events.
+    pub fn new(sender: mpmc::Sender<Action>) -> Self {
+        #[cfg(not(feature = "mock_base"))]
+        let (tx, worker) = {
             let (tx, rx) = mpsc::sync_channel(1);
-
             let worker = thread::named("Timer", move || Self::run(sender, rx));
+            (tx, worker)
+        };
 
-            Self {
-                inner: Rc::new(RefCell::new(Inner {
-                    next_token: 0,
-                    tx,
-                    _worker: worker,
-                })),
-            }
+        #[cfg(feature = "mock_base")]
+        let (tx, worker) = {
+            let (tx, mut rx) = mpsc::channel();
+            let mut deadlines = BTreeMap::default();
+            let worker =
+                Box::new(move || Self::do_process_timers(&mut deadlines, &sender, &mut rx));
+            (tx, worker)
+        };
+
+        Self {
+            inner: Rc::new(RefCell::new(Inner {
+                next_token: 0,
+                tx,
+                _worker: worker,
+            })),
         }
+    }
 
-        // TODO Do proper error handling here by returning a result - currently complying it with
-        // existing code and logging and error
-        /// Schedules a timeout event after `duration`. Returns a token that can be used to identify
-        /// the timeout event.
-        pub fn schedule(&self, duration: Duration) -> u64 {
-            let mut inner = self.inner.borrow_mut();
+    // TODO Do proper error handling here by returning a result - currently complying it with
+    // existing code and logging and error
+    /// Schedules a timeout event after `duration`. Returns a token that can be used to identify
+    /// the timeout event.
+    pub fn schedule(&self, duration: Duration) -> u64 {
+        let mut inner = self.inner.borrow_mut();
 
-            let token = inner.next_token;
-            inner.next_token = token.wrapping_add(1);
+        let token = inner.next_token;
+        inner.next_token = token.wrapping_add(1);
 
-            let detail = Detail {
-                expiry: Instant::now() + duration,
-                token,
-            };
-            inner.tx.send(detail).map(|()| token).unwrap_or_else(|e| {
-                error!("Timer could not be scheduled: {:?}", e);
-                0
-            })
-        }
+        let detail = Detail {
+            expiry: Instant::now() + duration,
+            token,
+        };
+        inner.tx.send(detail).map(|()| token).unwrap_or_else(|e| {
+            error!("Timer could not be scheduled: {:?}", e);
+            0
+        })
+    }
 
-        fn run(sender: mpmc::Sender<Action>, rx: mpsc::Receiver<Detail>) {
-            let mut deadlines: BTreeMap<Instant, Vec<u64>> = Default::default();
+    #[cfg(not(feature = "mock_base"))]
+    fn run(sender: mpmc::Sender<Action>, rx: mpsc::Receiver<Detail>) {
+        let mut deadlines: BTreeMap<Instant, Vec<u64>> = Default::default();
 
-            loop {
-                let r = if let Some(t) = deadlines.keys().next() {
-                    let now = Instant::now();
-                    if *t > now {
-                        let duration = *t - now;
-                        match rx.recv_timeout(duration) {
-                            Ok(d) => Some(d),
-                            Err(mpsc::RecvTimeoutError::Timeout) => None,
-                            Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                        }
-                    } else {
-                        None
+        loop {
+            let r = if let Some(t) = deadlines.keys().next() {
+                let now = Instant::now();
+                if *t > now {
+                    let duration = *t - now;
+                    match rx.recv_timeout(duration) {
+                        Ok(d) => Some(d),
+                        Err(mpsc::RecvTimeoutError::Timeout) => None,
+                        Err(mpsc::RecvTimeoutError::Disconnected) => break,
                     }
                 } else {
-                    match rx.recv() {
-                        Ok(d) => Some(d),
-                        Err(mpsc::RecvError) => break,
-                    }
-                };
-
-                if let Some(Detail { expiry, token }) = r {
-                    deadlines.entry(expiry).or_insert_with(Vec::new).push(token);
+                    None
                 }
-
-                let now = Instant::now();
-                let expired_list = deadlines
-                    .keys()
-                    .take_while(|&&deadline| deadline < now)
-                    .cloned()
-                    .collect_vec();
-                for expired in expired_list {
-                    // Safe to call `expect()` as we just got the key we're removing from
-                    // `deadlines`.
-                    let tokens = deadlines.remove(&expired).expect("Bug in `BTreeMap`.");
-                    for token in tokens {
-                        let _ = sender.send(Action::HandleTimeout(token));
-                    }
+            } else {
+                match rx.recv() {
+                    Ok(d) => Some(d),
+                    Err(mpsc::RecvError) => break,
                 }
+            };
+
+            if let Some(Detail { expiry, token }) = r {
+                deadlines.entry(expiry).or_insert_with(Vec::new).push(token);
+            }
+
+            Self::process_deadlines(&mut deadlines, &sender);
+        }
+    }
+
+    fn process_deadlines(
+        deadlines: &mut BTreeMap<Instant, Vec<u64>>,
+        sender: &mpmc::Sender<Action>,
+    ) {
+        let now = Instant::now();
+        let expired_list = deadlines
+            .keys()
+            .take_while(|&&deadline| deadline < now)
+            .cloned()
+            .collect_vec();
+        for expired in expired_list {
+            // Safe to call `expect()` as we just got the key we're removing from
+            // `deadlines`.
+            let tokens = deadlines.remove(&expired).expect("Bug in `BTreeMap`.");
+            for token in tokens {
+                let _ = sender.send(Action::HandleTimeout(token));
             }
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use crate::action::Action;
-        use std::thread;
-        use std::time::{Duration, Instant};
+    #[cfg(feature = "mock_base")]
+    pub fn process_timers(&self) {
+        let mut inner = self.inner.borrow_mut();
+        let process_timers = &mut *inner._worker;
+        process_timers();
+    }
 
-        #[test]
-        fn schedule() {
-            let (action_tx, action_rx) = mpmc::unbounded();
-            let interval = Duration::from_millis(500);
-            let instant_when_added;
-            let check_no_events_received = || {
-                let action = action_rx.try_recv();
-                assert!(
-                    action.is_err(),
-                    "Expected no event, but received {:?}",
-                    action
-                );
-            };
-            {
-                let timer = Timer::new(action_tx);
-
-                // Add deadlines, the first to time out after 2.5s, the second after 2.0s, and so on
-                // down to 500ms.
-                let count = 5;
-                for i in 0..count {
-                    let timeout = interval * (count - i);
-                    let token = timer.schedule(timeout);
-                    assert_eq!(token, u64::from(i));
-                }
-
-                // Ensure timeout notifications are received correctly.
-                thread::sleep(Duration::from_millis(100));
-                for i in 0..count {
-                    check_no_events_received();
-                    thread::sleep(interval);
-
-                    let action = action_rx.try_recv();
-                    match action.expect("Should have received an action.") {
-                        Action::HandleTimeout(token) => assert_eq!(token, u64::from(count - i - 1)),
-                        unexpected_action => {
-                            panic!(
-                                "Expected `Action::HandleTimeout`, but received {:?}",
-                                unexpected_action
-                            );
-                        }
-                    }
-                }
-
-                // Add deadline and check that dropping `timer` doesn't fire a timeout notification,
-                // and that dropping doesn't block until the deadline has expired.
-                instant_when_added = Instant::now();
-                let _ = timer.schedule(interval);
-            }
-
-            assert!(
-                Instant::now() - instant_when_added < interval,
-                "`Timer::drop()` is blocking."
-            );
-
-            thread::sleep(interval + Duration::from_millis(100));
-            check_no_events_received();
+    #[cfg(feature = "mock_base")]
+    fn do_process_timers(
+        deadlines: &mut BTreeMap<Instant, Vec<u64>>,
+        sender: &mpmc::Sender<Action>,
+        rx: &mut mpsc::Receiver<Detail>,
+    ) {
+        while let Ok(Detail { expiry, token }) = rx.try_recv() {
+            deadlines.entry(expiry).or_insert_with(Vec::new).push(token);
         }
 
-        #[test]
-        fn heavy_duty_time_out() {
-            let (action_tx, _) = mpmc::unbounded();
-            let timer = Timer::new(action_tx);
-            for _ in 0..1000 {
-                let _ = timer.schedule(Duration::new(0, 3000));
-            }
-        }
+        Self::process_deadlines(deadlines, sender);
     }
 }
 
-#[cfg(feature = "mock_base")]
-mod implementation {
-    use crate::{
-        action::Action,
-        time::{Duration, Instant},
-        unwrap,
-    };
-    use crossbeam_channel as mpmc;
-    use itertools::Itertools;
-    use std::cell::RefCell;
-    use std::collections::BTreeMap;
-    use std::rc::Rc;
+#[cfg(all(test, not(feature = "mock_base")))]
+mod tests {
+    use super::*;
+    use crate::action::Action;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
-    struct Inner {
-        next_token: u64,
-        deadlines: BTreeMap<Instant, Vec<u64>>,
-    }
+    #[test]
+    fn schedule() {
+        let (action_tx, action_rx) = mpmc::unbounded();
+        let interval = Duration::from_millis(500);
+        let instant_when_added;
+        let check_no_events_received = || {
+            let action = action_rx.try_recv();
+            assert!(
+                action.is_err(),
+                "Expected no event, but received {:?}",
+                action
+            );
+        };
+        {
+            let timer = Timer::new(action_tx);
 
-    #[derive(Clone)]
-    pub struct Timer {
-        inner: Rc<RefCell<Inner>>,
-    }
-
-    impl Timer {
-        pub fn new(_action_sender: mpmc::Sender<Action>) -> Self {
-            Self {
-                inner: Rc::new(RefCell::new(Inner {
-                    next_token: 0,
-                    deadlines: Default::default(),
-                })),
+            // Add deadlines, the first to time out after 2.5s, the second after 2.0s, and so on
+            // down to 500ms.
+            let count = 5;
+            for i in 0..count {
+                let timeout = interval * (count - i);
+                let token = timer.schedule(timeout);
+                assert_eq!(token, u64::from(i));
             }
+
+            // Ensure timeout notifications are received correctly.
+            thread::sleep(Duration::from_millis(100));
+            for i in 0..count {
+                check_no_events_received();
+                thread::sleep(interval);
+
+                let action = action_rx.try_recv();
+                match action.expect("Should have received an action.") {
+                    Action::HandleTimeout(token) => assert_eq!(token, u64::from(count - i - 1)),
+                    unexpected_action => {
+                        panic!(
+                            "Expected `Action::HandleTimeout`, but received {:?}",
+                            unexpected_action
+                        );
+                    }
+                }
+            }
+
+            // Add deadline and check that dropping `timer` doesn't fire a timeout notification,
+            // and that dropping doesn't block until the deadline has expired.
+            instant_when_added = Instant::now();
+            let _ = timer.schedule(interval);
         }
 
-        pub fn schedule(&self, duration: Duration) -> u64 {
-            let mut inner = self.inner.borrow_mut();
+        assert!(
+            Instant::now() - instant_when_added < interval,
+            "`Timer::drop()` is blocking."
+        );
 
-            let token = inner.next_token;
-            inner.next_token = token.wrapping_add(1);
+        thread::sleep(interval + Duration::from_millis(100));
+        check_no_events_received();
+    }
 
-            inner
-                .deadlines
-                .entry(Instant::now() + duration)
-                .or_insert_with(Vec::new)
-                .push(token);
-            token
-        }
-
-        pub fn get_timed_out_tokens(&mut self) -> Vec<u64> {
-            let mut inner = self.inner.borrow_mut();
-            let now = Instant::now();
-            let expired_list = inner
-                .deadlines
-                .keys()
-                .take_while(|&&deadline| deadline < now)
-                .cloned()
-                .collect_vec();
-            let mut expired_tokens = Vec::new();
-            for expired in expired_list {
-                // Safe to call `unwrap!()` as we just got the key we're removing from
-                // `deadlines`.
-                let tokens = unwrap!(inner.deadlines.remove(&expired));
-                expired_tokens.extend(tokens);
-            }
-            expired_tokens
+    #[test]
+    fn heavy_duty_time_out() {
+        let (action_tx, _) = mpmc::unbounded();
+        let timer = Timer::new(action_tx);
+        for _ in 0..1000 {
+            let _ = timer.schedule(Duration::new(0, 3000));
         }
     }
 }

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -375,7 +375,6 @@ pub fn create_connected_nodes(network: &Network, size: usize) -> Nodes {
                 | Event::SectionSplit(..)
                 | Event::RestartRequired
                 | Event::ClientEvent(..)
-                | Event::TimerTicked
                 | Event::Connected(ConnectEvent::Relocate) => (),
                 event => panic!("Got unexpected event: {:?}", event),
             }
@@ -451,7 +450,6 @@ pub fn add_connected_nodes_until_split(
     clear_all_event_queues(nodes, |node, event| match event {
         Event::NodeAdded(..)
         | Event::NodeLost(..)
-        | Event::TimerTicked
         | Event::ClientEvent(..)
         | Event::SectionSplit(..)
         | Event::Connected(ConnectEvent::Relocate) => (),

--- a/tests/mock_network_tests.rs
+++ b/tests/mock_network_tests.rs
@@ -71,7 +71,6 @@ macro_rules! expect_next_event {
         loop {
             match $node.inner.try_next_ev() {
                 Ok($pattern) => break,
-                Ok(Event::TimerTicked) => (),
                 other => panic!(
                     "Expected Ok({}) at {}, got {:?}",
                     stringify!($pattern),
@@ -111,7 +110,6 @@ macro_rules! expect_any_event {
 macro_rules! expect_no_event {
     ($node:expr) => {{
         match $node.inner.try_next_ev() {
-            Ok(Event::TimerTicked) => (),
             Err(crossbeam_channel::TryRecvError::Empty) => (),
             other => panic!("Expected no event at {}, got {:?}", $node.name(), other),
         }


### PR DESCRIPTION
Clean up timer to allow remove the incorrect call to `self.routing_node.borrow_mut().poll();` from safe_vault.

Test:
Verify test pass without that call using new routing.