### PR TITLE
fix/routing: avoid re-voting for completed event

### DIFF
--- a/src/states/adult.rs
+++ b/src/states/adult.rs
@@ -316,8 +316,12 @@ impl Adult {
         // This is problematic since Elders do additional checks before doing this.
         // This was necessary to merge the initial work for promotion demotion.
         let response = if self.our_prefix().matches(&destination) {
-            debug!("{} - Sending BootstrapResponse::Join to {}", self, p2p_node);
-            BootstrapResponse::Join(self.chain.our_info().clone())
+            let our_info = self.chain.our_info().clone();
+            debug!(
+                "{} - Sending BootstrapResponse::Join to {:?} ({:?})",
+                self, p2p_node, our_info
+            );
+            BootstrapResponse::Join(our_info)
         } else {
             let conn_infos: Vec<_> = self
                 .closest_known_elders_to(&destination)

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -264,15 +264,19 @@ impl Base for JoiningPeer {
             DirectMessage::BootstrapResponse(BootstrapResponse::Join(info)) => {
                 if info.version() > self.elders_info.version() {
                     if info.prefix().matches(self.name()) {
-                        info!("{} - Newer Join response for our prefix {:?}", self, info);
+                        info!(
+                            "{} - Newer Join response for our prefix {:?} from {:?}",
+                            self, info, p2p_node
+                        );
                         self.elders_info = info;
                         self.send_join_requests();
                     } else {
                         log_or_panic!(
                             LogLevel::Error,
-                            "{} - Newer Join response not for our prefix {:?}",
+                            "{} - Newer Join response not for our prefix {:?} from {:?}",
                             self,
-                            info
+                            info,
+                            p2p_node,
                         );
                     }
                 }


### PR DESCRIPTION
Fix aggressive_churn: [1221425541, 378878981, 107272102, 3204539950] at
dc2abe182b4eadcbd13f67c5e6c4dcb4f5ee59e8.

Address issue introduced with #1993: Ensure we filter out all completed
events.
Also improve logs for debuging.

Test:
Verify the seed is fixed.
soak test + clippy