### PR TITLE
refactor/events: make event module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,6 @@ mod macros;
 // ############################################################################
 pub use self::{
     error::RoutingError,
-    event::{Client, Connected, Event},
     event_stream::EventStream,
     id::{FullId, P2pNode, PublicId},
     node::{Builder, Node},
@@ -88,6 +87,8 @@ pub use self::{
     quic_p2p::{Config as NetworkConfig, NodeInfo as ConnectionInfo},
     xor_space::{Prefix, XorName, XOR_NAME_LEN},
 };
+/// Routing events.
+pub mod event;
 
 // ############################################################################
 // Mock and test API
@@ -133,7 +134,6 @@ pub use self::mock::parsec::init_mock;
 mod action;
 mod chain;
 mod error;
-mod event;
 mod event_stream;
 mod id;
 mod location;

--- a/src/node.rs
+++ b/src/node.rs
@@ -10,6 +10,7 @@ use crate::{
     action::Action,
     chain::NetworkParams,
     error::RoutingError,
+    event::Event,
     event_stream::{EventStepper, EventStream},
     id::{FullId, P2pNode, PublicId},
     location::Location,
@@ -20,7 +21,7 @@ use crate::{
     state_machine::{State, StateMachine},
     states::{self, BootstrappingPeer, BootstrappingPeerDetails},
     xor_space::XorName,
-    ConnectionInfo, Event, NetworkConfig,
+    ConnectionInfo, NetworkConfig,
 };
 use bytes::Bytes;
 use crossbeam_channel as mpmc;

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -9,6 +9,7 @@
 use crate::{
     action::Action,
     error::RoutingError,
+    event::Client,
     id::{FullId, P2pNode, PublicId},
     location::Location,
     messages::{
@@ -24,7 +25,7 @@ use crate::{
     timer::Timer,
     utils::LogIdent,
     xor_space::XorName,
-    Client, ConnectionInfo, NetworkEvent,
+    ConnectionInfo, NetworkEvent,
 };
 use bytes::Bytes;
 use log::LogLevel;

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -8,7 +8,7 @@
 
 use super::{create_connected_nodes, gen_bytes, poll_all, sort_nodes_by_distance_to, TestNode};
 use rand::Rng;
-use routing::{mock::Environment, Event, EventStream, Location, NetworkParams, XorName};
+use routing::{event::Event, mock::Environment, EventStream, Location, NetworkParams, XorName};
 
 #[test]
 fn messages_accumulate_with_quorum() {

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -13,11 +13,12 @@ use super::{
 use itertools::Itertools;
 use rand::{seq::SliceRandom, Rng};
 use routing::{
+    event::Event,
     mock::Environment,
     quorum_count,
     rng::MainRng,
     test_consts::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW},
-    Event, EventStream, FullId, Location, NetworkConfig, NetworkParams, Prefix, XorName, Xorable,
+    EventStream, FullId, Location, NetworkConfig, NetworkParams, Prefix, XorName, Xorable,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -10,7 +10,7 @@ use super::{
     create_connected_nodes, poll_all, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
 };
 use rand::Rng;
-use routing::{mock::Environment, Event, EventStream, NetworkParams};
+use routing::{event::Event, mock::Environment, EventStream, NetworkParams};
 
 // Drop node at index and verify its own section detected it.
 fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -8,7 +8,9 @@
 
 use super::{create_connected_nodes, gen_elder_index, gen_vec, poll_all};
 use rand::Rng;
-use routing::{mock::Environment, quorum_count, Event, EventStream, Location, NetworkParams};
+use routing::{
+    event::Event, mock::Environment, quorum_count, EventStream, Location, NetworkParams,
+};
 
 #[test]
 fn send() {

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -18,7 +18,7 @@ pub use self::utils::*;
 use itertools::Itertools;
 use rand::{seq::SliceRandom, Rng};
 use routing::{
-    mock::Environment, Event, EventStream, FullId, NetworkConfig, NetworkParams, Prefix,
+    event::Event, mock::Environment, EventStream, FullId, NetworkConfig, NetworkParams, Prefix,
     RelocationOverrides, XorName,
 };
 use std::collections::BTreeMap;

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -14,8 +14,10 @@ use rand::{
     Rng,
 };
 use routing::{
-    mock::Environment, test_consts, Builder, Connected, Event, EventStream, FullId, Location,
-    NetworkConfig, Node, PausedState, Prefix, PublicId, RelocationOverrides, XorName, Xorable,
+    event::{Connected, Event},
+    mock::Environment,
+    test_consts, Builder, EventStream, FullId, Location, NetworkConfig, Node, PausedState, Prefix,
+    PublicId, RelocationOverrides, XorName, Xorable,
 };
 use std::{
     cmp,


### PR DESCRIPTION
To prevent the confusion from the event types naming (`routing::Client`), we export the event module as a whole instead (`routing::event::Client`).