### PR TITLE
Gone peers detection

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -32,7 +32,6 @@ use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
     fmt::{self, Debug, Display, Formatter},
     iter, mem,
-    net::SocketAddr,
 };
 
 #[cfg(feature = "mock_base")]
@@ -750,11 +749,6 @@ impl Chain {
         self.neighbour_infos()
             .chain(iter::once(self.state.our_info()))
             .flat_map(EldersInfo::member_nodes)
-    }
-
-    pub fn find_p2p_node_from_addr(&self, socket_addr: &SocketAddr) -> Option<&P2pNode> {
-        self.known_nodes()
-            .find(|p2p_node| p2p_node.peer_addr() == socket_addr)
     }
 
     /// Checks if given `PublicId` is an elder in our section or one of our neighbour sections.

--- a/src/id.rs
+++ b/src/id.rs
@@ -263,18 +263,18 @@ impl P2pNode {
 
 impl Debug for P2pNode {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "P2pNode({} at {})",
-            self.public_id.name(),
-            self.connection_info.0.peer_addr,
-        )
+        write!(formatter, "P2pNode({})", self,)
     }
 }
 
 impl Display for P2pNode {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.public_id)
+        write!(
+            f,
+            "{} at {}",
+            self.public_id.name(),
+            self.connection_info.0.peer_addr
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use self::{
 pub mod test_consts {
     pub use crate::{
         chain::{UNRESPONSIVE_THRESHOLD, UNRESPONSIVE_WINDOW},
-        states::{BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT},
+        states::{BOOTSTRAP_TIMEOUT, JOIN_TIMEOUT, LOST_PEER_ATTEMPTS, LOST_PEER_BASE_TIMEOUT},
     };
 }
 

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -60,6 +60,11 @@ pub enum Variant {
     ParsecRequest(u64, parsec::Request),
     /// Parsec response message
     ParsecResponse(u64, parsec::Response),
+    /// Message sent to a lost peer to determine whether the disconnect is permanent or only
+    /// temporary.
+    PingRequest,
+    /// Response to `PingRequest` to notify the recipient that we are still online.
+    PingResponse,
 }
 
 impl Debug for Variant {
@@ -85,6 +90,8 @@ impl Debug for Variant {
             Self::MemberKnowledge(payload) => write!(f, "MemberKnowledge({:?})", payload),
             Self::ParsecRequest(version, _) => write!(f, "ParsecRequest({}, ..)", version),
             Self::ParsecResponse(version, _) => write!(f, "ParsecResponse({}, ..)", version),
+            Self::PingRequest => write!(f, "PingRequest"),
+            Self::PingResponse => write!(f, "PingResponse"),
         }
     }
 }

--- a/src/network_service/mod.rs
+++ b/src/network_service/mod.rs
@@ -78,6 +78,11 @@ impl NetworkService {
             );
             self.quic_p2p
                 .send(Peer::Node { node_info: tgt }, msg, token);
+        } else {
+            error!(
+                "{} Resending of message ID {} failed too many times; giving up.",
+                log_ident, token
+            );
         }
     }
 

--- a/src/states/adult/mod.rs
+++ b/src/states/adult/mod.rs
@@ -473,13 +473,17 @@ impl Base for Adult {
                 self.handle_bootstrap_request(msg.src.to_sender_node(sender)?, name);
                 Ok(Transition::Stay)
             }
+            Variant::PingRequest => {
+                self.handle_ping_request(msg.src.to_sender_node(sender)?);
+                Ok(Transition::Stay)
+            }
             _ => unreachable!(),
         }
     }
 
     fn unhandled_message(&mut self, sender: Option<ConnectionInfo>, msg: Message) {
         match msg.variant {
-            Variant::BootstrapResponse(_) => {
+            Variant::BootstrapResponse(_) | Variant::PingResponse => {
                 debug!("{} Unhandled message, discarding: {:?}", self, msg);
             }
             _ => {
@@ -500,7 +504,8 @@ impl Base for Adult {
             | Variant::MessageSignature(_)
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
-            | Variant::BootstrapRequest(_) => true,
+            | Variant::BootstrapRequest(_)
+            | Variant::PingRequest => true,
 
             Variant::NeighbourInfo(_)
             | Variant::UserMessage(_)
@@ -508,7 +513,8 @@ impl Base for Adult {
             | Variant::AckMessage { .. }
             | Variant::JoinRequest(_)
             | Variant::MemberKnowledge(_)
-            | Variant::BootstrapResponse(_) => false,
+            | Variant::BootstrapResponse(_)
+            | Variant::PingResponse => false,
         }
     }
 

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -465,11 +465,11 @@ mod tests {
         let mut sel = mpmc::Select::new();
         machine.register(&mut sel);
 
-        // Blocking step for the first one.
-        let op_index = sel.ready();
+        // Step for the first one.
+        let op_index = unwrap!(sel.try_ready());
         unwrap!(machine.step(op_index, outbox));
 
-        // Exhaust any remaining step
+        // Exhaust any remaining steps
         loop {
             let mut sel = mpmc::Select::new();
             machine.register(&mut sel);

--- a/src/states/bootstrapping_peer.rs
+++ b/src/states/bootstrapping_peer.rs
@@ -334,7 +334,9 @@ impl Base for BootstrappingPeer {
             | Variant::JoinRequest(_)
             | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
-            | Variant::ParsecResponse(..) => false,
+            | Variant::ParsecResponse(..)
+            | Variant::PingRequest
+            | Variant::PingResponse => false,
         }
     }
 

--- a/src/states/common/approved.rs
+++ b/src/states/common/approved.rs
@@ -535,6 +535,24 @@ pub trait Approved: Base {
             )
         }
     }
+
+    fn handle_ping_request(&mut self, sender: P2pNode) {
+        if !self.chain().is_peer_our_elder(sender.public_id()) {
+            trace!(
+                "{} - Received PingRequest from {} who is not our elder - ignoring",
+                self,
+                sender
+            );
+            return;
+        }
+
+        trace!(
+            "{} - Received PingRequest from {} - responding",
+            self,
+            sender
+        );
+        self.send_direct_message(sender.connection_info(), Variant::PingResponse)
+    }
 }
 
 #[allow(unused)]

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -423,8 +423,9 @@ pub trait Base: Display {
         dg_size: usize,
         message: Bytes,
     ) {
+        let log_ident = self.log_ident();
         self.network_service_mut()
-            .send_message_to_initial_targets(conn_infos, dg_size, message);
+            .send_message_to_initial_targets(conn_infos, dg_size, message, log_ident);
     }
 
     fn send_message_to_client(&mut self, peer_addr: SocketAddr, msg: Bytes, token: Token) {

--- a/src/states/elder/mod.rs
+++ b/src/states/elder/mod.rs
@@ -1259,7 +1259,7 @@ impl Elder {
                 attempts: 1,
             });
 
-            debug!("{} - Lost peer (member of our section): {}", self, node);
+            debug!("{} - Lost peer {}", self, node);
         } else {
             // We already know this peer is lost.
             return;
@@ -1269,8 +1269,13 @@ impl Elder {
     }
 
     fn remove_lost_peer(&mut self, pub_id: &PublicId) {
-        if self.lost_peers.remove(pub_id).is_some() {
-            trace!("{} - Peer no longer lost: {}", self, pub_id)
+        if let Some(info) = self.lost_peers.remove(pub_id) {
+            trace!(
+                "{} - Lost peer {} at {} found",
+                self,
+                pub_id,
+                info.conn_info.peer_addr
+            )
         }
     }
 
@@ -1288,9 +1293,10 @@ impl Elder {
         };
 
         trace!(
-            "{} - Lost peer {} ping failed. Remaining attempts: {}",
+            "{} - Lost peer {} at {} ping failed. Remaining attempts: {}",
             log_ident,
             pub_id,
+            info.conn_info.peer_addr,
             LOST_PEER_ATTEMPTS - info.attempts,
         );
 
@@ -1422,10 +1428,7 @@ impl Base for Elder {
         if let Some(node) = node {
             self.add_lost_peer(node);
         } else {
-            debug!(
-                "{} - Lost peer (not member of our section): {}",
-                self, peer_addr
-            );
+            debug!("{} - Lost peer (not our member) {}", self, peer_addr);
         };
 
         Transition::Stay

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -313,7 +313,9 @@ impl Base for JoiningPeer {
             | Variant::JoinRequest(_)
             | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
-            | Variant::ParsecResponse(..) => false,
+            | Variant::ParsecResponse(..)
+            | Variant::PingRequest
+            | Variant::PingResponse => false,
         }
     }
 

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -22,7 +22,11 @@ pub use self::{
 };
 
 #[cfg(feature = "mock_base")]
-pub use self::{bootstrapping_peer::BOOTSTRAP_TIMEOUT, joining_peer::JOIN_TIMEOUT};
+pub use self::{
+    bootstrapping_peer::BOOTSTRAP_TIMEOUT,
+    elder::{LOST_PEER_ATTEMPTS, LOST_PEER_BASE_TIMEOUT},
+    joining_peer::JOIN_TIMEOUT,
+};
 
 // # The state machine
 //


### PR DESCRIPTION
This PR improves the handling of peers that go offline. Instead of immediately voting them off the section, we give them chance to come back. This is to allow for temporary network connectivity issues, node restarts, and so on.

- When the peer gets disconnected or when messages sent to them fail more than allowed number of times, we consider them as "lost"
- When peer is "lost", we keep sending them "pings" and wait for the response. If we receive the response within a timeout we consider the peer as online again
- When the timeout expires and we have not received a response, we send the ping again and double the timeout
- We repeat this process a couple of times
- If we don't receive any response even after all the attempts are exhausted, we consider the peer as "gone" and vote it to be removed from the section.
- When that vote accumulates (that is, more than 2/3 of elders consider the peer "gone"), it is removed from the section

Closes #2037 

Draft, because some tests are failing. 