### PR TITLE
fix/rng: add compatibility for rand 0.7 for tmp-ed25519 v1.0.0-pre.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ config_file_handler = "~0.11.0"
 crossbeam-channel = "~0.3.9"
 ctrlc = { version = "~3", optional = true, features = ["termination"] }
 derive_more = "0.99.2"
-ed25519_dalek = { package = "tmp-ed25519", version = "1.0.0-pre.2", features = ["serde"] }
+ed25519_dalek = { package = "tmp-ed25519", version = "1.0.0-pre.3", features = ["serde"] }
 err-derive = "0.2.1"
 fake_clock = "~0.3.0"
 fxhash = "~0.2.1"

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -13,7 +13,6 @@ pub use self::implementation::{new, new_from, MainRng};
 pub use self::seed_printer::SeedPrinter;
 #[cfg(any(test, feature = "mock_base"))]
 pub use self::test::Seed;
-pub use rand::CryptoRng;
 
 // Note: routing uses different version of the rand crate than threshold_crypto. This is a
 // compatibility adapter between the two.
@@ -38,7 +37,27 @@ impl<R: rand::Rng> rand_crypto::RngCore for RngCompat<R> {
     }
 }
 
-impl<R: CryptoRng> rand_crypto::CryptoRng for RngCompat<R> {}
+impl<R: rand::CryptoRng> rand_crypto::CryptoRng for RngCompat<R> {}
+
+impl<R: rand::Rng> rand::RngCore for RngCompat<R> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl<R: rand::CryptoRng> rand::CryptoRng for RngCompat<R> {}
 
 // Rng implementation used in production. Uses `OsRng` for maximum cryptographic security.
 #[cfg(not(any(test, feature = "mock_base")))]


### PR DESCRIPTION
A new version exists for tmp-ed25519, selected when doing upgrade.
It uses a new version of rand.

Test:
clippy + test