### PR TITLE
Fix hop message handling

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -8,7 +8,7 @@
 
 use super::{
     chain_accumulator::{AccumulatingProof, ChainAccumulator, InsertError},
-    shared_state::{SectionKeyInfo, SectionProofBlock, SharedState, SplitCache},
+    shared_state::{SectionKeyInfo, SectionProofBlock, SharedState, SplitCache, TrustStatus},
     AccumulatedEvent, AccumulatingEvent, AgeCounter, EldersChange, EldersInfo, GenesisPfxInfo,
     MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof, ProofSet,
     SectionProofChain,
@@ -868,44 +868,9 @@ impl Chain {
         self.state.get_their_keys_info()
     }
 
-    /// Returns `true` if the `proof_chain` contains a key we have in `their_keys` and that key is
-    /// for a prefix compatible with proof_chain prefix.
+    /// Check whether we trust the given proof chain.
     pub fn check_trust(&self, proof_chain: &SectionProofChain) -> TrustStatus {
-        let last_prefix = proof_chain.last_public_key_info().prefix();
-        let known_key_infos: BTreeSet<_> = self
-            .state
-            .get_their_keys_info()
-            .filter(|&(pfx, _)| last_prefix.is_compatible(pfx))
-            .map(|(_, info)| info)
-            .collect();
-
-        if proof_chain
-            .all_key_infos()
-            .any(|proof_key_info| known_key_infos.contains(proof_key_info))
-        {
-            return TrustStatus::Trusted;
-        }
-
-        let max_known_version = match known_key_infos
-            .iter()
-            .map(|known_key_info| known_key_info.version())
-            .max()
-        {
-            Some(version) => version,
-            None => return TrustStatus::ProofInvalid,
-        };
-
-        let min_proof_version = proof_chain
-            .all_key_infos()
-            .map(|proof_key_info| proof_key_info.version())
-            .min()
-            .expect("empty proof");
-
-        if min_proof_version > max_known_version {
-            TrustStatus::ProofTooNew
-        } else {
-            TrustStatus::ProofInvalid
-        }
+        proof_chain.check_trust(self.state.get_their_keys_info())
     }
 
     /// Returns `true` if the `EldersInfo` isn't known to us yet.
@@ -1821,27 +1786,6 @@ impl EldersChangeBuilder {
                 .difference(&new_neighbour)
                 .cloned()
                 .collect(),
-        }
-    }
-}
-
-// Result of a message trust check.
-#[derive(Debug)]
-pub enum TrustStatus {
-    // Message is trusted.
-    Trusted,
-    // Message is untrusted because the proof is invalid.
-    ProofInvalid,
-    // Message trust cannot be determined because the proof starts at version that is newer than
-    // our latest one.
-    ProofTooNew,
-}
-
-impl TrustStatus {
-    pub fn is_trusted(&self) -> bool {
-        match self {
-            Self::Trusted => true,
-            _ => false,
         }
     }
 }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -8,7 +8,7 @@
 
 use super::{
     chain_accumulator::{AccumulatingProof, ChainAccumulator, InsertError},
-    shared_state::{SectionKeyInfo, SectionProofBlock, SharedState, SplitCache, TrustStatus},
+    shared_state::{SectionKeyInfo, SectionProofBlock, SharedState, SplitCache},
     AccumulatedEvent, AccumulatingEvent, AgeCounter, EldersChange, EldersInfo, GenesisPfxInfo,
     MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof, ProofSet,
     SectionProofChain,
@@ -866,11 +866,6 @@ impl Chain {
     /// Return the keys we know
     pub fn get_their_keys_info(&self) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
         self.state.get_their_keys_info()
-    }
-
-    /// Check whether we trust the given proof chain.
-    pub fn check_trust<'a>(&self, proof_chain: &'a SectionProofChain) -> TrustStatus<'a> {
-        proof_chain.check_trust(self.state.get_their_keys_info())
     }
 
     /// Returns `true` if the `EldersInfo` isn't known to us yet.

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -869,7 +869,7 @@ impl Chain {
     }
 
     /// Check whether we trust the given proof chain.
-    pub fn check_trust(&self, proof_chain: &SectionProofChain) -> TrustStatus {
+    pub fn check_trust<'a>(&self, proof_chain: &'a SectionProofChain) -> TrustStatus<'a> {
         proof_chain.check_trust(self.state.get_their_keys_info())
     }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -19,7 +19,9 @@ mod proof;
 mod shared_state;
 
 pub use self::{
-    chain::{delivery_group_size, Chain, ParsecResetData, PollAccumulated, SectionKeyShare},
+    chain::{
+        delivery_group_size, Chain, ParsecResetData, PollAccumulated, SectionKeyShare, TrustStatus,
+    },
     chain_accumulator::AccumulatingProof,
     config::NetworkParams,
     elders_info::{quorum_count, EldersInfo},

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -69,11 +69,12 @@ impl Debug for GenesisPfxInfo {
 
 #[cfg(feature = "mock_base")]
 /// Test helper to create arbitrary proof.
-pub fn section_proof_chain_from_elders_info(
-    elders_info: &EldersInfo,
+pub fn section_proof_chain_for_test(
+    version: u64,
+    prefix: Prefix<XorName>,
     key: bls::PublicKey,
 ) -> SectionProofChain {
-    SectionProofChain::from_genesis(SectionKeyInfo::from_elders_info(elders_info, key))
+    SectionProofChain::from_genesis(SectionKeyInfo::new(version, prefix, key))
 }
 
 #[cfg(feature = "mock_base")]

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -19,9 +19,7 @@ mod proof;
 mod shared_state;
 
 pub use self::{
-    chain::{
-        delivery_group_size, Chain, ParsecResetData, PollAccumulated, SectionKeyShare, TrustStatus,
-    },
+    chain::{delivery_group_size, Chain, ParsecResetData, PollAccumulated, SectionKeyShare},
     chain_accumulator::AccumulatingProof,
     config::NetworkParams,
     elders_info::{quorum_count, EldersInfo},
@@ -31,7 +29,7 @@ pub use self::{
         IntoAccumulatingEvent, NetworkEvent, OnlinePayload, SendAckMessagePayload,
     },
     proof::{Proof, ProofSet},
-    shared_state::{SectionKeyInfo, SectionProofChain},
+    shared_state::{SectionKeyInfo, SectionProofChain, TrustStatus},
 };
 use crate::PublicId;
 use std::{

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -622,11 +622,7 @@ impl SectionProofChain {
             None => return TrustStatus::ProofInvalid,
         };
 
-        let min_proof_version = self
-            .all_key_infos()
-            .map(|proof_key_info| proof_key_info.version())
-            .min()
-            .expect("empty proof");
+        let min_proof_version = self.genesis_key_info.version();
 
         if min_proof_version > max_known_version {
             TrustStatus::ProofTooNew

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -606,7 +606,7 @@ impl SectionProofChain {
             .all_key_infos()
             .any(|proof_key_info| known_key_infos.contains(proof_key_info))
         {
-            return TrustStatus::Trusted(Some(self.last_public_key_info().key()));
+            return TrustStatus::Trusted(self.last_public_key_info().key());
         }
 
         let max_known_version = match known_key_infos
@@ -710,7 +710,7 @@ impl SectionKeyInfo {
 #[derive(Debug)]
 pub enum TrustStatus<'a> {
     // Message is trusted. Contains the latest section public key.
-    Trusted(Option<&'a bls::PublicKey>),
+    Trusted(&'a bls::PublicKey),
     // Message is untrusted because the proof is invalid.
     ProofInvalid,
     // Message trust cannot be determined because the proof starts at version that is newer than

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@ pub mod rng;
 #[cfg(feature = "mock_base")]
 pub use self::{
     chain::{
-        delivery_group_size, elders_info_for_test, quorum_count,
-        section_proof_chain_from_elders_info, NetworkParams, SectionKeyShare, MIN_AGE,
+        delivery_group_size, elders_info_for_test, quorum_count, section_proof_chain_for_test,
+        NetworkParams, SectionKeyShare, MIN_AGE,
     },
     location::Location,
     messages::{Message, MessageContent, RoutingMessage, SignedRoutingMessage},

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -14,6 +14,7 @@ pub use self::direct::{
 use crate::{
     chain::{
         Chain, EldersInfo, GenesisPfxInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain,
+        TrustStatus,
     },
     crypto::{self, signing::Signature, Digest256},
     error::{Result, RoutingError},
@@ -327,13 +328,13 @@ impl SignedRoutingMessage {
     }
 
     /// Checks if the message can be trusted according to the Chain
-    pub fn check_trust(&self, chain: &Chain) -> bool {
+    pub fn check_trust(&self, chain: &Chain) -> TrustStatus {
         match self.security_metadata {
             SecurityMetadata::Full(ref security_metadata) => {
                 chain.check_trust(security_metadata.proof_chain())
             }
-            SecurityMetadata::None | SecurityMetadata::Single(_) => true,
-            SecurityMetadata::Partial(_) => false,
+            SecurityMetadata::None | SecurityMetadata::Single(_) => TrustStatus::Trusted,
+            SecurityMetadata::Partial(_) => TrustStatus::ProofInvalid,
         }
     }
 

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -70,11 +70,10 @@ impl SignedRelocateDetails {
         &self.proof
     }
 
-    // TODO: remove this `allow(unused)` when the Relocate signature issue is solved.
-    #[allow(unused)]
-    pub fn verify(&self) -> bool {
+    #[cfg_attr(feature = "mock_base", allow(clippy::trivially_copy_pass_by_ref))]
+    pub fn verify(&self, public_key: &bls::PublicKey) -> bool {
         serialize(&self.content)
-            .map(|bytes| self.proof.last_public_key().verify(&self.signature, bytes))
+            .map(|bytes| public_key.verify(&self.signature, bytes))
             .unwrap_or(false)
     }
 }

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -83,8 +83,8 @@ impl fmt::Debug for SignedRelocateDetails {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(
             formatter,
-            "SignedRelocateDetails {{ content: {:?}, .. }}",
-            self.content
+            "SignedRelocateDetails {{ content: {:?}, proof: {:?}, .. }}",
+            self.content, self.proof,
         )
     }
 }

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -523,15 +523,15 @@ pub trait Approved: Base {
     }
 
     fn check_signed_relocation_details(&self, details: &SignedRelocateDetails) -> bool {
-        match self.chain().check_trust(details.proof()) {
-            TrustStatus::Trusted => (),
-            TrustStatus::ProofTooNew | TrustStatus::ProofInvalid => {
+        let public_key = match self.chain().check_trust(details.proof()) {
+            TrustStatus::Trusted(Some(key)) => key,
+            TrustStatus::Trusted(None) | TrustStatus::ProofTooNew | TrustStatus::ProofInvalid => {
                 self.log_trust_check_failure(details);
                 return false;
             }
-        }
+        };
 
-        if !details.verify() {
+        if !details.verify(public_key) {
             log_or_panic!(
                 LogLevel::Error,
                 "{} - Invalid signature of {:?}",

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -431,8 +431,9 @@ pub trait Base: Display {
     fn check_signed_message_integrity(
         &self,
         msg: &SignedRoutingMessage,
+        public_key: Option<&bls::PublicKey>,
     ) -> Result<(), RoutingError> {
-        msg.check_integrity().map_err(|err| {
+        msg.check_integrity(public_key).map_err(|err| {
             log_or_panic!(
                 LogLevel::Error,
                 "{} Invalid integrity of {:?}: {:?}",

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -14,7 +14,6 @@ use crate::{
     location::Location,
     messages::{
         DirectMessage, HopMessageWithBytes, Message, MessageWithBytes, SignedDirectMessage,
-        SignedRoutingMessage,
     },
     network_service::NetworkService,
     outbox::EventBox,
@@ -28,7 +27,6 @@ use crate::{
     ConnectionInfo, NetworkEvent,
 };
 use bytes::Bytes;
-use log::LogLevel;
 use std::{fmt::Display, net::SocketAddr, slice};
 
 // Trait for all states.
@@ -426,23 +424,6 @@ pub trait Base: Display {
         self.network_service_mut()
             .service_mut()
             .send(client, msg, token);
-    }
-
-    fn check_signed_message_integrity(
-        &self,
-        msg: &SignedRoutingMessage,
-        public_key: Option<&bls::PublicKey>,
-    ) -> Result<(), RoutingError> {
-        msg.check_integrity(public_key).map_err(|err| {
-            log_or_panic!(
-                LogLevel::Error,
-                "{} Invalid integrity of {:?}: {:?}",
-                self,
-                msg,
-                err,
-            );
-            err
-        })
     }
 }
 

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -318,7 +318,7 @@ impl Base for JoiningPeer {
         );
 
         if self.in_location(&msg.routing_message().dst) {
-            self.check_signed_message_integrity(&msg)?;
+            // TODO: verify the message
             self.dispatch_routing_message(msg, outbox)
         } else {
             self.routing_msg_backlog.push(msg);

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -310,6 +310,13 @@ impl Base for JoiningPeer {
         }
 
         let msg = msg.into_signed_routing_message();
+
+        trace!(
+            "{} - Handle signed message: {:?}",
+            self,
+            msg.routing_message()
+        );
+
         if self.in_location(&msg.routing_message().dst) {
             self.check_signed_message_integrity(&msg)?;
             self.dispatch_routing_message(msg, outbox)


### PR DESCRIPTION
This PR fixes two failures:

1. When we are recently joined node and we have a backlogged message that we received while still in `JoiningPeer` state, we must forward the message to our elders if we can't handle it ourselves instead of ignoring it. This prevents losing `NeighbourInfo` votes (among possibly other things)
2. When we are elder and we receive a message whose proof is too new for us, we must not fail but instead forward the message to the other elders. This is because we've already been demoted, we just haven't catched up to it yet.