### PR TITLE
pull quic-p2p with separate channel for client and node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ lazy_static = { version = "~1", optional = true }
 log = "~0.3.8"
 lru_time_cache = "~0.8.1"
 maidsafe_utilities = "~0.18.0"
-mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "f1991746a8", optional = true }
+mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "b50a029", optional = true }
 num-bigint = "~0.1.40"
 parsec = { git = "https://github.com/maidsafe/parsec", rev = "0f9b1226" }
 # quic-p2p = "~0.2.0"
-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "f1991746a8" }
+quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "b50a029" }
 # rand in the versions used for compatibility
 rand = "0.7.2"
 rand_crypto = { package = "rand", version = "~0.6.5" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub use self::{
     node::{Builder, Node},
     pause::PausedState,
     quic_p2p::Config as NetworkConfig,
+    quic_p2p::Event as NetworkEvent,
     xor_space::{Prefix, XorName, XOR_NAME_LEN},
 };
 /// Routing events.
@@ -175,7 +176,6 @@ const SAFE_SECTION_SIZE: usize = 100;
 /// Number of elders per section.
 const ELDER_SIZE: usize = 7;
 
-use self::quic_p2p::Event as NetworkEvent;
 #[cfg(any(test, feature = "mock_base"))]
 use unwrap::unwrap;
 

--- a/src/network_service/mod.rs
+++ b/src/network_service/mod.rs
@@ -9,12 +9,11 @@
 mod sending_targets_cache;
 
 use crate::{
-    quic_p2p::{Builder, Peer, QuicP2p, QuicP2pError, Token},
+    quic_p2p::{Builder, EventSenders, Peer, QuicP2p, QuicP2pError, Token},
     utils::LogIdent,
-    NetworkConfig, NetworkEvent,
+    NetworkConfig,
 };
 use bytes::Bytes;
-use crossbeam_channel::Sender;
 use std::net::SocketAddr;
 
 use sending_targets_cache::SendingTargetsCache;
@@ -88,7 +87,7 @@ pub struct NetworkBuilder {
 }
 
 impl NetworkBuilder {
-    pub fn new(event_tx: Sender<NetworkEvent>) -> Self {
+    pub fn new(event_tx: EventSenders) -> Self {
         Self {
             quic_p2p: Builder::new(event_tx),
         }

--- a/src/states/elder/tests.rs
+++ b/src/states/elder/tests.rs
@@ -544,7 +544,11 @@ struct JoiningPeer {
 
 impl JoiningPeer {
     fn new(rng: &mut MainRng) -> Self {
-        let (network_event_tx, network_event_rx) = crossbeam_channel::unbounded();
+        let (network_event_tx, network_event_rx) = {
+            let (node_tx, node_rx) = crossbeam_channel::unbounded();
+            let (client_tx, _) = crossbeam_channel::unbounded();
+            (quic_p2p::EventSenders { node_tx, client_tx }, node_rx)
+        };
         let network_service = unwrap!(quic_p2p::Builder::new(network_event_tx).build());
 
         Self {

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -389,7 +389,6 @@ pub fn create_connected_nodes(env: &Environment, size: usize) -> Nodes {
             match event {
                 Event::SectionSplit(..)
                 | Event::RestartRequired
-                | Event::Client(..)
                 | Event::Connected(Connected::Relocate) => (),
                 event => panic!("Got unexpected event: {:?}", event),
             }
@@ -455,7 +454,7 @@ pub fn add_connected_nodes_until_split(
     );
 
     clear_all_event_queues(nodes, |node, event| match event {
-        Event::Client(..) | Event::SectionSplit(..) | Event::Connected(Connected::Relocate) => (),
+        Event::SectionSplit(..) | Event::Connected(Connected::Relocate) => (),
         event => panic!("Got unexpected event for {}: {:?}", node.inner, event),
     });
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -191,7 +191,7 @@ impl<'a> TestNodeBuilder<'a> {
     }
 
     pub fn create(self) -> TestNode {
-        let (inner, user_event_rx) = self
+        let (inner, user_event_rx, _client_rx) = self
             .inner
             .network_cfg(self.env.network_cfg())
             .rng(&mut self.env.new_rng())


### PR DESCRIPTION
Depends on https://github.com/maidsafe/quic-p2p/pull/95

Closes https://github.com/maidsafe/routing/issues/2039

This allow to provide user, safe_vault with a receiver for quic_p2p
client events directly.
This will avoid having routing mediating between quic-p2p and vaults for
client events.
