### PR TITLE
Authority -> Location

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{authority::Authority, error::InterfaceError, xor_space::XorName};
+use crate::{error::InterfaceError, location::Location, xor_space::XorName};
 use bytes::Bytes;
 use hex_fmt::HexFmt;
 use quic_p2p::Token;
@@ -24,8 +24,8 @@ use std::{
 ///       After completion `Core` will send `Event::Terminated`.
 pub enum Action {
     SendMessage {
-        src: Authority<XorName>,
-        dst: Authority<XorName>,
+        src: Location<XorName>,
+        dst: Location<XorName>,
         content: Vec<u8>,
         result_tx: Sender<Result<(), InterfaceError>>,
     },

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -14,9 +14,9 @@ use super::{
     SectionProofChain,
 };
 use crate::{
-    authority::Authority,
     error::RoutingError,
     id::{P2pNode, PublicId},
+    location::Location,
     parsec::{DkgResult, DkgResultWrapper},
     relocation::{self, RelocateDetails},
     utils::LogIdent,
@@ -907,16 +907,16 @@ impl Chain {
     }
 
     /// Provide a SectionProofChain that proves the given signature to the given destination
-    /// authority.
+    /// location.
     /// If `node_knowledge_override` is `Some`, it is used when calculating proof for
-    /// `Authority::Node` instead of the stored knowledge. Has no effect for other authority types.
+    /// `Location::Node` instead of the stored knowledge. Has no effect for other location types.
     pub fn prove(
         &self,
-        target: &Authority<XorName>,
+        target: &Location<XorName>,
         node_knowledge_override: Option<u64>,
     ) -> SectionProofChain {
         let first_index = match (target, node_knowledge_override) {
-            (Authority::Node(_), Some(knowledge)) => knowledge,
+            (Location::Node(_), Some(knowledge)) => knowledge,
             _ => self.state.proving_index(target),
         };
 
@@ -1396,17 +1396,17 @@ impl Chain {
         result
     }
 
-    /// Returns a set of nodes to which a message for the given `Authority` could be sent
+    /// Returns a set of nodes to which a message for the given `Location` could be sent
     /// onwards, sorted by priority, along with the number of targets the message should be sent to.
     /// If the total number of targets returned is larger than this number, the spare targets can
     /// be used if the message can't be delivered to some of the initial ones.
     ///
-    /// * If the destination is an `Authority::Section`:
+    /// * If the destination is an `Location::Section`:
     ///     - if our section is the closest on the network (i.e. our section's prefix is a prefix of
     ///       the destination), returns all other members of our section; otherwise
     ///     - returns the `N/3` closest members to the target
     ///
-    /// * If the destination is an `Authority::PrefixSection`:
+    /// * If the destination is an `Location::PrefixSection`:
     ///     - if the prefix is compatible with our prefix and is fully-covered by prefixes in our
     ///       RT, returns all members in these prefixes except ourself; otherwise
     ///     - if the prefix is compatible with our prefix and is *not* fully-covered by prefixes in
@@ -1418,12 +1418,9 @@ impl Chain {
     ///     - if our name *is* the destination, returns an empty set; otherwise
     ///     - if the destination name is an entry in the routing table, returns it; otherwise
     ///     - returns the `N/3` closest members of the RT to the target
-    pub fn targets(
-        &self,
-        dst: &Authority<XorName>,
-    ) -> Result<(Vec<&P2pNode>, usize), RoutingError> {
+    pub fn targets(&self, dst: &Location<XorName>) -> Result<(Vec<&P2pNode>, usize), RoutingError> {
         let (best_section, dg_size) = match *dst {
-            Authority::Node(ref target_name) => {
+            Location::Node(ref target_name) => {
                 if target_name == self.our_id().name() {
                     return Ok((Vec::new(), 0));
                 }
@@ -1432,7 +1429,7 @@ impl Chain {
                 }
                 self.candidates(target_name)?
             }
-            Authority::Section(ref target_name) => {
+            Location::Section(ref target_name) => {
                 let (prefix, section) = self.closest_section_info(*target_name);
                 if prefix == self.our_prefix() || prefix.is_neighbour(self.our_prefix()) {
                     // Exclude our name since we don't need to send to ourself
@@ -1449,7 +1446,7 @@ impl Chain {
                 }
                 self.candidates(target_name)?
             }
-            Authority::PrefixSection(ref prefix) => {
+            Location::PrefixSection(ref prefix) => {
                 if prefix.is_compatible(self.our_prefix()) || prefix.is_neighbour(self.our_prefix())
                 {
                     // only route the message when we have all the targets in our chain -
@@ -1528,12 +1525,12 @@ impl Chain {
         }
     }
 
-    /// Returns whether we are a part of the given authority.
-    pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
+    /// Returns whether we are a part of the given location.
+    pub fn in_location(&self, auth: &Location<XorName>) -> bool {
         match *auth {
-            Authority::Node(ref name) => self.our_id().name() == name,
-            Authority::Section(ref name) => self.our_prefix().matches(name),
-            Authority::PrefixSection(ref prefix) => self.our_prefix().is_compatible(prefix),
+            Location::Node(ref name) => self.our_id().name() == name,
+            Location::Section(ref name) => self.our_prefix().matches(name),
+            Location::PrefixSection(ref prefix) => self.our_prefix().is_compatible(prefix),
         }
     }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -11,7 +11,7 @@ use super::{
     MemberState, MIN_AGE_COUNTER,
 };
 use crate::{
-    authority::Authority, error::RoutingError, id::PublicId, relocation::RelocateDetails,
+    error::RoutingError, id::PublicId, location::Location, relocation::RelocateDetails,
     utils::LogIdent, Prefix, XorName,
 };
 use itertools::Itertools;
@@ -395,8 +395,8 @@ impl SharedState {
     }
 
     /// Returns the index of the public key in our_history that will be trusted by the target
-    /// Authority
-    pub fn proving_index(&self, target: &Authority<XorName>) -> u64 {
+    /// Location
+    pub fn proving_index(&self, target: &Location<XorName>) -> u64 {
         let (prefix, &index) = if let Some(pair) = self
             .their_knowledge
             .iter()
@@ -410,7 +410,7 @@ impl SharedState {
 
         if let Some(sibling_index) = self.their_knowledge.get(&prefix.sibling()) {
             // The sibling section might not have processed the split yet, so it might still be in
-            // `target`'s authority. Because of that, we need to return index that would be trusted
+            // `target`'s location. Because of that, we need to return index that would be trusted
             // by them too.
             index.min(*sibling_index)
         } else {
@@ -793,10 +793,10 @@ mod test {
     }
 
     // Perform a series of updates to `their_knowledge`, then verify that the proving indices for
-    // the given dst authorities are as expected.
+    // the given dst locations are as expected.
     //
     // - `updates` - pairs of (prefix, version) to pass to `update_their_knowledge`
-    // - `expected_proving_indices` - pairs of (prefix, index) where the dst authority name is
+    // - `expected_proving_indices` - pairs of (prefix, index) where the dst location name is
     //   generated such that it matches `prefix` and `index` is the expected proving index.
     fn update_their_knowledge_and_check_proving_index(
         rng: &mut MainRng,
@@ -817,7 +817,7 @@ mod test {
         for (dst_name_prefix_str, expected_index) in expected_proving_indices {
             let dst_name_prefix: Prefix<_> = unwrap!(dst_name_prefix_str.parse());
             let dst_name = dst_name_prefix.substituted_in(rng.gen());
-            let dst = Authority::Section(dst_name);
+            let dst = Location::Section(dst_name);
 
             assert_eq!(state.proving_index(&dst), expected_index);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,8 +30,8 @@ pub enum InterfaceError {
 pub enum RoutingError {
     #[error(display = "Invalid State.")]
     Terminated,
-    #[error(display = "Invalid requester or handler authorities.")]
-    BadAuthority,
+    #[error(display = "Invalid requester or handler locations.")]
+    BadLocation,
     #[error(display = "Failed signature check.")]
     FailedSignature,
     #[error(display = "Duplicate request received.")]

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    authority::Authority,
+    location::Location,
     xor_space::{Prefix, XorName},
 };
 use bytes::Bytes;
@@ -74,7 +74,7 @@ pub enum Connected {
 /// These are sent by routing to the library's user. It allows the user to handle requests and
 /// responses, and to react to changes in the network.
 ///
-/// `Request` and `Response` events from section authorities are only raised once the quorum has
+/// `Request` and `Response` events from section locations are only raised once the quorum has
 /// been reached, i.e. enough members of the section have sent the same message.
 #[derive(Clone, Eq, PartialEq)]
 // FIXME - See https://maidsafe.atlassian.net/browse/MAID-2026 for info on removing this exclusion.
@@ -86,10 +86,10 @@ pub enum Event {
     MessageReceived {
         /// The content of the message.
         content: Vec<u8>,
-        /// The source authority that sent the message.
-        src: Authority<XorName>,
-        /// The destination authority that receives the message.
-        dst: Authority<XorName>,
+        /// The source location that sent the message.
+        src: Location<XorName>,
+        /// The destination location that receives the message.
+        dst: Location<XorName>,
     },
     /// Our own section has been split, resulting in the included `Prefix` for our new section.
     SectionSplit(Prefix<XorName>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,11 +103,11 @@ pub mod rng;
 /// Mock network
 #[cfg(feature = "mock_base")]
 pub use self::{
-    authority::Authority,
     chain::{
         delivery_group_size, elders_info_for_test, quorum_count,
         section_proof_chain_from_elders_info, NetworkParams, SectionKeyShare, MIN_AGE,
     },
+    location::Location,
     messages::{HopMessage, Message, MessageContent, RoutingMessage, SignedRoutingMessage},
     parsec::generate_bls_threshold_secret_key,
     relocation::Overrides as RelocationOverrides,
@@ -131,12 +131,12 @@ pub use self::mock::parsec::init_mock;
 // ############################################################################
 
 mod action;
-mod authority;
 mod chain;
 mod error;
 mod event;
 mod event_stream;
 mod id;
+mod location;
 mod message_filter;
 mod messages;
 mod network_service;

--- a/src/location.rs
+++ b/src/location.rs
@@ -9,16 +9,13 @@
 use crate::xor_space::{Prefix, XorName, Xorable};
 use std::fmt::{self, Binary, Debug, Display, Formatter};
 
-/// An entity that can act as a source or destination of a message.
+/// A `Location` is a source or destination of a message.
 ///
-/// `Client` and `ManagedNode` are single-node authorities (i.e. no verification of messages from
-/// additional sources needed); other authorities require agreement by a quorum of some set.
-/// `NodeManager`, `ClientManager` and `NaeManager` use _group_ verification of messages: they
-/// require quorum agreement from the group of nodes closest to the source, while `Section` and
-/// `PrefixSection` use _section_ verification: the set from which a quorum is required is all
-/// members of the section (`Section`) or of all sections matching the prefix (`PrefixSection`).
+/// `Node` is single-node location (i.e. no verification of messages from
+/// additional sources needed). It's name is the `Authority::key` other
+/// locations require agreement by a quorum of `Elders`.
 #[derive(Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Hash)]
-pub enum Authority<N: Xorable + Clone + Copy + Binary + Default> {
+pub enum Location<N: Xorable + Clone + Copy + Binary + Default> {
     /// A single section whose prefix matches the given name
     Section(N),
     /// A set of nodes with names sharing a common prefix - may span multiple `Section`s present in
@@ -28,8 +25,8 @@ pub enum Authority<N: Xorable + Clone + Copy + Binary + Default> {
     Node(N),
 }
 
-impl<N: Xorable + Clone + Copy + Binary + Default> Authority<N> {
-    /// Returns `true` if the authority consists of multiple nodes, otherwise `false`.
+impl<N: Xorable + Clone + Copy + Binary + Default> Location<N> {
+    /// Returns `true` if the location consists of multiple nodes, otherwise `false`.
     pub fn is_multiple(&self) -> bool {
         match self {
             Self::Section(_) | Self::PrefixSection(_) => true,
@@ -37,7 +34,7 @@ impl<N: Xorable + Clone + Copy + Binary + Default> Authority<N> {
         }
     }
 
-    /// Returns `true` if the authority is a single node, and `false` otherwise.
+    /// Returns `true` if the location is a single node, and `false` otherwise.
     pub fn is_single(&self) -> bool {
         match self {
             Self::Section(_) | Self::PrefixSection(_) => false,
@@ -45,7 +42,7 @@ impl<N: Xorable + Clone + Copy + Binary + Default> Authority<N> {
         }
     }
 
-    /// Returns the name of authority.
+    /// Returns the name of location.
     pub fn name(&self) -> N {
         match self {
             Self::Section(name) | Self::Node(name) => *name,
@@ -53,7 +50,7 @@ impl<N: Xorable + Clone + Copy + Binary + Default> Authority<N> {
         }
     }
 
-    /// Returns if the authority is compatible with that prefix
+    /// Returns if the location is compatible with that prefix
     pub fn is_compatible(&self, other_prefix: &Prefix<N>) -> bool {
         match self {
             Self::Section(name) | Self::Node(name) => other_prefix.matches(name),
@@ -62,7 +59,7 @@ impl<N: Xorable + Clone + Copy + Binary + Default> Authority<N> {
     }
 }
 
-impl Authority<XorName> {
+impl Location<XorName> {
     /// provide the name mathching a single node's public key
     pub fn single_signing_name(&self) -> Option<&XorName> {
         match *self {
@@ -72,7 +69,7 @@ impl Authority<XorName> {
     }
 }
 
-impl<N: Xorable + Clone + Copy + Binary + Default + Display> Debug for Authority<N> {
+impl<N: Xorable + Clone + Copy + Binary + Default + Display> Debug for Location<N> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
             Self::Section(ref name) => write!(formatter, "Section(name: {})", name),

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -27,7 +27,7 @@ use std::{
 /// Direct message content.
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
 pub enum DirectMessage {
-    /// Sent from members of a section or group message's source authority to the first hop. The
+    /// Sent from members of a section or group message's source location to the first hop. The
     /// message will only be relayed once enough signatures have been accumulated.
     MessageSignature(Box<SignedRoutingMessage>),
     /// Sent from a newly connected peer to the bootstrap node to request connection infos of

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -12,13 +12,13 @@ pub use self::direct::{
     BootstrapResponse, DirectMessage, JoinRequest, MemberKnowledge, SignedDirectMessage,
 };
 use crate::{
-    authority::Authority,
     chain::{
         Chain, EldersInfo, GenesisPfxInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain,
     },
     crypto::{self, signing::Signature, Digest256},
     error::{Result, RoutingError},
     id::{FullId, PublicId},
+    location::Location,
     xor_space::{Prefix, XorName},
 };
 use log::LogLevel;
@@ -413,13 +413,13 @@ impl SignedRoutingMessage {
     }
 }
 
-/// A routing message with source and destination authorities.
+/// A routing message with source and destination locations.
 #[derive(Eq, PartialEq, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct RoutingMessage {
-    /// Source authority
-    pub src: Authority<XorName>,
-    /// Destination authority
-    pub dst: Authority<XorName>,
+    /// Source location
+    pub src: Location<XorName>,
+    /// Destination location
+    pub dst: Location<XorName>,
     /// The message content
     pub content: MessageContent,
 }
@@ -447,7 +447,7 @@ impl RoutingMessage {
 /// responds with a `BootstrapResponse`, indicating success or failure. Once it receives that, A
 /// goes into the `Client` state and uses B as its proxy to the network.
 ///
-/// A can now exchange messages with any `Authority`. This completes the bootstrap process for
+/// A can now exchange messages with any `Location`. This completes the bootstrap process for
 /// clients.
 ///
 ///
@@ -460,7 +460,7 @@ impl RoutingMessage {
 ///
 /// ### Relocating on the network
 ///
-/// Once in `JoiningNode` state, A sends a `Relocate` request to the `NaeManager` section authority
+/// Once in `JoiningNode` state, A sends a `Relocate` request to the `NaeManager` section location
 /// X of A's current name. X computes a target destination Y to which A should relocate and sends
 /// that section's `NaeManager`s an `ExpectCandidate` containing A's current public ID. Each member
 /// of Y votes for `ExpectCandidate`. Once Y accumulates votes for `ExpectCandidate`, send a
@@ -552,7 +552,6 @@ impl Debug for MessageContent {
 mod tests {
     use super::*;
     use crate::{
-        authority::Authority,
         chain::SectionKeyInfo,
         parsec::generate_bls_threshold_secret_key,
         rng::{self, MainRng},
@@ -650,8 +649,8 @@ mod tests {
 
         let name = rng.gen();
         RoutingMessage {
-            src: Authority::Section(name),
-            dst: Authority::Section(name),
+            src: Location::Section(name),
+            dst: Location::Section(name),
             content: MessageContent::UserMessage(rng.sample_iter(Standard).take(6).collect()),
         }
     }

--- a/src/mock/env.rs
+++ b/src/mock/env.rs
@@ -166,7 +166,7 @@ mod tests {
             SignedDirectMessage, SignedRoutingMessage,
         },
         parsec::{Request, Response},
-        rng, unwrap, Authority,
+        rng, unwrap, Location,
     };
     use maidsafe_utilities::serialisation;
     use rand::Rng;
@@ -222,8 +222,8 @@ mod tests {
 
         // A hop message never contains a Parsec message.
         let msg = RoutingMessage {
-            src: Authority::Section(rand::random()),
-            dst: Authority::Section(rand::random()),
+            src: Location::Section(rand::random()),
+            dst: Location::Section(rand::random()),
             content: MessageContent::UserMessage(vec![
                 rand::random(),
                 rand::random(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,11 +8,11 @@
 
 use crate::{
     action::Action,
-    authority::Authority,
     chain::NetworkParams,
     error::{InterfaceError, RoutingError},
     event_stream::{EventStepper, EventStream},
     id::{FullId, P2pNode, PublicId},
+    location::Location,
     outbox::EventBox,
     pause::PausedState,
     quic_p2p::{OurType, Token},
@@ -151,9 +151,9 @@ impl Builder {
 /// routing node.
 ///
 /// A node is a part of the network that can route messages and be a member of a section or group
-/// authority. Its methods can be used to send requests and responses as either an individual
-/// `Node` or as a part of a section or group authority. Their `src` argument indicates that
-/// role, and can be any [`Authority`](enum.Authority.html).
+/// location. Its methods can be used to send requests and responses as either an individual
+/// `Node` or as a part of a section or group location. Their `src` argument indicates that
+/// role, and can be any [`Location`](enum.Location.html).
 pub struct Node {
     user_event_tx: mpmc::Sender<Event>,
     user_event_rx: mpmc::Receiver<Event>,
@@ -241,8 +241,8 @@ impl Node {
     /// Send a message.
     pub fn send_message(
         &mut self,
-        src: Authority<XorName>,
-        dst: Authority<XorName>,
+        src: Location<XorName>,
+        dst: Location<XorName>,
         content: Vec<u8>,
     ) -> Result<(), InterfaceError> {
         // Make sure the state machine has processed any outstanding network events.
@@ -494,13 +494,13 @@ impl Node {
 
     /// Provide a SectionProofChain that proves the given signature to the section with a given
     /// prefix
-    pub fn prove(&self, target: &Authority<XorName>) -> Option<SectionProofChain> {
+    pub fn prove(&self, target: &Location<XorName>) -> Option<SectionProofChain> {
         self.chain().map(|chain| chain.prove(target, None))
     }
 
-    /// Checks whether the given authority represents self.
-    pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
-        self.machine.current().in_authority(auth)
+    /// Checks whether the given location represents self.
+    pub fn in_location(&self, auth: &Location<XorName>) -> bool {
+        self.machine.current().in_location(auth)
     }
 
     /// Returns the age counter of the given node if it is member of the same section as this node,

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -75,9 +75,9 @@ impl SignatureAccumulator {
 mod tests {
     use super::*;
     use crate::{
-        authority::Authority,
         chain::{EldersInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain},
         id::{FullId, P2pNode},
+        location::Location,
         messages::{
             DirectMessage, MessageContent, RoutingMessage, SignedDirectMessage,
             SignedRoutingMessage,
@@ -102,8 +102,8 @@ mod tests {
             pk_set: &bls::PublicKeySet,
         ) -> Self {
             let routing_msg = RoutingMessage {
-                src: Authority::Section(rand::random()),
-                dst: Authority::Section(rand::random()),
+                src: Location::Section(rand::random()),
+                dst: Location::Section(rand::random()),
                 content: MessageContent::UserMessage(vec![
                     rand::random(),
                     rand::random(),

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -21,7 +21,7 @@ use crate::{
     ConnectionInfo, NetworkConfig, NetworkEvent,
 };
 #[cfg(feature = "mock_base")]
-use crate::{authority::Authority, chain::Chain, rng::MainRng};
+use crate::{chain::Chain, location::Location, rng::MainRng};
 use crossbeam_channel as mpmc;
 #[cfg(feature = "mock_base")]
 use std::net::SocketAddr;
@@ -260,10 +260,10 @@ impl State {
         }
     }
 
-    pub fn in_authority(&self, auth: &Authority<XorName>) -> bool {
+    pub fn in_location(&self, auth: &Location<XorName>) -> bool {
         state_dispatch!(
             *self,
-            ref state => state.in_authority(auth),
+            ref state => state.in_location(auth),
             Terminated => false
         )
     }

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -15,7 +15,6 @@ use super::{
     elder::{Elder, ElderDetails},
 };
 use crate::{
-    authority::Authority,
     chain::{
         Chain, EldersChange, EldersInfo, GenesisPfxInfo, NetworkParams, OnlinePayload,
         SectionKeyInfo, SendAckMessagePayload,
@@ -23,6 +22,7 @@ use crate::{
     error::RoutingError,
     event::Event,
     id::{FullId, P2pNode, PublicId},
+    location::Location,
     messages::{
         BootstrapResponse, DirectMessage, HopMessage, MessageContent, SignedRoutingMessage,
     },
@@ -412,7 +412,7 @@ impl Adult {
             signed_msg.routing_message()
         );
 
-        if self.in_authority(&signed_msg.routing_message().dst) {
+        if self.in_location(&signed_msg.routing_message().dst) {
             self.check_signed_message_integrity(&signed_msg)?;
 
             match &signed_msg.routing_message().content {
@@ -493,8 +493,8 @@ impl Base for Adult {
         &self.full_id
     }
 
-    fn in_authority(&self, auth: &Authority<XorName>) -> bool {
-        self.chain.in_authority(auth)
+    fn in_location(&self, auth: &Location<XorName>) -> bool {
+        self.chain.in_location(auth)
     }
 
     fn peer_map(&self) -> &PeerMap {

--- a/src/states/adult/tests.rs
+++ b/src/states/adult/tests.rs
@@ -60,8 +60,8 @@ impl AdultUnderTest {
 
     fn genesis_update_message(&self, gen_pfx_info: GenesisPfxInfo) -> SignedRoutingMessage {
         let msg = RoutingMessage {
-            src: Authority::PrefixSection(Prefix::default()),
-            dst: Authority::Node(*self.adult.name()),
+            src: Location::PrefixSection(Prefix::default()),
+            dst: Location::Node(*self.adult.name()),
             content: MessageContent::GenesisUpdate(gen_pfx_info),
         };
 

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -8,11 +8,11 @@
 
 use super::{common::Base, joining_peer::JoiningPeerDetails};
 use crate::{
-    authority::Authority,
     chain::{EldersInfo, NetworkParams},
     error::{InterfaceError, RoutingError},
     event::Event,
     id::{FullId, P2pNode},
+    location::Location,
     messages::{BootstrapResponse, DirectMessage, HopMessage},
     network_service::NetworkService,
     outbox::EventBox,
@@ -203,7 +203,7 @@ impl Base for BootstrappingPeer {
         &self.full_id
     }
 
-    fn in_authority(&self, _: &Authority<XorName>) -> bool {
+    fn in_location(&self, _: &Location<XorName>) -> bool {
         false
     }
 
@@ -225,8 +225,8 @@ impl Base for BootstrappingPeer {
 
     fn handle_send_message(
         &mut self,
-        _: Authority<XorName>,
-        _: Authority<XorName>,
+        _: Location<XorName>,
+        _: Location<XorName>,
         _: Vec<u8>,
     ) -> Result<(), InterfaceError> {
         warn!("{} - Cannot handle SendMessage - not bootstrapped.", self);

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -8,9 +8,9 @@
 
 use crate::{
     action::Action,
-    authority::Authority,
     error::{InterfaceError, RoutingError},
     id::{FullId, P2pNode, PublicId},
+    location::Location,
     messages::{DirectMessage, HopMessage, Message, SignedDirectMessage, SignedRoutingMessage},
     network_service::NetworkService,
     outbox::EventBox,
@@ -33,7 +33,7 @@ pub trait Base: Display {
     fn network_service(&self) -> &NetworkService;
     fn network_service_mut(&mut self) -> &mut NetworkService;
     fn full_id(&self) -> &FullId;
-    fn in_authority(&self, auth: &Authority<XorName>) -> bool;
+    fn in_location(&self, auth: &Location<XorName>) -> bool;
     fn peer_map(&self) -> &PeerMap;
     fn peer_map_mut(&mut self) -> &mut PeerMap;
     fn timer(&mut self) -> &mut Timer;
@@ -105,8 +105,8 @@ pub trait Base: Display {
 
     fn handle_send_message(
         &mut self,
-        _src: Authority<XorName>,
-        _dst: Authority<XorName>,
+        _src: Location<XorName>,
+        _dst: Location<XorName>,
         _content: Vec<u8>,
     ) -> Result<(), InterfaceError> {
         warn!("{} - Cannot handle SendMessage - invalid state.", self);

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -12,11 +12,11 @@ use super::{
     common::Base,
 };
 use crate::{
-    authority::Authority,
     chain::{EldersInfo, GenesisPfxInfo, NetworkParams},
     error::{InterfaceError, RoutingError},
     event::{Connected, Event},
     id::{FullId, P2pNode},
+    location::Location,
     messages::{
         BootstrapResponse, DirectMessage, HopMessage, JoinRequest, MessageContent, RoutingMessage,
         SignedRoutingMessage,
@@ -164,8 +164,8 @@ impl JoiningPeer {
         match msg {
             RoutingMessage {
                 content: MessageContent::NodeApproval(gen_info),
-                src: Authority::PrefixSection(_),
-                dst: Authority::Node { .. },
+                src: Location::PrefixSection(_),
+                dst: Location::Node { .. },
             } => Ok(self.handle_node_approval(gen_info)),
             _ => {
                 debug!(
@@ -207,7 +207,7 @@ impl Base for JoiningPeer {
         &self.full_id
     }
 
-    fn in_authority(&self, dst: &Authority<XorName>) -> bool {
+    fn in_location(&self, dst: &Location<XorName>) -> bool {
         dst.is_single() && dst.name() == *self.full_id.public_id().name()
     }
 
@@ -229,8 +229,8 @@ impl Base for JoiningPeer {
 
     fn handle_send_message(
         &mut self,
-        _: Authority<XorName>,
-        _: Authority<XorName>,
+        _: Location<XorName>,
+        _: Location<XorName>,
         _: Vec<u8>,
     ) -> Result<(), InterfaceError> {
         warn!("{} - Cannot handle SendMessage - not joined.", self);
@@ -316,7 +316,7 @@ impl Base for JoiningPeer {
             return Ok(Transition::Stay);
         }
 
-        if self.in_authority(&msg.routing_message().dst) {
+        if self.in_location(&msg.routing_message().dst) {
             self.check_signed_message_integrity(&msg)?;
             self.dispatch_routing_message(msg, outbox)
         } else {

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -8,7 +8,7 @@
 
 use super::{create_connected_nodes, gen_bytes, poll_all, sort_nodes_by_distance_to, TestNode};
 use rand::Rng;
-use routing::{mock::Environment, Authority, Event, EventStream, NetworkParams, XorName};
+use routing::{mock::Environment, Event, EventStream, Location, NetworkParams, XorName};
 
 #[test]
 fn messages_accumulate_with_quorum() {
@@ -21,10 +21,10 @@ fn messages_accumulate_with_quorum() {
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes(&env, section_size);
 
-    let src = Authority::Section(rng.gen());
+    let src = Location::Section(rng.gen());
     sort_nodes_by_distance_to(&mut nodes, &src.name());
 
-    let send = |node: &mut TestNode, dst: &Authority<XorName>, content: Vec<u8>| {
+    let send = |node: &mut TestNode, dst: &Location<XorName>, content: Vec<u8>| {
         assert!(node.inner.send_message(src, *dst, content).is_ok());
     };
 
@@ -37,7 +37,7 @@ fn messages_accumulate_with_quorum() {
         .next()
         .unwrap();
 
-    let dst = Authority::Node(nodes[closest_elder_index].name()); // The closest node.
+    let dst = Location::Node(nodes[closest_elder_index].name()); // The closest node.
     let content = gen_bytes(&mut rng, 8);
 
     // The BLS scheme will require more than `participants / 3`
@@ -80,7 +80,7 @@ fn messages_accumulate_with_quorum() {
     let _ = poll_all(&mut nodes);
     expect_no_event!(nodes[closest_elder_index]);
 
-    let dst_grp = Authority::Section(src.name()); // The whole section.
+    let dst_grp = Location::Section(src.name()); // The whole section.
     let content = gen_bytes(&mut rng, 9);
 
     // Send a message from the section `src` to the section `dst_grp`. Only the `quorum`-th sender

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -8,7 +8,7 @@
 
 use super::{create_connected_nodes, gen_elder_index, gen_vec, poll_all};
 use rand::Rng;
-use routing::{mock::Environment, quorum_count, Authority, Event, EventStream, NetworkParams};
+use routing::{mock::Environment, quorum_count, Event, EventStream, Location, NetworkParams};
 
 #[test]
 fn send() {
@@ -23,8 +23,8 @@ fn send() {
     let mut nodes = create_connected_nodes(&env, elder_size + 1);
 
     let sender_index = gen_elder_index(&mut rng, &nodes);
-    let src = Authority::Node(nodes[sender_index].name());
-    let dst = Authority::Section(rng.gen());
+    let src = Location::Node(nodes[sender_index].name());
+    let dst = Location::Section(rng.gen());
     let content = gen_vec(&mut rng, 1024);
     assert!(nodes[sender_index]
         .inner
@@ -71,8 +71,8 @@ fn send_and_receive() {
     let mut nodes = create_connected_nodes(&env, elder_size + 1);
 
     let sender_index = gen_elder_index(&mut rng, &nodes);
-    let src = Authority::Node(nodes[sender_index].name());
-    let dst = Authority::Section(rng.gen());
+    let src = Location::Node(nodes[sender_index].name());
+    let dst = Location::Section(rng.gen());
 
     let req_content = gen_vec(&mut rng, 10);
     let res_content = gen_vec(&mut rng, 11);

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -9,7 +9,7 @@
 use super::{create_connected_nodes_until_split, poll_all, Nodes, TestNode};
 use routing::{
     elders_info_for_test, generate_bls_threshold_secret_key, mock::Environment,
-    section_proof_chain_from_elders_info, Authority, ConnectionInfo, FullId, HopMessage, Message,
+    section_proof_chain_from_elders_info, ConnectionInfo, FullId, HopMessage, Location, Message,
     MessageContent, NetworkParams, P2pNode, Prefix, RoutingMessage, SectionKeyShare,
     SignedRoutingMessage, XorName,
 };
@@ -75,8 +75,8 @@ fn message_with_invalid_security(fail_type: FailType) {
     let new_info = unwrap!(elders_info_for_test(members, our_prefix, 10001,));
 
     let routing_msg = RoutingMessage {
-        src: Authority::Section(our_prefix.name()),
-        dst: Authority::PrefixSection(their_prefix),
+        src: Location::Section(our_prefix.name()),
+        dst: Location::PrefixSection(their_prefix),
         content: MessageContent::NeighbourInfo(new_info.clone()),
     };
 
@@ -84,7 +84,7 @@ fn message_with_invalid_security(fail_type: FailType) {
         let proof = match fail_type {
             FailType::TrustedProofInvalidSig => unwrap!(nodes[our_node_pos]
                 .inner
-                .prove(&Authority::PrefixSection(their_prefix))),
+                .prove(&Location::PrefixSection(their_prefix))),
             FailType::UntrustedProofValidSig => {
                 section_proof_chain_from_elders_info(&new_info, bls_keys.public_keys().public_key())
             }

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -14,7 +14,7 @@ use rand::{
     Rng,
 };
 use routing::{
-    mock::Environment, test_consts, Authority, Builder, Connected, Event, EventStream, FullId,
+    mock::Environment, test_consts, Builder, Connected, Event, EventStream, FullId, Location,
     NetworkConfig, Node, PausedState, Prefix, PublicId, RelocationOverrides, XorName, Xorable,
 };
 use std::{
@@ -123,8 +123,8 @@ impl TestNode {
         unwrap!(self.inner.our_prefix(), "{}", self.inner)
     }
 
-    pub fn is_recipient(&self, dst: &Authority<XorName>) -> bool {
-        self.inner.in_authority(dst)
+    pub fn is_recipient(&self, dst: &Location<XorName>) -> bool {
+        self.inner.in_location(dst)
     }
 
     pub fn env(&self) -> &Environment {


### PR DESCRIPTION
Renamed Authority to Location. This is the next phase of cleanup and does appear to make more
locial sense when reading the code. It is likely Authority will make a come back though, but as
an actual authority that we can query for validity. Desing considerations though on whether
Authority will be src dst or content. There is reasonable argument that Authority should be for
whole message.