### PR TITLE
Improve log identifier

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -19,7 +19,6 @@ use crate::{
     location::{DstLocation, SrcLocation},
     parsec::{DkgResult, DkgResultWrapper},
     relocation::{self, RelocateDetails},
-    utils::LogIdent,
     xor_space::Xorable,
     Prefix, XorName,
 };
@@ -161,7 +160,7 @@ impl Chain {
 
         // On split membership may need to be checked again.
         self.members_changed = true;
-        self.state.update(new_state, &LogIdent::new(self));
+        self.state.update(new_state);
 
         Ok(())
     }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -28,7 +28,7 @@ use serde::Serialize;
 use std::{
     cmp::Ordering,
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Debug, Formatter},
     iter, mem,
     net::SocketAddr,
 };
@@ -177,7 +177,7 @@ impl Chain {
                 .insert(*first.name(), dkg_result.0.clone())
                 .is_some()
             {
-                log_or_panic!(log::Level::Error, "{} - Ejected previous DKG result", self);
+                log_or_panic!(log::Level::Error, "Ejected previous DKG result");
             }
         }
 
@@ -225,8 +225,7 @@ impl Chain {
                 // TODO: If detecting duplicate vote from peer, penalise.
                 log_or_panic!(
                     log::Level::Warn,
-                    "{} Duplicate proof for {:?} in chain accumulator. {:?}",
-                    self,
+                    "Duplicate proof for {:?} in chain accumulator. {:?}",
                     event,
                     self.chain_accumulator.incomplete_events().collect_vec()
                 );
@@ -335,8 +334,7 @@ impl Chain {
         if self.can_poll_churn() {
             if let Some(event) = self.state.churn_event_backlog.pop_back() {
                 trace!(
-                    "{} churn backlog poll {:?}, Others: {:?}",
-                    self,
+                    "churn backlog poll {:?}, Others: {:?}",
                     event,
                     self.state.churn_event_backlog
                 );
@@ -358,8 +356,7 @@ impl Chain {
 
         if start_churn_event && !self.can_poll_churn() {
             trace!(
-                "{} churn backlog {:?}, Other: {:?}",
-                self,
+                "churn backlog {:?}, Other: {:?}",
                 event,
                 self.state.churn_event_backlog
             );
@@ -388,8 +385,7 @@ impl Chain {
             // Temporarily ignore until we either find a better way of preventing churn spam,
             // or we change the tests to provide some Adult churn at all times.
             trace!(
-                "{} FIXME: should do nothing for infants and unknown nodes {:?}",
-                self,
+                "FIXME: should do nothing for infants and unknown nodes {:?}",
                 trigger_node
             );
         }
@@ -435,7 +431,7 @@ impl Chain {
         trace!("increment_age_counters: {:?}", self.state.our_members);
 
         for details in details_to_add {
-            trace!("{} - Change state to Relocating {}", self, details.pub_id);
+            trace!("Change state to Relocating {}", details.pub_id);
 
             let destination_key_info = self
                 .latest_compatible_their_key_info(&details.destination)
@@ -463,11 +459,7 @@ impl Chain {
                 if self.is_peer_our_member(&details.pub_id) {
                     break details;
                 } else {
-                    trace!(
-                        "{} - Not relocating {} - not a member",
-                        self,
-                        details.pub_id
-                    );
+                    trace!("Not relocating {} - not a member", details.pub_id);
                 }
             } else {
                 return None;
@@ -476,8 +468,8 @@ impl Chain {
 
         if self.is_peer_our_elder(&details.pub_id) {
             warn!(
-                "{} - Not relocating {} - The peer is still our elder.",
-                self, details.pub_id,
+                "Not relocating {} - The peer is still our elder.",
+                details.pub_id,
             );
 
             // Keep the details in the queue so when the node is demoted we can relocate it.
@@ -485,7 +477,7 @@ impl Chain {
             return None;
         }
 
-        trace!("{} - relocating member {}", self, details.pub_id);
+        trace!("relocating member {}", details.pub_id);
         self.relocation_in_progress = true;
 
         Some(details)
@@ -525,8 +517,7 @@ impl Chain {
                     // Node already joined - this should not happen.
                     log_or_panic!(
                         log::Level::Error,
-                        "{} - Adding member that already exists: {}",
-                        self,
+                        "Adding member that already exists: {}",
                         p2p_node,
                     );
                 }
@@ -559,8 +550,7 @@ impl Chain {
         } else {
             log_or_panic!(
                 log::Level::Error,
-                "{} - Removing member that doesn't exist: {}",
-                self,
+                "Removing member that doesn't exist: {}",
                 pub_id
             );
 
@@ -651,8 +641,8 @@ impl Chain {
         self.check_and_clean_neighbour_infos(None);
         self.split_in_progress = false;
 
-        info!("{} - finalise_prefix_change: {:?}", self, self.our_prefix());
-        trace!("{} - finalise_prefix_change state: {:?}", self, self.state);
+        info!("finalise_prefix_change: {:?}", self.our_prefix());
+        trace!("finalise_prefix_change state: {:?}", self.state);
 
         self.prepare_parsec_reset(parsec_version)
     }
@@ -1164,8 +1154,7 @@ impl Chain {
             if old_elders_info.version() > new_elders_info_version {
                 log_or_panic!(
                     log::Level::Error,
-                    "{} Ejected newer neighbour info {:?}",
-                    self,
+                    "Ejected newer neighbour info {:?}",
                     old_elders_info
                 );
             }
@@ -1211,8 +1200,7 @@ impl Chain {
             .map_err(|err| {
                 log_or_panic!(
                     log::Level::Error,
-                    "{} Failed to serialise accumulated event: {:?} for {:?}",
-                    self,
+                    "Failed to serialise accumulated event: {:?} for {:?}",
                     err,
                     signed_payload
                 );
@@ -1229,8 +1217,7 @@ impl Chain {
             .or_else(|| {
                 log_or_panic!(
                     log::Level::Error,
-                    "{} Failed to combine signatures for accumulated event: {:?}",
-                    self,
+                    "Failed to combine signatures for accumulated event: {:?}",
                     signed_payload
                 );
                 None
@@ -1240,9 +1227,8 @@ impl Chain {
     /// Inserts the `version` of our own section into `their_knowledge` for `pfx`.
     pub fn update_their_knowledge(&mut self, prefix: Prefix<XorName>, version: u64) {
         trace!(
-            "{:?} attempts to update their_knowledge of our elders_info with version {:?} for \
+            "attempts to update their_knowledge of our elders_info with version {:?} for \
              prefix {:?} ",
-            self.our_id(),
             version,
             prefix
         );
@@ -1586,8 +1572,7 @@ impl Chain {
         if self.split_in_progress {
             log_or_panic!(
                 log::Level::Warn,
-                "{} - attempt to {} during prefix change.",
-                self,
+                "attempt to {} during prefix change.",
                 label,
             );
         }
@@ -1624,12 +1609,6 @@ impl Debug for Chain {
         }
 
         writeln!(formatter, "}}")
-    }
-}
-
-impl Display for Chain {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Node({}({:b}))", self.our_id(), self.state.our_prefix())
     }
 }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -11,8 +11,8 @@ use super::{
     MIN_AGE_COUNTER,
 };
 use crate::{
-    error::RoutingError, id::PublicId, location::DstLocation, relocation::RelocateDetails,
-    utils::LogIdent, Prefix, XorName,
+    error::RoutingError, id::PublicId, location::DstLocation, relocation::RelocateDetails, Prefix,
+    XorName,
 };
 use bincode::serialize;
 use itertools::Itertools;
@@ -96,12 +96,11 @@ impl SharedState {
         }
     }
 
-    pub fn update(&mut self, new: Option<Self>, log_ident: &LogIdent) {
+    pub fn update(&mut self, new: Option<Self>) {
         if self.handled_genesis_event {
             log_or_panic!(
                 log::Level::Error,
-                "{} - shared state update - genesis event already handled",
-                log_ident
+                "shared state update - genesis event already handled",
             );
         }
 
@@ -109,8 +108,7 @@ impl SharedState {
             if self.our_infos.len() > 1 && *self != new {
                 log_or_panic!(
                     log::Level::Error,
-                    "{} - shared state update - mismatch: old: {:?} --- new: {:?}",
-                    log_ident,
+                    "shared state update - mismatch: old: {:?} --- new: {:?}",
                     self,
                     new
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,11 +66,11 @@
 )]
 
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde_derive;
 
 // Needs to be before all other modules to make the macros available to them.
+#[macro_use]
+mod log_utils;
 #[macro_use]
 mod macros;
 

--- a/src/log_utils.rs
+++ b/src/log_utils.rs
@@ -1,0 +1,169 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Logging with log identifier
+//!
+//! This module implement logging macros that automatically prefix each output with a custom log
+//! identifier. To log identifier is scoped to the current thread.
+//!
+//! # Example
+//!
+//! ```ignore
+//! // No ident set so this outputs just "foo"
+//! trace!("foo");
+//!
+//! // Set the ident
+//! let guard = log_utils::set_ident(|buffer| {
+//!     use std::fmt::Write;
+//!     write!(buffer, "MY IDENT: ")
+//! });
+//!
+//! // This now outputs "MY IDENT: bar"
+//! trace!("bar");
+//!
+//! // Guard goes out of scope which clears the ident.
+//! drop(guard)
+//!
+//! // This now outputs just "baz"
+//! trace!("baz")
+//! ```
+//!
+
+use std::{cell::RefCell, fmt, marker::PhantomData};
+
+thread_local! {
+    static LOG_IDENT: RefCell<String> = RefCell::new(String::new());
+}
+
+/// Set the log identifier for the current thread. Returns a RAII-style guard that automatically
+/// clears the ident on scope exit.
+pub fn set_ident<F>(f: F) -> Guard
+where
+    F: FnOnce(&mut String) -> Result<(), fmt::Error>,
+{
+    LOG_IDENT.with(|ident| {
+        let mut buffer = ident.borrow_mut();
+        buffer.clear();
+        f(&mut *buffer).expect("failed to set log ident")
+    });
+
+    Guard::new()
+}
+
+/// RAII-style guard that clear the log ident on drop.
+pub struct Guard {
+    // This makes this type not `Send` to make sure it's dropped in the same thread it was created
+    // in.
+    _not_send_sync: PhantomData<*const ()>,
+}
+
+impl Guard {
+    fn new() -> Self {
+        Self {
+            _not_send_sync: PhantomData,
+        }
+    }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        LOG_IDENT.with(|ident| ident.borrow_mut().clear())
+    }
+}
+
+// Internal function but it needs to be `pub` so it can be used in the macros.
+#[doc(hidden)]
+pub fn with_ident<F: FnOnce(&str)>(f: F) {
+    LOG_IDENT.with(|ident| f(&*ident.borrow()))
+}
+
+// NOTE: an alternative to having custom logging macros would be to override the logger format and
+// inject the ident there.
+//
+// Example with env_logger:
+//
+// ```
+// env_logger::builder()
+//     .format(|buf, record| {
+//         log_utils::with_ident(|ident| {
+//             writeln!(
+//                 buf,
+//                 "{} {} {}",
+//                 record.level(),
+//                 ident
+//                 record.args(),
+//             )
+//         })
+//     .init()
+// ```
+//
+// There are tradeoffs with either approach. For example, if we want the upper layers to
+// automatically see the log ident, we should use macros. On the other hand, if we want to inject
+// the log ident also to the log output of the lower layers, we should use custom logger format.
+//
+// We are currently opting for the macro approach as it seems useful for the upper layers to see
+// the log idents without any additional configuration. This approach might be revisited in the
+// future if needed.
+
+/// Log a message at the given level prefixed with the current log ident.
+#[macro_export]
+macro_rules! log {
+    // Log with explicit target.
+    (target: $target:expr, $level:expr, $($arg:tt)+) => {
+        if log::log_enabled!($level) {
+            $crate::log_utils::with_ident(|ident| {
+                log::log!(target: $target, $level, "{}{}", ident, format_args!($($arg)+));
+            })
+        }
+    };
+
+    // Log using the current module path as the target.
+    ($level:expr, $($arg:tt)+) => {
+        log!(target: module_path!(), $level, $($arg)+)
+    };
+}
+
+/// Log a message at the error level prefixed with the current log ident.
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)+) => {
+        log!(log::Level::Error, $($arg)+)
+    }
+}
+
+/// Log a message at the warn level prefixed with the current log ident.
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)+) => {
+        log!(log::Level::Warn, $($arg)+)
+    }
+}
+
+/// Log a message at the info level prefixed with the current log ident.
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)+) => {
+        log!(log::Level::Info, $($arg)+)
+    }
+}
+
+/// Log a message at the debug level prefixed with the current log ident.
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)+) => {
+        log!(log::Level::Debug, $($arg)+)
+    }
+}
+
+/// Log a message at the trace level prefixed with the current log ident.
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)+) => {
+        log!(log::Level::Trace, $($arg)+)
+    }
+}

--- a/src/messages/with_bytes.rs
+++ b/src/messages/with_bytes.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{DstLocation, Message, MessageHash, PartialMessage};
-use crate::{error::Result, utils::LogIdent};
+use crate::error::Result;
 use bytes::Bytes;
 use std::fmt::{self, Debug, Formatter};
 
@@ -26,12 +26,12 @@ pub struct MessageWithBytes {
 
 impl MessageWithBytes {
     /// Serialize message and keep both SignedRoutingMessage and Bytes.
-    pub fn new(full_content: Message, log_ident: &LogIdent) -> Result<Self> {
+    pub fn new(full_content: Message) -> Result<Self> {
         let full_bytes = full_content.to_bytes()?;
         let partial_content = full_content.to_partial();
         let result = Self::new_from_parts(Some(full_content), partial_content, full_bytes);
 
-        trace!("{} Creating {:?}", log_ident, result);
+        trace!("Creating {:?}", result);
 
         Ok(result)
     }
@@ -109,7 +109,7 @@ mod tests {
         let variant = Variant::UserMessage(rng.sample_iter(Standard).take(6).collect());
         let msg = unwrap!(Message::single_src(&full_id, dst, variant));
 
-        let msg_with_bytes = unwrap!(MessageWithBytes::new(msg.clone(), &LogIdent::new("node")));
+        let msg_with_bytes = unwrap!(MessageWithBytes::new(msg.clone()));
         let bytes = msg_with_bytes.full_bytes();
 
         let full_msg = unwrap!(Message::from_bytes(bytes));

--- a/src/node.rs
+++ b/src/node.rs
@@ -33,10 +33,7 @@ use {
         chain::{Chain, SectionProofSlice},
         Prefix,
     },
-    std::{
-        collections::{BTreeMap, BTreeSet},
-        fmt::{self, Display, Formatter},
-    },
+    std::collections::{BTreeMap, BTreeSet},
 };
 
 /// A builder to configure and create a new `Node`.
@@ -367,6 +364,11 @@ impl Node {
         }
     }
 
+    /// The name of this node.
+    pub fn name(&self) -> XorName {
+        *self.id().expect("invalid node state").name()
+    }
+
     /// Our `Prefix` once we are a part of the section.
     pub fn our_prefix(&self) -> Option<&Prefix<XorName>> {
         self.chain().map(Chain::our_prefix)
@@ -488,12 +490,5 @@ impl Node {
     pub fn member_age_counter(&self, name: &XorName) -> Option<u32> {
         self.chain()
             .and_then(|chain| chain.member_age_counter(name))
-    }
-}
-
-#[cfg(feature = "mock_base")]
-impl Display for Node {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        self.machine.fmt(formatter)
     }
 }

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use crossbeam_channel as mpmc;
 use std::{
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Debug, Formatter},
     mem,
     net::SocketAddr,
 };
@@ -147,35 +147,11 @@ impl State {
         E: Debug,
     {
         let old_state = mem::replace(self, Self::Terminated);
-        let old_state_log_ident = format!("{}", old_state);
 
         match f(old_state) {
             Ok(new_state) => *self = new_state,
-            Err(error) => error!(
-                "{} - Failed state transition: {:?}",
-                old_state_log_ident, error
-            ),
+            Err(error) => error!("Failed state transition: {:?}", error),
         }
-    }
-}
-
-impl Display for State {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        state_dispatch!(
-            *self,
-            ref state => write!(formatter, "{}", state),
-            Terminated => write!(formatter, "Terminated")
-        )
-    }
-}
-
-impl Debug for State {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        state_dispatch!(
-            *self,
-            ref state => write!(formatter, "State::{}", state),
-            Terminated => write!(formatter, "State::Terminated")
-        )
     }
 }
 
@@ -316,7 +292,7 @@ impl StateMachine {
     }
 
     pub fn pause(self) -> Result<PausedState, RoutingError> {
-        info!("{} - Pause", self.current());
+        info!("Pause");
 
         let mut paused_state = match self.state {
             State::ApprovedPeer(state) => state.pause(),
@@ -343,7 +319,7 @@ impl StateMachine {
             is_running: true,
         };
 
-        info!("{} - Resume", machine.current());
+        info!("Resume");
 
         (action_tx, machine)
     }
@@ -378,7 +354,7 @@ impl StateMachine {
     }
 
     fn terminate(&mut self) {
-        debug!("{} Terminating state machine", self);
+        debug!("Terminating state machine");
         self.is_running = false;
     }
 
@@ -443,12 +419,6 @@ impl StateMachine {
     /// Get mutable reference to the current state.
     pub fn current_mut(&mut self) -> &mut State {
         &mut self.state
-    }
-}
-
-impl Display for StateMachine {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{}", self.state)
     }
 }
 

--- a/src/states/approved_peer/mod.rs
+++ b/src/states/approved_peer/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     event::{Connected, Event},
     id::{FullId, P2pNode, PublicId},
     location::{DstLocation, SrcLocation},
+    log_utils,
     message_filter::MessageFilter,
     messages::{
         AccumulatingMessage, BootstrapResponse, JoinRequest, MemberKnowledge, Message, MessageHash,
@@ -1885,7 +1886,7 @@ impl ApprovedPeer {
 
     fn print_rt_size(&self) {
         const TABLE_LVL: log::Level = log::Level::Info;
-        if log_enabled!(TABLE_LVL) {
+        if log::log_enabled!(TABLE_LVL) {
             let status_str = format!(
                 "{} - Routing Table size: {:3}",
                 self,
@@ -2020,6 +2021,11 @@ impl Base for ApprovedPeer {
 
     fn rng(&mut self) -> &mut MainRng {
         &mut self.rng
+    }
+
+    fn set_log_ident(&self) -> log_utils::Guard {
+        use std::fmt::Write;
+        log_utils::set_ident(|buffer| write!(buffer, "{} ", self))
     }
 
     fn handle_send_message(

--- a/src/states/approved_peer/tests/adult.rs
+++ b/src/states/approved_peer/tests/adult.rs
@@ -90,7 +90,7 @@ impl Env {
     }
 
     fn handle_message(&mut self, msg: Message) -> Result<()> {
-        let msg = MessageWithBytes::new(msg, &self.subject.log_ident()).unwrap();
+        let msg = MessageWithBytes::new(msg).unwrap();
         let _ = self.subject.try_handle_message(None, msg, &mut ())?;
         let _ = self.subject.handle_messages(&mut ());
         Ok(())

--- a/src/states/common/base.rs
+++ b/src/states/common/base.rs
@@ -12,6 +12,7 @@ use crate::{
     error::{Result, RoutingError},
     id::{FullId, PublicId},
     location::{DstLocation, SrcLocation},
+    log_utils,
     messages::{Message, MessageWithBytes, Variant},
     network_service::{NetworkService, Resend},
     outbox::EventBox,
@@ -46,6 +47,8 @@ pub trait Base: Display {
         LogIdent::new(self)
     }
 
+    fn set_log_ident(&self) -> log_utils::Guard;
+
     fn handle_peer_lost(
         &mut self,
         _peer_addr: SocketAddr,
@@ -70,6 +73,8 @@ pub trait Base: Display {
     fn unhandled_message(&mut self, sender: Option<SocketAddr>, msg: Message, msg_bytes: Bytes);
 
     fn handle_action(&mut self, action: Action, outbox: &mut dyn EventBox) -> Transition {
+        let _log_ident = self.set_log_ident();
+
         match action {
             Action::SendMessage {
                 src,
@@ -139,6 +144,8 @@ pub trait Base: Display {
         outbox: &mut dyn EventBox,
     ) -> Transition {
         use crate::NetworkEvent::*;
+
+        let _log_ident = self.set_log_ident();
 
         let transition = match event {
             BootstrappedTo { node } => self.handle_bootstrapped_to(node),

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -16,6 +16,7 @@ use crate::{
     event::{Connected, Event},
     id::{FullId, P2pNode},
     location::{DstLocation, SrcLocation},
+    log_utils,
     message_filter::MessageFilter,
     messages::{
         BootstrapResponse, JoinRequest, Message, MessageHash, MessageWithBytes, Variant,
@@ -384,6 +385,11 @@ impl Base for JoiningPeer {
 
     fn rng(&mut self) -> &mut MainRng {
         &mut self.rng
+    }
+
+    fn set_log_ident(&self) -> log_utils::Guard {
+        use std::fmt::Write;
+        log_utils::set_ident(|buffer| write!(buffer, "{} ", self))
     }
 
     fn handle_send_message(

--- a/src/states/joining_peer.rs
+++ b/src/states/joining_peer.rs
@@ -150,21 +150,20 @@ impl JoiningPeer {
         response: BootstrapResponse,
     ) -> Result<()> {
         let name = *self.name();
-        let log_ident = self.log_ident();
 
         match &mut self.stage {
             Stage::Bootstrapping(_) => match response {
                 BootstrapResponse::Join(elders_info) => {
                     info!(
-                        "{} - Joining a section {:?} (given by {:?})",
-                        self, elders_info, sender
+                        "Joining a section {:?} (given by {:?})",
+                        elders_info, sender
                     );
                     self.join_section(elders_info)
                 }
                 BootstrapResponse::Rebootstrap(new_conn_infos) => {
                     info!(
-                        "{} - Bootstrapping redirected to another set of peers: {:?}",
-                        self, new_conn_infos
+                        "Bootstrapping redirected to another set of peers: {:?}",
+                        new_conn_infos
                     );
                     self.reconnect_to_new_section(new_conn_infos);
                     Ok(())
@@ -175,16 +174,15 @@ impl JoiningPeer {
                     if new_elders_info.version() > stage.elders_info.version() {
                         if new_elders_info.prefix().matches(&name) {
                             info!(
-                                "{} - Newer Join response for our prefix {:?} from {:?}",
-                                log_ident, new_elders_info, sender
+                                "Newer Join response for our prefix {:?} from {:?}",
+                                new_elders_info, sender
                             );
                             stage.elders_info = new_elders_info;
                             self.send_join_requests();
                         } else {
                             log_or_panic!(
                                 log::Level::Error,
-                                "{} - Newer Join response not for our prefix {:?} from {:?}",
-                                self,
+                                "Newer Join response not for our prefix {:?} from {:?}",
                                 new_elders_info,
                                 sender,
                             );
@@ -405,15 +403,10 @@ impl Base for JoiningPeer {
     }
 
     fn handle_timeout(&mut self, token: u64, _: &mut dyn EventBox) -> Transition {
-        let log_ident = self.log_ident();
-
         match &mut self.stage {
             Stage::Bootstrapping(stage) => {
                 if let Some(peer_addr) = stage.timeout_tokens.remove(&token) {
-                    debug!(
-                        "{} - Timeout when trying to bootstrap against {}.",
-                        log_ident, peer_addr
-                    );
+                    debug!("Timeout when trying to bootstrap against {}.", peer_addr);
 
                     if !stage.pending_requests.remove(&peer_addr) {
                         return Transition::Stay;
@@ -434,7 +427,7 @@ impl Base for JoiningPeer {
                 };
 
                 if join_token == token {
-                    debug!("{} - Timeout when trying to join a section.", log_ident);
+                    debug!("Timeout when trying to join a section.");
 
                     for addr in stage
                         .elders_info

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,22 +38,6 @@ impl Display for DisplayDurObj {
     }
 }
 
-/// Identified or node/client for logging purposes.
-#[derive(Clone)]
-pub struct LogIdent(String);
-
-impl LogIdent {
-    pub fn new<T: Display + ?Sized>(node: &T) -> Self {
-        Self(format!("{}", node))
-    }
-}
-
-impl Display for LogIdent {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{}", self.0)
-    }
-}
-
 // Test utils
 
 /// If the iterator yields exactly one element, returns it. Otherwise panics.

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -118,9 +118,9 @@ fn remove_unresponsive_node() {
         .iter()
         .map(|n| &n.inner)
         .filter(|n| n.elders().any(|id| *id.name() == non_responsive_name))
-        .map(|n| format!("{}", n))
+        .map(|n| n.name())
         .collect_vec();
-    assert_eq!(still_has_unresponsibe_elder, Vec::<String>::new());
+    assert_eq!(still_has_unresponsibe_elder, Vec::<XorName>::new());
 }
 
 // Parameters for the churn tests.
@@ -685,9 +685,12 @@ impl Expectations {
                     } else {
                         let expected_dst = DstLocation::Node(orig_name);
                         assert_eq!(
-                            expected_dst, dst,
+                            expected_dst,
+                            dst,
                             "Receiver does not match destination {}: {:?}, {:?}",
-                            node.inner, expected_dst, dst,
+                            node.name(),
+                            expected_dst,
+                            dst,
                         );
                         assert!(
                             self.messages.remove(&key),
@@ -708,7 +711,7 @@ impl Expectations {
                     assert!(
                         !node.inner.is_elder(),
                         "{} failed to receive message {:?}",
-                        node.inner,
+                        node.name(),
                         key
                     );
                 }

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -52,7 +52,7 @@ fn send() {
                     }
                 }
                 Some(_) => (),
-                _ => panic!("{} - Event::MessageReceived not received", node.inner),
+                _ => panic!("{} - Event::MessageReceived not received", node.name()),
             }
         }
     }

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -489,6 +489,7 @@ fn check_close_names_for_elder_size_nodes() {
         }),
         LOWERED_ELDER_SIZE,
     );
+
     let close_sections_complete = nodes
         .iter()
         .all(|n| nodes.iter().all(|m| m.close_names().contains(&n.name())));

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -58,7 +58,7 @@ fn relocate_without_split() {
     assert!(
         target_prefix.matches(&nodes[0].name()),
         "Verify the Node {}, got relocated to prefix {:?}",
-        nodes[0].inner,
+        nodes[0].name(),
         target_prefix
     );
 }
@@ -105,7 +105,7 @@ fn relocate_causing_split() {
     assert!(
         target_prefix.matches(&nodes[0].name()),
         "Verify the Node {}, got relocated to prefix {:?}",
-        nodes[0].inner,
+        nodes[0].name(),
         target_prefix
     );
 


### PR DESCRIPTION
Followup to #2072. Changes start at the"Implement thread-local log identifier" commit.

When running the integration tests, it's very useful to be able to tell from the log output which node each log line belongs to. To achieve this, we prefix each log line with a short identifier of the node. It looks like this:
```
Elder(2d390f..(001))
```
The way this was implemented before this PR was to have a `Display` impl in each node state which produces the identifier and then manually output `self` in every log statement:
```rust
debug!("{} - handle SectionInfo: {:?}", self, info)
``` 
This works, but has several issues:
- works only if `self` is a node state. If we need to log inside one of the other structs, we need to capture the ident before and pass it explicitly:
    ```rust
    let log_ident = format!("{}", self);
    self.parsec_map.handle_request(..., log_ident)
    ```
- interferes with the borrow checker - can only be used if `self` is not already mutably borrowed and requires ugly workarounds otherwise.
- is verbose and unergonomic

So this PR improves the situation by making the log ident implicit. It is set only once before handling any input (using `log_utils::set_ident`) and stored in a thread-local variable. Then it is automatically fetched from this variable in each log statement (using provided custom logging macros: `error!`, `info!`, `debug!`, ...). This solves all the above issues. 
