### PR TITLE
Avoid unecessary serialize for Hop messages

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -109,6 +109,10 @@ impl HopMessageWithSerializedMessage {
         self.content
     }
 
+    pub fn routing_message(&self) -> &RoutingMessage {
+        self.content.routing_message()
+    }
+
     pub fn serialized_message(&self) -> Bytes {
         // Bytes is backed by Rc so clone is cheap and result in the same memory held.
         self.serialized_message.clone()

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -109,8 +109,9 @@ impl HopMessageWithSerializedMessage {
         self.content
     }
 
-    pub fn serialized_message(&self) -> &Bytes {
-        &self.serialized_message
+    pub fn serialized_message(&self) -> Bytes {
+        // Bytes is backed by Rc so clone is cheap and result in the same memory held.
+        self.serialized_message.clone()
     }
 
     pub fn message_dst(&self) -> &Location<XorName> {

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -6,9 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    crypto, id::PublicId, message_filter::MessageFilter, messages::HopMessageWithSerializedMessage,
-};
+use crate::{crypto, id::PublicId, message_filter::MessageFilter, messages::HopMessageWithBytes};
 use bytes::Bytes;
 use lru_time_cache::LruCache;
 use std::time::Duration;
@@ -54,8 +52,8 @@ impl RoutingMessageFilter {
     }
 
     // Filter incoming `RoutingMessage`. Return whether this specific message has already been seen.
-    pub fn filter_incoming(&mut self, msg: &HopMessageWithSerializedMessage) -> FilteringResult {
-        let hash = hash(&msg.serialized_message());
+    pub fn filter_incoming(&mut self, msg: &HopMessageWithBytes) -> FilteringResult {
+        let hash = hash(msg.full_message_bytes());
 
         if self.incoming.insert(&hash) > 1 {
             FilteringResult::KnownMessage
@@ -70,10 +68,10 @@ impl RoutingMessageFilter {
     // Return `KnownMessage` also if hashing the message fails - that can be handled elsewhere.
     pub fn filter_outgoing(
         &mut self,
-        msg: &HopMessageWithSerializedMessage,
+        msg: &HopMessageWithBytes,
         pub_id: &PublicId,
     ) -> FilteringResult {
-        let hash = hash(&msg.serialized_message());
+        let hash = hash(msg.full_message_bytes());
 
         if self.outgoing.insert((hash, *pub_id), ()).is_some() {
             FilteringResult::KnownMessage

--- a/src/routing_message_filter.rs
+++ b/src/routing_message_filter.rs
@@ -6,11 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{crypto, id::PublicId, message_filter::MessageFilter, messages::RoutingMessage};
+use crate::{
+    crypto, id::PublicId, message_filter::MessageFilter, messages::HopMessageWithSerializedMessage,
+};
+use bytes::Bytes;
 use lru_time_cache::LruCache;
-use maidsafe_utilities::serialisation::serialise;
-use serde::Serialize;
-use std::{fmt::Debug, time::Duration};
+use std::time::Duration;
 
 type Digest = [u8; 32];
 
@@ -53,11 +54,9 @@ impl RoutingMessageFilter {
     }
 
     // Filter incoming `RoutingMessage`. Return whether this specific message has already been seen.
-    pub fn filter_incoming(&mut self, msg: &RoutingMessage) -> FilteringResult {
-        let hash = match hash(msg) {
-            Some(hash) => hash,
-            None => return FilteringResult::NewMessage,
-        };
+    pub fn filter_incoming(&mut self, msg: &HopMessageWithSerializedMessage) -> FilteringResult {
+        let hash = hash(&msg.serialized_message());
+
         if self.incoming.insert(&hash) > 1 {
             FilteringResult::KnownMessage
         } else {
@@ -69,14 +68,18 @@ impl RoutingMessageFilter {
     // (and thus should not be sent, due to deduplication).
     //
     // Return `KnownMessage` also if hashing the message fails - that can be handled elsewhere.
-    pub fn filter_outgoing(&mut self, msg: &RoutingMessage, pub_id: &PublicId) -> FilteringResult {
-        hash(msg).map_or(FilteringResult::KnownMessage, |hash| {
-            if self.outgoing.insert((hash, *pub_id), ()).is_some() {
-                FilteringResult::KnownMessage
-            } else {
-                FilteringResult::NewMessage
-            }
-        })
+    pub fn filter_outgoing(
+        &mut self,
+        msg: &HopMessageWithSerializedMessage,
+        pub_id: &PublicId,
+    ) -> FilteringResult {
+        let hash = hash(&msg.serialized_message());
+
+        if self.outgoing.insert((hash, *pub_id), ()).is_some() {
+            FilteringResult::KnownMessage
+        } else {
+            FilteringResult::NewMessage
+        }
     }
 }
 
@@ -86,11 +89,6 @@ impl Default for RoutingMessageFilter {
     }
 }
 
-fn hash<T: Serialize + Debug>(msg: &T) -> Option<Digest> {
-    if let Ok(msg_bytes) = serialise(msg) {
-        Some(crypto::sha3_256(&msg_bytes))
-    } else {
-        trace!("Tried to filter oversized routing message: {:?}", msg);
-        None
-    }
+fn hash(msg_bytes: &Bytes) -> Digest {
+    crypto::sha3_256(msg_bytes)
 }

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -330,11 +330,10 @@ impl Adult {
         &mut self,
         msg: HopMessageWithSerializedMessage,
     ) -> Result<(), RoutingError> {
-        let signed_msg = msg.signed_routing_message();
         trace!(
             "{}: Forwarding message {:?} via elder targets {:?}",
             self,
-            signed_msg,
+            msg.signed_routing_message(),
             self.chain.our_elders().format(", ")
         );
 
@@ -386,12 +385,11 @@ impl Adult {
         &mut self,
         msg: HopMessageWithSerializedMessage,
     ) -> Result<Transition, RoutingError> {
-        let signed_msg = msg.signed_routing_message();
         if !self.routing_msg_filter.filter_incoming(&msg).is_new() {
             trace!(
                 "{} Known message: {:?} - not handling further",
                 self,
-                signed_msg.routing_message()
+                msg.routing_message()
             );
             return Ok(Transition::Stay);
         }
@@ -403,14 +401,14 @@ impl Adult {
         &mut self,
         msg: HopMessageWithSerializedMessage,
     ) -> Result<Transition, RoutingError> {
-        let signed_msg = msg.signed_routing_message();
         trace!(
             "{} - Handle signed message: {:?}",
             self,
-            signed_msg.routing_message()
+            msg.routing_message()
         );
 
-        if self.in_location(&signed_msg.routing_message().dst) {
+        if self.in_location(msg.message_dst()) {
+            let signed_msg = msg.signed_routing_message();
             self.check_signed_message_integrity(signed_msg)?;
 
             match &signed_msg.routing_message().content {

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -344,18 +344,16 @@ impl Adult {
             .our_elders()
             .filter(|p2p_node| {
                 routing_msg_filter
-                    .filter_outgoing(signed_msg.routing_message(), p2p_node.public_id())
+                    .filter_outgoing(&msg, p2p_node.public_id())
                     .is_new()
             })
             .map(|node| node.connection_info().clone())
             .collect();
 
-        self.send_message_to_targets(&targets, targets.len(), msg.serialized_message().clone());
+        self.send_message_to_targets(&targets, targets.len(), msg.serialized_message());
 
         // we've seen this message - don't handle it again if someone else sends it to us
-        let _ = self
-            .routing_msg_filter
-            .filter_incoming(signed_msg.routing_message());
+        let _ = self.routing_msg_filter.filter_incoming(&msg);
 
         Ok(())
     }
@@ -389,11 +387,7 @@ impl Adult {
         msg: HopMessageWithSerializedMessage,
     ) -> Result<Transition, RoutingError> {
         let signed_msg = msg.signed_routing_message();
-        if !self
-            .routing_msg_filter
-            .filter_incoming(signed_msg.routing_message())
-            .is_new()
-        {
+        if !self.routing_msg_filter.filter_incoming(&msg).is_new() {
             trace!(
                 "{} Known message: {:?} - not handling further",
                 self,

--- a/src/states/adult/tests.rs
+++ b/src/states/adult/tests.rs
@@ -58,7 +58,10 @@ impl AdultUnderTest {
         )
     }
 
-    fn genesis_update_message(&self, gen_pfx_info: GenesisPfxInfo) -> SignedRoutingMessage {
+    fn genesis_update_message(
+        &self,
+        gen_pfx_info: GenesisPfxInfo,
+    ) -> HopMessageWithSerializedMessage {
         let msg = RoutingMessage {
             src: Location::PrefixSection(Prefix::default()),
             dst: Location::Node(*self.adult.name()),
@@ -89,7 +92,7 @@ impl AdultUnderTest {
                 }
             }));
         msg.combine_signatures();
-        msg
+        unwrap!(HopMessageWithSerializedMessage::new(msg))
     }
 
     fn perform_elders_change(&mut self) {

--- a/src/states/adult/tests.rs
+++ b/src/states/adult/tests.rs
@@ -58,10 +58,7 @@ impl AdultUnderTest {
         )
     }
 
-    fn genesis_update_message(
-        &self,
-        gen_pfx_info: GenesisPfxInfo,
-    ) -> HopMessageWithSerializedMessage {
+    fn genesis_update_message(&self, gen_pfx_info: GenesisPfxInfo) -> HopMessageWithBytes {
         let msg = RoutingMessage {
             src: Location::PrefixSection(Prefix::default()),
             dst: Location::Node(*self.adult.name()),
@@ -92,7 +89,7 @@ impl AdultUnderTest {
                 }
             }));
         msg.combine_signatures();
-        unwrap!(HopMessageWithSerializedMessage::new(msg))
+        unwrap!(HopMessageWithBytes::new(msg))
     }
 
     fn perform_elders_change(&mut self) {

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -13,7 +13,7 @@ use crate::{
     event::Event,
     id::{FullId, P2pNode},
     location::Location,
-    messages::{BootstrapResponse, DirectMessage, HopMessageWithSerializedMessage},
+    messages::{BootstrapResponse, DirectMessage, HopMessageWithBytes},
     network_service::NetworkService,
     outbox::EventBox,
     peer_map::PeerMap,
@@ -321,7 +321,7 @@ impl Base for BootstrappingPeer {
 
     fn handle_hop_message(
         &mut self,
-        msg: HopMessageWithSerializedMessage,
+        msg: HopMessageWithBytes,
         _: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
         trace!(

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -12,8 +12,8 @@ use crate::{
     id::{FullId, P2pNode, PublicId},
     location::Location,
     messages::{
-        DirectMessage, HopMessageWithSerializedMessage, Message, MessageWithBytes,
-        SignedDirectMessage, SignedRoutingMessage,
+        DirectMessage, HopMessageWithBytes, Message, MessageWithBytes, SignedDirectMessage,
+        SignedRoutingMessage,
     },
     network_service::NetworkService,
     outbox::EventBox,
@@ -63,7 +63,7 @@ pub trait Base: Display {
 
     fn handle_hop_message(
         &mut self,
-        msg: HopMessageWithSerializedMessage,
+        msg: HopMessageWithBytes,
         outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError>;
 

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -11,5 +11,5 @@ mod base;
 
 pub use self::{
     approved::Approved,
-    base::{from_network_bytes, Base},
+    base::{from_network_bytes, to_network_bytes, Base},
 };

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -695,11 +695,7 @@ impl Elder {
         msg: HopMessageWithSerializedMessage,
     ) -> Result<(), RoutingError> {
         let signed_msg = msg.signed_routing_message();
-        if !self
-            .routing_msg_filter
-            .filter_incoming(signed_msg.routing_message())
-            .is_new()
-        {
+        if !self.routing_msg_filter.filter_incoming(&msg).is_new() {
             trace!(
                 "{} Known message: {:?} - not handling further",
                 self,
@@ -1253,18 +1249,16 @@ impl Elder {
             .into_iter()
             .filter(|p2p_node| {
                 self.routing_msg_filter
-                    .filter_outgoing(signed_msg.routing_message(), p2p_node.public_id())
+                    .filter_outgoing(msg, p2p_node.public_id())
                     .is_new()
             })
             .map(|node| node.connection_info().clone())
             .collect();
 
-        self.send_message_to_targets(&targets, dg_size, msg.serialized_message().clone());
+        self.send_message_to_targets(&targets, dg_size, msg.serialized_message());
 
         // we've seen this message - don't handle it again if someone else sends it to us
-        let _ = self
-            .routing_msg_filter
-            .filter_incoming(signed_msg.routing_message());
+        let _ = self.routing_msg_filter.filter_incoming(msg);
 
         Ok(())
     }

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -303,11 +303,7 @@ impl Base for JoiningPeer {
     ) -> Result<Transition, RoutingError> {
         let signed_message = msg.signed_routing_message();
 
-        if !self
-            .routing_msg_filter
-            .filter_incoming(signed_message.routing_message())
-            .is_new()
-        {
+        if !self.routing_msg_filter.filter_incoming(&msg).is_new() {
             trace!(
                 "{} Known message: {:?} - not handling further",
                 self,

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -18,8 +18,8 @@ use crate::{
     id::{FullId, P2pNode},
     location::Location,
     messages::{
-        BootstrapResponse, DirectMessage, HopMessageWithSerializedMessage, JoinRequest,
-        MessageContent, RoutingMessage, SignedRoutingMessage,
+        BootstrapResponse, DirectMessage, HopMessageWithBytes, JoinRequest, MessageContent,
+        RoutingMessage, SignedRoutingMessage,
     },
     network_service::NetworkService,
     outbox::EventBox,
@@ -298,7 +298,7 @@ impl Base for JoiningPeer {
 
     fn handle_hop_message(
         &mut self,
-        msg: HopMessageWithSerializedMessage,
+        msg: HopMessageWithBytes,
         outbox: &mut dyn EventBox,
     ) -> Result<Transition, RoutingError> {
         if !self.routing_msg_filter.filter_incoming(&msg).is_new() {

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -30,7 +30,7 @@ fn send_message(nodes: &mut Nodes, src: usize, dst: usize, message: Message) {
     let _ = nodes[src]
         .inner
         .elder_state_mut()
-        .map(|state| state.send_msg_to_targets(&targets, 1, message));
+        .map(|state| unwrap!(state.send_msg_to_targets(&targets, 1, message)));
 }
 
 enum FailType {


### PR DESCRIPTION
Partially addresses #2010 
Closes #2011 

Avoid throwing away the serialized data we get from quic_p2p, and re-use it for filtering and for re-sending the Hop message.

Building on this work, we should avoid de-serializing the full message when all we need is the destination if we are not part of the destination authority.

We can probably also futher clean up the code following this change, in particular it is not clear we still need the HopMessage type.