### PR TITLE
fix/routing: use same mechanism for Relocate as GenesisUpdate

### DIFF
--- a/src/chain/network_event.rs
+++ b/src/chain/network_event.rs
@@ -14,7 +14,6 @@ use crate::{
     relocation::RelocateDetails,
     Prefix, XorName,
 };
-use bincode::serialize;
 use hex_fmt::HexFmt;
 use serde::Serialize;
 use std::{
@@ -51,19 +50,6 @@ pub struct EventSigPayload {
 }
 
 impl EventSigPayload {
-    pub fn new<T: Serialize>(
-        key_share: &bls::SecretKeyShare,
-        payload: &T,
-    ) -> Result<Self, RoutingError> {
-        let sig_share = key_share.sign(&serialize(&payload)?[..]);
-        let pub_key_share = key_share.public_key_share();
-
-        Ok(Self {
-            pub_key_share,
-            sig_share,
-        })
-    }
-
     pub fn new_for_section_key_info(
         key_share: &bls::SecretKeyShare,
         section_key_info: &SectionKeyInfo,
@@ -210,7 +196,6 @@ impl Debug for NetworkEvent {
 pub struct AccumulatedEvent {
     pub content: AccumulatingEvent,
     pub elders_change: EldersChange,
-    pub signature: Option<bls::Signature>,
 }
 
 impl AccumulatedEvent {
@@ -218,12 +203,7 @@ impl AccumulatedEvent {
         Self {
             content,
             elders_change: EldersChange::default(),
-            signature: None,
         }
-    }
-
-    pub fn with_signature(self, signature: Option<bls::Signature>) -> Self {
-        Self { signature, ..self }
     }
 
     pub fn with_elders_change(self, elders_change: EldersChange) -> Self {

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -13,7 +13,7 @@ use crate::{
     id::{FullId, PublicId},
     messages::SignedRoutingMessage,
     parsec,
-    relocation::{RelocatePayload, SignedRelocateDetails},
+    relocation::RelocatePayload,
     xor_space::XorName,
     ConnectionInfo,
 };
@@ -49,8 +49,6 @@ pub enum DirectMessage {
     ParsecRequest(u64, parsec::Request),
     /// Parsec response message
     ParsecResponse(u64, parsec::Response),
-    /// Send from a section to the node being relocated.
-    Relocate(Box<SignedRelocateDetails>),
 }
 
 /// Response to a BootstrapRequest
@@ -101,13 +99,12 @@ impl Debug for DirectMessage {
                 join_request
                     .relocate_payload
                     .as_ref()
-                    .map(|payload| payload.details.content())
+                    .and_then(|payload| payload.relocate_details()),
             ),
             ConnectionResponse => write!(formatter, "ConnectionResponse"),
             ParsecRequest(v, _) => write!(formatter, "ParsecRequest({}, _)", v),
             ParsecResponse(v, _) => write!(formatter, "ParsecResponse({}, _)", v),
             MemberKnowledge(payload) => write!(formatter, "{:?}", payload),
-            Relocate(payload) => write!(formatter, "Relocate({:?})", payload.content()),
         }
     }
 }
@@ -140,7 +137,6 @@ impl Hash for DirectMessage {
                 // Fake hash via serialisation
                 serialize(&response).ok().hash(state)
             }
-            Relocate(details) => details.hash(state),
         }
     }
 }

--- a/src/messages/direct.rs
+++ b/src/messages/direct.rs
@@ -99,7 +99,7 @@ impl Debug for DirectMessage {
                 join_request
                     .relocate_payload
                     .as_ref()
-                    .and_then(|payload| payload.relocate_details()),
+                    .map(|payload| payload.relocate_details()),
             ),
             ConnectionResponse => write!(formatter, "ConnectionResponse"),
             ParsecRequest(v, _) => write!(formatter, "ParsecRequest({}, _)", v),

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     error::{Result, RoutingError},
     id::{FullId, PublicId},
     location::Location,
+    relocation::RelocateDetails,
     states::common::{from_network_bytes, partial_from_network_bytes, to_network_bytes},
     utils::LogIdent,
     xor_space::{Prefix, XorName},
@@ -580,6 +581,8 @@ pub enum MessageContent {
     },
     /// Update sent to Adults and Infants by Elders
     GenesisUpdate(GenesisPfxInfo),
+    /// Send from a section to the node being relocated.
+    Relocate(RelocateDetails),
 }
 
 impl Debug for SignedRoutingMessage {
@@ -604,6 +607,7 @@ impl Debug for MessageContent {
                 ack_version,
             } => write!(formatter, "AckMessage({:?}, {})", src_prefix, ack_version),
             GenesisUpdate(info) => write!(formatter, "GenesisUpdate({:?})", info),
+            Relocate(payload) => write!(formatter, "Relocate({:?})", payload),
         }
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -581,8 +581,8 @@ pub enum MessageContent {
     },
     /// Update sent to Adults and Infants by Elders
     GenesisUpdate(GenesisPfxInfo),
-    /// Send from a section to the node being relocated.
-    Relocate(RelocateDetails),
+    /// Send to a node being relocated from its own section.
+    Relocate(Box<RelocateDetails>),
 }
 
 impl Debug for SignedRoutingMessage {

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -11,10 +11,11 @@ use crate::{
     chain::{EldersInfo, GenesisPfxInfo},
     error::RoutingError,
     id::{P2pNode, PublicId},
+    messages::SignedRoutingMessage,
     network_service::{NetworkBuilder, NetworkService},
     outbox::EventBox,
     pause::PausedState,
-    relocation::{RelocatePayload, SignedRelocateDetails},
+    relocation::RelocatePayload,
     states::{common::Base, Adult, BootstrappingPeer, Elder, JoiningPeer},
     timer::Timer,
     xor_space::{Prefix, XorName},
@@ -301,7 +302,7 @@ pub enum Transition {
     // Node getting relocated.
     Relocate {
         conn_infos: Vec<ConnectionInfo>,
-        details: SignedRelocateDetails,
+        details: SignedRoutingMessage,
     },
     // `JoiningPeer` state transitioning to `Adult`.
     IntoAdult {

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -11,11 +11,10 @@ use crate::{
     chain::{EldersInfo, GenesisPfxInfo},
     error::RoutingError,
     id::{P2pNode, PublicId},
-    messages::SignedRoutingMessage,
     network_service::{NetworkBuilder, NetworkService},
     outbox::EventBox,
     pause::PausedState,
-    relocation::RelocatePayload,
+    relocation::{RelocatePayload, SignedRelocateDetails},
     states::{common::Base, Adult, BootstrappingPeer, Elder, JoiningPeer},
     timer::Timer,
     xor_space::{Prefix, XorName},
@@ -302,7 +301,7 @@ pub enum Transition {
     // Node getting relocated.
     Relocate {
         conn_infos: Vec<ConnectionInfo>,
-        details: SignedRoutingMessage,
+        details: SignedRelocateDetails,
     },
     // `JoiningPeer` state transitioning to `Adult`.
     IntoAdult {

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     parsec::{DkgResultWrapper, ParsecMap},
     pause::PausedState,
     peer_map::PeerMap,
-    relocation::{RelocateDetails, SignedRelocateDetails},
+    relocation::RelocateDetails,
     rng::{self, MainRng},
     routing_message_filter::RoutingMessageFilter,
     signature_accumulator::SignatureAccumulator,
@@ -152,7 +152,7 @@ impl Adult {
     pub fn relocate(
         self,
         conn_infos: Vec<ConnectionInfo>,
-        details: SignedRelocateDetails,
+        details: SignedRoutingMessage,
     ) -> Result<State, RoutingError> {
         Ok(State::BootstrappingPeer(BootstrappingPeer::relocate(
             BootstrappingPeerDetails {
@@ -233,21 +233,24 @@ impl Adult {
         self.chain.our_prefix()
     }
 
-    fn handle_relocate(&mut self, details: SignedRelocateDetails) -> Transition {
-        if details.content().pub_id != *self.id() {
+    fn handle_relocate(
+        &mut self,
+        signed_msg: &SignedRoutingMessage,
+        details: &RelocateDetails,
+    ) -> Result<Transition, RoutingError> {
+        if details.pub_id != *self.id() {
             // This `Relocate` message is not for us - it's most likely a duplicate of a previous
             // message that we already handled.
-            return Transition::Stay;
+            return Ok(Transition::Stay);
         }
 
         debug!(
             "{} - Received Relocate message to join the section at {}.",
-            self,
-            details.content().destination
+            self, details.destination
         );
 
-        if !self.check_signed_relocation_details(&details) {
-            return Transition::Stay;
+        if !self.check_signed_relocation_details(signed_msg) {
+            return Ok(Transition::Stay);
         }
 
         let conn_infos: Vec<_> = self
@@ -258,10 +261,10 @@ impl Adult {
 
         self.network_service_mut().remove_and_disconnect_all();
 
-        Transition::Relocate {
-            details,
+        Ok(Transition::Relocate {
+            details: signed_msg.clone(),
             conn_infos,
-        }
+        })
     }
 
     // Since we are an adult we should only give info about our section elders and they would
@@ -415,6 +418,10 @@ impl Adult {
                     self.verify_signed_message(&signed_msg)?;
                     return self.handle_genesis_update(info.clone());
                 }
+                MessageContent::Relocate(details) => {
+                    self.verify_signed_message(&signed_msg)?;
+                    return self.handle_relocate(&signed_msg, details);
+                }
                 _ => {
                     self.routing_msg_backlog.push(signed_msg);
                 }
@@ -563,7 +570,6 @@ impl Base for Adult {
                 debug!("{} - Received connection response from {}", self, p2p_node);
                 Ok(Transition::Stay)
             }
-            Relocate(details) => Ok(self.handle_relocate(*details)),
             msg @ BootstrapResponse(_) => {
                 debug!(
                     "{} Unhandled direct message from {}, discard: {:?}",
@@ -654,10 +660,10 @@ impl Approved for Adult {
     fn handle_member_relocated(
         &mut self,
         _details: RelocateDetails,
-        _signature: bls::Signature,
         _node_knowledge: u64,
         _outbox: &mut dyn EventBox,
-    ) {
+    ) -> Result<(), RoutingError> {
+        Ok(())
     }
 
     fn handle_dkg_result_event(
@@ -696,8 +702,7 @@ impl Approved for Adult {
         _payload: RelocateDetails,
         _count_down: i32,
         _outbox: &mut dyn EventBox,
-    ) -> Result<(), RoutingError> {
-        Ok(())
+    ) {
     }
 
     fn handle_their_key_info_event(

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1023,15 +1023,7 @@ impl Elder {
                 return;
             }
 
-            let details = if let Some(details) = payload.relocate_details() {
-                details
-            } else {
-                debug!(
-                    "{} - Ignoring relocation JoinRequest from {} - invalid payload.",
-                    self, pub_id
-                );
-                return;
-            };
+            let details = payload.relocate_details();
 
             if !self.our_prefix().matches(&details.destination) {
                 debug!(
@@ -1045,7 +1037,7 @@ impl Elder {
                 return;
             }
 
-            if !self.check_signed_relocation_details(&*payload.details) {
+            if !self.check_signed_relocation_details(&payload.details) {
                 return;
             }
 
@@ -1676,7 +1668,7 @@ impl Approved for Elder {
 
         let src = Location::Section(self.our_prefix().name());
         let dst = Location::Node(*details.pub_id.name());
-        let content = MessageContent::Relocate(details);
+        let content = MessageContent::Relocate(Box::new(details));
 
         self.send_routing_message(RoutingMessage { src, dst, content }, Some(knowledge_index))
     }

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -191,20 +191,18 @@ impl JoiningPeer {
 
     fn verify_signed_message(&self, msg: &SignedRoutingMessage) -> Result<(), RoutingError> {
         if let JoinType::Relocate(payload) = &self.join_type {
-            if let Some(details) = payload.relocate_details() {
-                let key_info = &details.destination_key_info;
-                return msg
-                    .verify(as_iter(key_info))
-                    .and_then(VerifyStatus::require_full)
-                    .map_err(|error| {
-                        self.log_verify_failure(msg, &error, as_iter(key_info));
-                        error
-                    });
-            }
+            let details = payload.relocate_details();
+            let key_info = &details.destination_key_info;
+            msg.verify(as_iter(key_info))
+                .and_then(VerifyStatus::require_full)
+                .map_err(|error| {
+                    self.log_verify_failure(msg, &error, as_iter(key_info));
+                    error
+                })
+        } else {
+            // We don't have the root key info so we can't verify the message.
+            Ok(())
         }
-
-        // We don't have the root key info so we can't verify the message.
-        Ok(())
     }
 
     #[cfg(feature = "mock_base")]


### PR DESCRIPTION
With GenesisUpdate, we can now send a SignedRoutingMessage to one of
our members, by directly sending it the direct message MessageSignature.
The node accumulate it at reception and process it when enough signature
is received. This remove the need to sign the message before going
through Parsec.

Test:
soak + clippy