### PR TITLE
fix/routing: remove uneeded NodeLost/NodeAdded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ lazy_static = { version = "~1", optional = true }
 log = "~0.3.8"
 lru_time_cache = "~0.8.1"
 maidsafe_utilities = "~0.18.0"
-mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", optional = true }
+mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "5c023b7ded2", optional = true }
 num-bigint = "~0.1.40"
 parsec = { git = "https://github.com/maidsafe/parsec", rev = "a3a1eb2" }
 # quic-p2p = "~0.2.0"
-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p" }
+quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "5c023b7ded2" }
 # rand in the versions used for compatibility
 rand = "0.7.2"
 rand_crypto = { package = "rand", version = "~0.6.5" }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -1767,21 +1767,18 @@ impl SectionKeys {
 }
 
 struct EldersChangeBuilder {
-    old_own: BTreeSet<P2pNode>,
     old_neighbour: BTreeSet<P2pNode>,
 }
 
 impl EldersChangeBuilder {
     fn new(chain: &Chain) -> Self {
         Self {
-            old_own: chain.our_info().member_nodes().cloned().collect(),
             old_neighbour: chain.neighbour_elder_nodes().cloned().collect(),
         }
     }
 
     fn build(self, chain: &Chain) -> EldersChange {
         let new_neighbour: BTreeSet<_> = chain.neighbour_elder_nodes().cloned().collect();
-        let new_own: BTreeSet<_> = chain.our_info().member_nodes().cloned().collect();
         EldersChange {
             neighbour_added: new_neighbour
                 .difference(&self.old_neighbour)
@@ -1792,8 +1789,6 @@ impl EldersChangeBuilder {
                 .difference(&new_neighbour)
                 .cloned()
                 .collect(),
-            own_added: new_own.difference(&self.old_own).cloned().collect(),
-            own_removed: self.old_own.difference(&new_own).cloned().collect(),
         }
     }
 }

--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -242,8 +242,4 @@ pub struct EldersChange {
     pub neighbour_added: BTreeSet<P2pNode>,
     // Peers that ceased to be elders.
     pub neighbour_removed: BTreeSet<P2pNode>,
-    // Peers that became elders.
-    pub own_added: BTreeSet<P2pNode>,
-    // Peers that ceased to be elders.
-    pub own_removed: BTreeSet<P2pNode>,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -91,10 +91,6 @@ pub enum Event {
         /// The destination authority that receives the message.
         dst: Authority<XorName>,
     },
-    /// A node has connected to us.
-    NodeAdded(XorName),
-    /// A node has disconnected from us.
-    NodeLost(XorName),
     /// Our own section has been split, resulting in the included `Prefix` for our new section.
     SectionSplit(Prefix<XorName>),
     /// The client has successfully connected to a proxy node on the network.
@@ -130,10 +126,6 @@ impl Debug for Event {
                 src,
                 dst
             ),
-            Self::NodeAdded(ref node_name) => {
-                write!(formatter, "Event::NodeAdded({:?})", node_name)
-            }
-            Self::NodeLost(ref node_name) => write!(formatter, "Event::NodeLost({:?})", node_name),
             Self::SectionSplit(ref prefix) => {
                 write!(formatter, "Event::SectionSplit({:?})", prefix)
             }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -263,11 +263,6 @@ pub trait Approved: Base {
                         related_info.len()
                     );
 
-                    for pub_id in group {
-                        // Notify upper layers about the new node.
-                        self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-                    }
-
                     self.chain_mut().handle_genesis_event(group, related_info)?;
                     self.set_pfx_successfully_polled(true);
 

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -324,8 +324,6 @@ impl Elder {
 
         // Handle the SectionInfo event which triggered us becoming established node.
         let change = EldersChange {
-            own_added: Default::default(),
-            own_removed: Default::default(),
             neighbour_added: self.chain.neighbour_elder_nodes().cloned().collect(),
             neighbour_removed: Default::default(),
         };
@@ -1706,14 +1704,6 @@ impl Approved for Elder {
         let is_member = elders_info.is_member(self.full_id.public_id());
 
         info!("{} - handle SectionInfo: {:?}.", self, elders_info);
-
-        for pub_id in &elders_change.own_added {
-            self.send_event(Event::NodeAdded(*pub_id.name()), outbox);
-        }
-
-        for pub_id in &elders_change.own_removed {
-            self.send_event(Event::NodeLost(*pub_id.name()), outbox);
-        }
 
         let complete_data = if info_prefix.is_extension_of(&old_pfx) {
             self.prepare_finalise_split()?

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -100,10 +100,13 @@ fn remove_unresponsive_node() {
         poll_and_resend(&mut nodes);
     }
 
-    // Verify the other nodes saw the paused node and removed it.
-    for node in nodes.iter_mut().filter(|n| n.inner.is_elder()) {
-        expect_any_event!(node, Event::NodeLost(_));
-    }
+    let still_has_unresponsibe_elder = nodes
+        .iter()
+        .map(|n| &n.inner)
+        .filter(|n| n.elders().any(|id| *id.name() == non_responsive_name))
+        .map(|n| format!("{}", n))
+        .collect_vec();
+    assert_eq!(still_has_unresponsibe_elder, Vec::<String>::new());
 }
 
 // Parameters for the churn tests.


### PR DESCRIPTION
Closes #1950

From a vault perspective, things like ElderChanged with a set of new
elders is likely to be more useful than individual event in sequence.

We are not really using these events in tests, and they really mean
Elder Promoted/Demoted, so remove these event.

Test:
clippy + tests.