### PR TITLE
Verify NodeApproval message as JoiningPeer

### DIFF
--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -80,8 +80,12 @@ impl EventSigPayload {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct OnlinePayload {
+    // Identifier of the joining node.
     pub p2p_node: P2pNode,
+    // The age the node should have after joining.
     pub age: u8,
+    // The version of the destination section that the joining node knows, if any.
+    pub their_knowledge: Option<u64>,
 }
 
 /// Routing Network events

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -32,6 +32,9 @@ pub struct RelocateDetails {
     /// Relocation destination - the node will be relocated to a section whose prefix matches this
     /// name.
     pub destination: XorName,
+    /// The `SectionKeyInfo` of the destination section used by the relocated node to verify
+    /// messages.
+    pub destination_key_info: SectionKeyInfo,
     /// The age the node will have post-relocation.
     pub age: u8,
 }
@@ -80,7 +83,6 @@ impl SignedRelocateDetails {
         };
 
         let bytes = serialize(&self.content)?;
-
         if public_key.verify(&self.signature, bytes) {
             Ok(())
         } else {

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -426,15 +426,12 @@ impl Adult {
     }
 
     fn verify_signed_message(&self, msg: &SignedRoutingMessage) -> Result<(), RoutingError> {
-        let result = match msg.verify(self.chain.get_their_keys_info()) {
-            Ok(VerifyStatus::Full) => Ok(()),
-            Ok(VerifyStatus::ProofTooNew) => Err(RoutingError::UntrustedMessage),
-            Err(error) => Err(error),
-        };
-        result.map_err(|error| {
-            self.log_verify_failure(msg, &error);
-            error
-        })
+        msg.verify(self.chain.get_their_key_infos())
+            .and_then(VerifyStatus::require_full)
+            .map_err(|error| {
+                self.log_verify_failure(msg, &error, self.chain.get_their_key_infos());
+                error
+            })
     }
 }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -25,7 +25,7 @@ use crate::{
 use itertools::Itertools;
 use log::LogLevel;
 use rand::Rng;
-use std::{collections::BTreeSet, fmt::Debug};
+use std::collections::BTreeSet;
 
 /// Common functionality for node states post resource proof.
 pub trait Approved: Base {
@@ -522,10 +522,10 @@ pub trait Approved: Base {
     }
 
     fn check_signed_relocation_details(&self, details: &SignedRelocateDetails) -> bool {
-        match details.verify(self.chain().get_their_keys_info()) {
+        match details.verify(self.chain().get_their_key_infos()) {
             Ok(()) => true,
             Err(error) => {
-                self.log_verify_failure(details, &error);
+                self.log_verify_failure(details, &error, self.chain().get_their_key_infos());
                 false
             }
         }
@@ -552,17 +552,6 @@ pub trait Approved: Base {
                 DirectMessage::MemberKnowledge(payload),
             )
         }
-    }
-
-    fn log_verify_failure<T: Debug>(&self, msg: &T, error: &RoutingError) {
-        log_or_panic!(
-            LogLevel::Error,
-            "{} - Verification failed: {:?} - {:?} --- [{:?}]",
-            self,
-            msg,
-            error,
-            self.chain().get_their_keys_info().format(", ")
-        )
     }
 }
 

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -173,6 +173,7 @@ impl ElderUnderTest {
             iter::once(AccumulatingEvent::Online(OnlinePayload {
                 p2p_node,
                 age: MIN_AGE,
+                their_knowledge: None,
             })),
         );
     }


### PR DESCRIPTION
- If we are a newly joining node, we don't have any trusted keys so we cannot fully verify the message. Instead we only check that the proof and the message signature are valid.
- If we are relocating node, we carry the trusted keys from our previous section into the `JoiningPeer` state and use that to fully verify the message

Closes #2022 .