### PR TITLE
Remove tusted key from Hop messages

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -11,7 +11,7 @@ use super::{
     shared_state::{SectionKeyInfo, SectionProofBlock, SharedState, SplitCache},
     AccumulatedEvent, AccumulatingEvent, AgeCounter, EldersChange, EldersInfo, GenesisPfxInfo,
     MemberInfo, MemberPersona, MemberState, NetworkEvent, NetworkParams, Proof, ProofSet,
-    SectionProofChain,
+    SectionProofSlice,
 };
 use crate::{
     error::RoutingError,
@@ -891,7 +891,7 @@ impl Chain {
             && self.is_new(elders_info)
     }
 
-    /// Provide a SectionProofChain that proves the given signature to the given destination
+    /// Provide a SectionProofSlice that proves the given signature to the given destination
     /// location.
     /// If `node_knowledge_override` is `Some`, it is used when calculating proof for
     /// `Location::Node` instead of the stored knowledge. Has no effect for other location types.
@@ -899,7 +899,7 @@ impl Chain {
         &self,
         target: &Location,
         node_knowledge_override: Option<u64>,
-    ) -> SectionProofChain {
+    ) -> SectionProofSlice {
         let first_index = match (target, node_knowledge_override) {
             (Location::Node(_), Some(knowledge)) => knowledge,
             _ => self.state.proving_index(target),

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
         IntoAccumulatingEvent, NetworkEvent, OnlinePayload, SendAckMessagePayload,
     },
     proof::{Proof, ProofSet},
-    shared_state::{SectionKeyInfo, SectionProofChain, TrustStatus},
+    shared_state::{SectionKeyInfo, SectionProofSlice, TrustStatus},
 };
 use crate::PublicId;
 use std::{
@@ -69,12 +69,12 @@ impl Debug for GenesisPfxInfo {
 
 #[cfg(feature = "mock_base")]
 /// Test helper to create arbitrary proof.
-pub fn section_proof_chain_for_test(
+pub fn section_proof_slice_for_test(
     version: u64,
     prefix: Prefix<XorName>,
     key: bls::PublicKey,
-) -> SectionProofChain {
-    SectionProofChain::from_genesis(SectionKeyInfo::new(version, prefix, key))
+) -> SectionProofSlice {
+    SectionProofSlice::from_genesis(SectionKeyInfo::new(version, prefix, key))
 }
 
 #[cfg(feature = "mock_base")]

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -18,7 +18,7 @@ use bincode::{deserialize, serialize};
 use itertools::Itertools;
 use log::LogLevel;
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fmt::{self, Debug, Formatter},
     iter, mem,
 };
@@ -520,6 +520,119 @@ impl SectionProofBlock {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+pub struct SectionProofSlice {
+    /// The version of the section key to use as root of trust.
+    version: u64,
+    /// The prefix of section key to use as root of trust.
+    prefix: Prefix<XorName>,
+    /// chain of trust to the section, if empty use root of trust.
+    blocks: Vec<SectionProofBlock>,
+}
+
+impl SectionProofSlice {
+    #[cfg(any(feature = "mock_base", test))]
+    pub fn from_genesis(key_info: SectionKeyInfo) -> Self {
+        Self {
+            version: key_info.version,
+            prefix: key_info.prefix,
+            blocks: Vec::new(),
+        }
+    }
+
+    pub fn blocks_len(&self) -> usize {
+        self.blocks.len()
+    }
+
+    pub fn last_prefix_version(&self) -> (&Prefix<XorName>, u64) {
+        self.blocks
+            .last()
+            .map(|block| (block.prefix(), block.version()))
+            .unwrap_or((&self.prefix, self.version))
+    }
+
+    #[cfg(all(test, feature = "mock"))]
+    pub fn all_prefix_version(&self) -> impl DoubleEndedIterator<Item = (&Prefix<XorName>, u64)> {
+        iter::once((&self.prefix, self.version)).chain(
+            self.blocks
+                .iter()
+                .map(|block| (block.prefix(), block.version())),
+        )
+    }
+
+    pub fn last_new_public_key_info(&self) -> Option<&SectionKeyInfo> {
+        self.blocks.last().map(|block| block.key_info())
+    }
+
+    fn last_trusted_key_info<'a>(
+        &'a self,
+        last_trusted: &'a SectionKeyInfo,
+    ) -> Option<&'a SectionKeyInfo> {
+        let block_offset = last_trusted.version().saturating_sub(self.version) as usize;
+
+        if block_offset == 0 {
+            if last_trusted.version() != self.version || last_trusted.prefix() != &self.prefix {
+                return None;
+            }
+        } else if let Some(block) = self.blocks.get(block_offset - 1) {
+            if block.key_info() != last_trusted {
+                return None;
+            }
+        } else {
+            // Root of trust not found
+            return None;
+        }
+
+        let mut current = last_trusted;
+        for block in &self.blocks[block_offset..] {
+            if !validate_next_block(current, block) {
+                return None;
+            }
+
+            current = block.key_info();
+        }
+
+        Some(current)
+    }
+
+    // Verify this proof chain against the given key infos.
+    pub fn check_trust<'a, I>(&'a self, their_key_infos: I) -> TrustStatus<'a>
+    where
+        I: IntoIterator<Item = (&'a Prefix<XorName>, &'a SectionKeyInfo)>,
+    {
+        let first_version = self.version;
+        let (last_prefix, last_version) = self.last_prefix_version();
+        let inclusive_range = first_version..=last_version;
+
+        let mut max_known_version = 0;
+        let mut found_prefix_keys = false;
+
+        for proof_key_info in their_key_infos
+            .into_iter()
+            .filter(|&(pfx, _)| last_prefix.is_compatible(pfx))
+            .map(|(_, info)| info)
+        {
+            max_known_version = std::cmp::max(max_known_version, proof_key_info.version());
+            found_prefix_keys = true;
+
+            if inclusive_range.contains(&proof_key_info.version()) {
+                // We can validate trust with that key: we are done.
+                if let Some(trusted_info) = self.last_trusted_key_info(proof_key_info) {
+                    return TrustStatus::Trusted(trusted_info.key());
+                } else {
+                    return TrustStatus::ProofInvalid;
+                }
+            }
+        }
+
+        if found_prefix_keys && self.version > max_known_version {
+            TrustStatus::ProofTooNew
+        } else {
+            TrustStatus::ProofInvalid
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct SectionProofChain {
     genesis_key_info: SectionKeyInfo,
     blocks: Vec<SectionProofBlock>,
@@ -533,12 +646,8 @@ impl SectionProofChain {
         }
     }
 
-    pub fn blocks_len(&self) -> usize {
-        self.blocks.len()
-    }
-
     pub fn push(&mut self, block: SectionProofBlock) {
-        if !self.validate_next_block(self.last_public_key_info(), &block) {
+        if !validate_next_block(self.last_public_key_info(), &block) {
             log_or_panic!(
                 LogLevel::Error,
                 "Invalid next block: {:?} -> {:?}",
@@ -551,10 +660,11 @@ impl SectionProofChain {
         self.blocks.push(block)
     }
 
+    #[cfg(test)]
     pub fn validate(&self) -> bool {
         let mut current = &self.genesis_key_info;
         for block in &self.blocks {
-            if !self.validate_next_block(current, block) {
+            if !validate_next_block(current, block) {
                 return false;
             }
 
@@ -570,13 +680,13 @@ impl SectionProofChain {
             .unwrap_or(&self.genesis_key_info)
     }
 
-    pub fn all_key_infos(&self) -> impl DoubleEndedIterator<Item = &SectionKeyInfo> {
-        iter::once(&self.genesis_key_info).chain(self.blocks.iter().map(|block| block.key_info()))
-    }
-
-    pub fn slice_from(&self, first_index: usize) -> Self {
+    pub fn slice_from(&self, first_index: usize) -> SectionProofSlice {
         if first_index == 0 || self.blocks.is_empty() {
-            return self.clone();
+            return SectionProofSlice {
+                version: self.genesis_key_info.version,
+                prefix: self.genesis_key_info.prefix,
+                blocks: self.blocks.clone(),
+            };
         }
 
         let genesis_index = std::cmp::min(first_index, self.blocks.len()) - 1;
@@ -589,66 +699,30 @@ impl SectionProofChain {
             self.blocks[block_first_index..].to_vec()
         };
 
-        Self {
-            genesis_key_info,
+        SectionProofSlice {
+            version: genesis_key_info.version,
+            prefix: genesis_key_info.prefix,
             blocks,
         }
     }
+}
 
-    // Verify this proof chain against the given key infos.
-    pub fn check_trust<'a, I>(&'a self, their_key_infos: I) -> TrustStatus<'a>
-    where
-        I: IntoIterator<Item = (&'a Prefix<XorName>, &'a SectionKeyInfo)>,
+fn validate_next_block(last: &SectionKeyInfo, next: &SectionProofBlock) -> bool {
+    if next.version() != last.version() + 1 {
+        return false;
+    }
+
+    if !next.prefix().is_compatible(last.prefix())
+        || next.prefix().bit_count() > last.prefix().bit_count() + 1
     {
-        let last_prefix = self.last_public_key_info().prefix();
-        let known_key_infos: BTreeSet<_> = their_key_infos
-            .into_iter()
-            .filter(|&(pfx, _)| last_prefix.is_compatible(pfx))
-            .map(|(_, info)| info)
-            .collect();
-
-        if self
-            .all_key_infos()
-            .any(|proof_key_info| known_key_infos.contains(proof_key_info))
-        {
-            return TrustStatus::Trusted(self.last_public_key_info().key());
-        }
-
-        let max_known_version = match known_key_infos
-            .iter()
-            .map(|known_key_info| known_key_info.version())
-            .max()
-        {
-            Some(version) => version,
-            None => return TrustStatus::ProofInvalid,
-        };
-
-        let min_proof_version = self.genesis_key_info.version();
-
-        if min_proof_version > max_known_version {
-            TrustStatus::ProofTooNew
-        } else {
-            TrustStatus::ProofInvalid
-        }
+        return false;
     }
 
-    fn validate_next_block(&self, last: &SectionKeyInfo, next: &SectionProofBlock) -> bool {
-        if next.version() != last.version() + 1 {
-            return false;
-        }
-
-        if !next.prefix().is_compatible(last.prefix())
-            || next.prefix().bit_count() > last.prefix().bit_count() + 1
-        {
-            return false;
-        }
-
-        if !next.verify_with_pk(*last.key()) {
-            return false;
-        }
-
-        true
+    if !next.verify_with_pk(*last.key()) {
+        return false;
     }
+
+    true
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -596,9 +596,9 @@ impl SectionProofChain {
     }
 
     // Verify this proof chain against the given key infos.
-    pub fn check_trust<'a, 'b, I>(&'a self, their_key_infos: I) -> TrustStatus<'a>
+    pub fn check_trust<'a, I>(&'a self, their_key_infos: I) -> TrustStatus<'a>
     where
-        I: IntoIterator<Item = (&'b Prefix<XorName>, &'b SectionKeyInfo)>,
+        I: IntoIterator<Item = (&'a Prefix<XorName>, &'a SectionKeyInfo)>,
     {
         let last_prefix = self.last_public_key_info().prefix();
         let known_key_infos: BTreeSet<_> = their_key_infos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub mod rng;
 #[cfg(feature = "mock_base")]
 pub use self::{
     chain::{
-        delivery_group_size, elders_info_for_test, quorum_count, section_proof_chain_for_test,
+        delivery_group_size, elders_info_for_test, quorum_count, section_proof_slice_for_test,
         NetworkParams, SectionKeyShare, MIN_AGE,
     },
     location::Location,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -13,7 +13,7 @@ pub use self::direct::{
 };
 use crate::{
     chain::{
-        EldersInfo, GenesisPfxInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain, TrustStatus,
+        EldersInfo, GenesisPfxInfo, SectionKeyInfo, SectionKeyShare, SectionProofSlice, TrustStatus,
     },
     crypto::{self, signing::Signature, Digest256},
     error::{Result, RoutingError},
@@ -171,7 +171,7 @@ impl HopMessageWithBytes {
 /// and into a FullSecurityMetadata.
 #[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PartialSecurityMetadata {
-    proof: SectionProofChain,
+    proof: SectionProofSlice,
     shares: BTreeSet<(usize, bls::SignatureShare)>,
     pk_set: bls::PublicKeySet,
 }
@@ -201,13 +201,13 @@ impl Debug for PartialSecurityMetadata {
 /// Metadata needed for verification of the sender.
 #[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct FullSecurityMetadata {
-    proof: SectionProofChain,
+    proof: SectionProofSlice,
     signature: bls::Signature,
 }
 
 impl FullSecurityMetadata {
-    pub fn last_public_key_info(&self) -> &SectionKeyInfo {
-        self.proof.last_public_key_info()
+    pub fn last_new_public_key_info(&self) -> Option<&SectionKeyInfo> {
+        self.proof.last_new_public_key_info()
     }
 
     pub fn verify<'a, I>(
@@ -218,10 +218,6 @@ impl FullSecurityMetadata {
     where
         I: IntoIterator<Item = (&'a Prefix<XorName>, &'a SectionKeyInfo)>,
     {
-        if !self.proof.validate() {
-            return Err(RoutingError::InvalidProvingSection);
-        }
-
         let public_key = match self.proof.check_trust(their_key_infos) {
             TrustStatus::Trusted(key) => key,
             TrustStatus::ProofTooNew => return Ok(VerifyStatus::ProofTooNew),
@@ -346,7 +342,7 @@ impl SignedRoutingMessage {
         content: RoutingMessage,
         section_share: &SectionKeyShare,
         pk_set: bls::PublicKeySet,
-        proof: SectionProofChain,
+        proof: SectionProofSlice,
     ) -> Result<Self> {
         let mut signatures = BTreeSet::new();
         let sig = section_share.key.sign(&serialize(&content)?);
@@ -417,7 +413,7 @@ impl SignedRoutingMessage {
                 None
             }
             SecurityMetadata::Full(ref security_metadata) => {
-                Some(security_metadata.last_public_key_info())
+                security_metadata.last_new_public_key_info()
             }
         }
     }
@@ -536,7 +532,7 @@ impl SignedRoutingMessage {
     }
 
     #[cfg(all(test, feature = "mock"))]
-    pub(crate) fn proof_chain(&self) -> Option<&SectionProofChain> {
+    pub(crate) fn proof_chain(&self) -> Option<&SectionProofSlice> {
         match &self.security_metadata {
             SecurityMetadata::Full(md) => Some(&md.proof),
             SecurityMetadata::Partial(md) => Some(&md.proof),
@@ -757,8 +753,8 @@ mod tests {
         assert_eq!(signed_msg, Some(signed_msg_org))
     }
 
-    fn make_proof_chain(pk_set: &bls::PublicKeySet) -> SectionProofChain {
-        SectionProofChain::from_genesis(make_section_key_info(pk_set))
+    fn make_proof_chain(pk_set: &bls::PublicKeySet) -> SectionProofSlice {
+        SectionProofSlice::from_genesis(make_section_key_info(pk_set))
     }
 
     fn make_their_key_infos(

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -211,7 +211,7 @@ impl FullSecurityMetadata {
     }
 
     pub fn verify<'a, I>(
-        &self,
+        &'a self,
         content: &RoutingMessage,
         their_key_infos: I,
     ) -> Result<VerifyStatus, RoutingError>
@@ -395,7 +395,7 @@ impl SignedRoutingMessage {
     }
 
     /// Verify this message is properly signed and trusted.
-    pub fn verify<'a, I>(&self, their_key_infos: I) -> Result<VerifyStatus, RoutingError>
+    pub fn verify<'a, I>(&'a self, their_key_infos: I) -> Result<VerifyStatus, RoutingError>
     where
         I: IntoIterator<Item = (&'a Prefix<XorName>, &'a SectionKeyInfo)>,
     {

--- a/src/node.rs
+++ b/src/node.rs
@@ -31,7 +31,7 @@ use std::{net::SocketAddr, sync::mpsc};
 #[cfg(feature = "mock_base")]
 use {
     crate::{
-        chain::{Chain, SectionProofChain},
+        chain::{Chain, SectionProofSlice},
         Prefix,
     },
     std::{
@@ -491,9 +491,9 @@ impl Node {
         self.machine.current().is_connected(socket_addr)
     }
 
-    /// Provide a SectionProofChain that proves the given signature to the section with a given
+    /// Provide a SectionProofSlice that proves the given signature to the section with a given
     /// prefix
-    pub fn prove(&self, target: &Location) -> Option<SectionProofChain> {
+    pub fn prove(&self, target: &Location) -> Option<SectionProofSlice> {
         self.chain().map(|chain| chain.prove(target, None))
     }
 

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     chain::{
-        AccumulatingEvent, IntoAccumulatingEvent, SectionKeyInfo, SectionProofChain, TrustStatus,
+        AccumulatingEvent, IntoAccumulatingEvent, SectionKeyInfo, SectionProofSlice, TrustStatus,
     },
     crypto::{self, signing::Signature},
     error::RoutingError,
@@ -47,14 +47,14 @@ impl IntoAccumulatingEvent for RelocateDetails {
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SignedRelocateDetails {
     content: RelocateDetails,
-    proof: SectionProofChain,
+    proof: SectionProofSlice,
     signature: bls::Signature,
 }
 
 impl SignedRelocateDetails {
     pub fn new(
         content: RelocateDetails,
-        proof: SectionProofChain,
+        proof: SectionProofSlice,
         signature: bls::Signature,
     ) -> Self {
         Self {

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -68,7 +68,7 @@ impl SignedRelocateDetails {
         &self.content
     }
 
-    pub fn verify<'a, I>(&self, their_key_infos: I) -> Result<(), RoutingError>
+    pub fn verify<'a, I>(&'a self, their_key_infos: I) -> Result<(), RoutingError>
     where
         I: IntoIterator<Item = (&'a Prefix<XorName>, &'a SectionKeyInfo)>,
     {

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -75,7 +75,7 @@ impl SignatureAccumulator {
 mod tests {
     use super::*;
     use crate::{
-        chain::{EldersInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain},
+        chain::{EldersInfo, SectionKeyInfo, SectionKeyShare, SectionProofSlice},
         id::{FullId, P2pNode},
         location::Location,
         messages::{
@@ -117,7 +117,7 @@ mod tests {
             let prefix = Prefix::new(0, *unwrap!(all_nodes.keys().next()));
             let elders_info = unwrap!(EldersInfo::new(all_nodes.clone(), prefix, None));
             let key_info = SectionKeyInfo::from_elders_info(&elders_info, pk_set.public_key());
-            let proof = SectionProofChain::from_genesis(key_info);
+            let proof = SectionProofSlice::from_genesis(key_info);
             let signed_msg = unwrap!(SignedRoutingMessage::new(
                 routing_msg.clone(),
                 msg_sender_secret_bls,

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -15,7 +15,7 @@
 
 use super::{super::test_utils, *};
 use crate::{
-    chain::{SectionKeyInfo, SectionProofChain},
+    chain::{SectionKeyInfo, SectionProofSlice},
     generate_bls_threshold_secret_key,
     messages::DirectMessage,
     rng::{self, MainRng},
@@ -558,22 +558,22 @@ fn send_genesis_update() {
     verify_proof_chain_does_not_contain(proof_chain, orig_elders_version);
 }
 
-fn verify_proof_chain_contains(proof_chain: &SectionProofChain, expected_version: u64) {
+fn verify_proof_chain_contains(proof_chain: &SectionProofSlice, expected_version: u64) {
     assert!(
         proof_chain
-            .all_key_infos()
-            .any(|key_info| key_info.version() == expected_version),
+            .all_prefix_version()
+            .any(|(_, version)| version == expected_version),
         "{:?} doesn't contain expected version {}",
         proof_chain,
         expected_version,
     );
 }
 
-fn verify_proof_chain_does_not_contain(proof_chain: &SectionProofChain, unexpected_version: u64) {
+fn verify_proof_chain_does_not_contain(proof_chain: &SectionProofSlice, unexpected_version: u64) {
     assert!(
         proof_chain
-            .all_key_infos()
-            .all(|key_info| key_info.version() != unexpected_version),
+            .all_prefix_version()
+            .all(|(_, version)| version != unexpected_version),
         "{:?} contains unexpected version {}",
         proof_chain,
         unexpected_version,

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -9,7 +9,7 @@
 use super::{create_connected_nodes_until_split, poll_all, Nodes, TestNode};
 use routing::{
     elders_info_for_test, generate_bls_threshold_secret_key, mock::Environment,
-    section_proof_chain_for_test, ConnectionInfo, FullId, Location, Message, MessageContent,
+    section_proof_slice_for_test, ConnectionInfo, FullId, Location, Message, MessageContent,
     NetworkParams, P2pNode, Prefix, RoutingMessage, SectionKeyShare, SignedRoutingMessage, XorName,
 };
 use std::{collections::BTreeMap, iter, net::SocketAddr};
@@ -87,7 +87,7 @@ fn message_with_invalid_security(fail_type: FailType) {
                 .prove(&Location::PrefixSection(their_prefix))),
             FailType::UntrustedProofValidSig => {
                 let invalid_prefix = our_prefix;
-                section_proof_chain_for_test(0, invalid_prefix, bls_keys.public_keys().public_key())
+                section_proof_slice_for_test(0, invalid_prefix, bls_keys.public_keys().public_key())
             }
         };
         let pk_set = bls_keys.public_keys();


### PR DESCRIPTION
Closes #1752 

We should only validate trust when we have the root of trust:
The root of trust bls::PublicKey is no longer part of the Hop message from a Section.
For most message the security_metadata will now only be a Prefix + version(u64).
To validate the message we must find the key we trust and either use it to validate a new
key to trust, or the message itself.