### PR TITLE
Partial deserialize for hop messages

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -302,17 +302,10 @@ impl Debug for SecurityMetadata {
 }
 
 /// Wrapper around a routing message, signed by the originator of the message.
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Deserialize)]
 pub struct PartialSignedRoutingMessage {
     /// Destination location
     pub dst: Location,
-}
-
-impl<'de> Deserialize<'de> for PartialSignedRoutingMessage {
-    fn deserialize<D: Deserializer<'de>>(deserialiser: D) -> std::result::Result<Self, D::Error> {
-        let dst: Location = Deserialize::deserialize(deserialiser)?;
-        Ok(PartialSignedRoutingMessage { dst })
-    }
 }
 
 /// Wrapper around a routing message, signed by the originator of the message.

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -400,7 +400,7 @@ impl Adult {
 
     fn handle_filtered_signed_message(
         &mut self,
-        msg: HopMessageWithBytes,
+        mut msg: HopMessageWithBytes,
     ) -> Result<Transition, RoutingError> {
         trace!(
             "{} - Handle signed message: {:?}",
@@ -409,14 +409,14 @@ impl Adult {
         );
 
         if self.in_location(msg.message_dst()) {
-            let signed_msg = msg.signed_routing_message();
+            let signed_msg = msg.take_or_deserialize_signed_routing_message()?;
             match &signed_msg.routing_message().content {
                 MessageContent::GenesisUpdate(info) => {
-                    self.verify_signed_message(signed_msg)?;
+                    self.verify_signed_message(&signed_msg)?;
                     return self.handle_genesis_update(info.clone());
                 }
                 _ => {
-                    self.routing_msg_backlog.push(signed_msg.clone());
+                    self.routing_msg_backlog.push(signed_msg);
                 }
             }
         }

--- a/src/states/adult/tests.rs
+++ b/src/states/adult/tests.rs
@@ -89,7 +89,7 @@ impl AdultUnderTest {
                 }
             }));
         msg.combine_signatures();
-        unwrap!(HopMessageWithBytes::new(msg))
+        unwrap!(HopMessageWithBytes::new(msg, &LogIdent::new("node")))
     }
 
     fn perform_elders_change(&mut self) {

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -327,7 +327,7 @@ impl Base for BootstrappingPeer {
         trace!(
             "{} - Unhandled hop message: {:?}",
             self,
-            msg.signed_routing_message()
+            msg.full_message_crypto_hash()
         );
         Ok(Transition::Stay)
     }

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -13,7 +13,7 @@ use crate::{
     id::{FullId, P2pNode, PublicId},
     location::Location,
     messages::{
-        DirectMessage, HopMessageWithBytes, Message, MessagePeek, MessageWithBytes,
+        DirectMessage, HopMessageWithBytes, Message, MessageWithBytes, PartialMessage,
         SignedDirectMessage,
     },
     network_service::NetworkService,
@@ -246,7 +246,7 @@ pub trait Base: Display {
         bytes: Bytes,
         outbox: &mut dyn EventBox,
     ) -> Transition {
-        let result = MessageWithBytes::peek_from_bytes(bytes)
+        let result = MessageWithBytes::partial_from_bytes(bytes)
             .and_then(|message| self.handle_new_deserialised_message(src_addr, message, outbox));
 
         match result {
@@ -436,6 +436,6 @@ pub fn from_network_bytes(data: &Bytes) -> Result<Message, RoutingError> {
     Ok(bincode::deserialize(&data[..])?)
 }
 
-pub fn peek_from_network_bytes(data: &Bytes) -> Result<MessagePeek, RoutingError> {
+pub fn partial_from_network_bytes(data: &Bytes) -> Result<PartialMessage, RoutingError> {
     Ok(bincode::deserialize(&data[..])?)
 }

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -13,7 +13,8 @@ use crate::{
     id::{FullId, P2pNode, PublicId},
     location::Location,
     messages::{
-        DirectMessage, HopMessageWithBytes, Message, MessageWithBytes, SignedDirectMessage,
+        DirectMessage, HopMessageWithBytes, Message, MessagePeek, MessageWithBytes,
+        SignedDirectMessage,
     },
     network_service::NetworkService,
     outbox::EventBox,
@@ -245,7 +246,7 @@ pub trait Base: Display {
         bytes: Bytes,
         outbox: &mut dyn EventBox,
     ) -> Transition {
-        let result = MessageWithBytes::from_bytes(bytes)
+        let result = MessageWithBytes::peek_from_bytes(bytes)
             .and_then(|message| self.handle_new_deserialised_message(src_addr, message, outbox));
 
         match result {
@@ -432,5 +433,9 @@ pub fn to_network_bytes(message: &Message) -> Result<Bytes, RoutingError> {
 }
 
 pub fn from_network_bytes(data: &Bytes) -> Result<Message, RoutingError> {
+    Ok(bincode::deserialize(&data[..])?)
+}
+
+pub fn peek_from_network_bytes(data: &Bytes) -> Result<MessagePeek, RoutingError> {
     Ok(bincode::deserialize(&data[..])?)
 }

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -11,5 +11,5 @@ mod base;
 
 pub use self::{
     approved::Approved,
-    base::{from_network_bytes, peek_from_network_bytes, to_network_bytes, Base},
+    base::{from_network_bytes, partial_from_network_bytes, to_network_bytes, Base},
 };

--- a/src/states/common/mod.rs
+++ b/src/states/common/mod.rs
@@ -11,5 +11,5 @@ mod base;
 
 pub use self::{
     approved::Approved,
-    base::{from_network_bytes, to_network_bytes, Base},
+    base::{from_network_bytes, peek_from_network_bytes, to_network_bytes, Base},
 };

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -304,7 +304,7 @@ impl Base for JoiningPeer {
             trace!(
                 "{} Known message: {:?} - not handling further",
                 self,
-                msg.routing_message()
+                msg.full_message_crypto_hash()
             );
             return Ok(Transition::Stay);
         }


### PR DESCRIPTION
Closes #2010 

- Partial de-serialization of Hop message (find it is `Hop`, get `dst`).
- Use tuple serialization for SigneRoutingMessage to ease partial de-serialization.
- Use hash for logging/tracing with a log at the beginning with the routing message and hash.