### PR TITLE
Update quic-p2p dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ lazy_static = { version = "~1", optional = true }
 log = "~0.3.8"
 lru_time_cache = "~0.8.1"
 maidsafe_utilities = "~0.18.0"
-mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "b50a029", optional = true }
+mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "52f8ae2", optional = true }
 num-bigint = "~0.1.40"
 parsec = { git = "https://github.com/maidsafe/parsec", rev = "0f9b1226" }
 # quic-p2p = "~0.2.0"
-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "b50a029" }
+quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "52f8ae2" }
 # rand in the versions used for compatibility
 rand = "0.7.2"
 rand_crypto = { package = "rand", version = "~0.6.5" }


### PR DESCRIPTION
Fix the failure occurring in the multi-threaded tokio runtime