### PR TITLE
Treat infants differently from adults

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -524,6 +524,7 @@ impl Chain {
             }
             Entry::Vacant(entry) => {
                 // Node joining for the first time.
+
                 let _ = entry.insert(MemberInfo::new(
                     age,
                     p2p_node.clone(),

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -421,6 +421,7 @@ impl Chain {
             details_to_add.push(PartialRelocateDetails {
                 pub_id: *member_info.p2p_node.public_id(),
                 destination,
+                // TODO: why the +1 ?
                 age: member_info.age() + 1,
             })
         }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -371,6 +371,8 @@ impl Chain {
         let our_section_size = self.state.our_joined_members().count();
         let safe_section_size = self.safe_section_size();
 
+        // As a measure against sybil attacks, we don't increment the age counters on infant churn
+        // once we reach safe_section_size.
         if our_section_size >= safe_section_size
             && self
                 .state
@@ -378,15 +380,11 @@ impl Chain {
                 .map(|persona| persona == MemberPersona::Infant)
                 .unwrap_or(true)
         {
-            // FIXME: skipping infants churn for ageing breaks tests for node ageing, as once a
-            // section reaches a safe size, nodes stop ageing at all, because all churn in tests
-            // is Infant churn.
-            // Temporarily ignore until we either find a better way of preventing churn spam,
-            // or we change the tests to provide some Adult churn at all times.
             trace!(
-                "FIXME: should do nothing for infants and unknown nodes {:?}",
-                trigger_node
+                "Not incrementing age counters on infant churn (section size: {})",
+                our_section_size,
             );
+            return;
         }
 
         let our_prefix = *self.state.our_prefix();

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -809,12 +809,11 @@ impl Chain {
         self.state.our_info().member_nodes()
     }
 
-    fn elders_and_adults(&self) -> impl Iterator<Item = &PublicId> {
+    /// Returns joined adults and elders from our section.
+    fn our_mature_members(&self) -> impl Iterator<Item = &PublicId> {
         self.state
             .our_joined_members()
-            // FIXME: we temporarily treat all section
-            // members as Adults
-            //.filter(|(_, info)| info.is_mature())
+            .filter(|(_, info)| info.is_mature())
             .map(|(_, info)| info.p2p_node.public_id())
     }
 
@@ -1294,7 +1293,7 @@ impl Chain {
         let our_name = self.our_id.name();
         let our_prefix_bit_count = self.our_prefix().bit_count();
         let (our_new_size, sibling_new_size) = self
-            .elders_and_adults()
+            .our_mature_members()
             .map(|id| our_name.common_prefix(id.name()) > our_prefix_bit_count)
             .fold((0, 0), |(ours, siblings), is_our_prefix| {
                 if is_our_prefix {

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -54,15 +54,18 @@ pub struct MemberInfo {
     pub age_counter: AgeCounter,
     pub state: MemberState,
     pub p2p_node: P2pNode,
+    // Section version at the time this node joined.
+    pub section_version: u64,
 }
 
 impl MemberInfo {
     /// Create new `MemberInfo` in the `Joined` state.
-    pub fn new(age: u8, p2p_node: P2pNode) -> Self {
+    pub fn new(age: u8, p2p_node: P2pNode, section_version: u64) -> Self {
         Self {
             age_counter: AgeCounter::from_age(age),
             state: MemberState::Joined,
             p2p_node,
+            section_version,
         }
     }
 

--- a/src/chain/shared_state.rs
+++ b/src/chain/shared_state.rs
@@ -38,6 +38,9 @@ pub struct SharedState {
     pub our_infos: NonEmptyList<EldersInfo>,
     /// Info about all members of our section - elders, adults and infants.
     pub our_members: BTreeMap<XorName, MemberInfo>,
+    /// Number that gets incremented every time a node joins or leaves our section - that is, every
+    /// time `our_members` changes.
+    pub section_version: u64,
     /// Maps our neighbours' prefixes to their latest signed elders infos.
     /// Note that after a split, the neighbour's latest section info could be the one from the
     /// pre-split parent section, so the value's prefix doesn't always match the key.
@@ -74,6 +77,7 @@ impl SharedState {
                     age_counter: *ages.get(p2p_node.public_id()).unwrap_or(&MIN_AGE_COUNTER),
                     state: MemberState::Joined,
                     p2p_node: p2p_node.clone(),
+                    section_version: 0,
                 };
                 (*p2p_node.name(), info)
             })
@@ -84,6 +88,7 @@ impl SharedState {
             our_infos: NonEmptyList::new(elders_info),
             neighbour_infos: Default::default(),
             our_members,
+            section_version: 0,
             our_history,
             their_keys,
             their_knowledge: Default::default(),
@@ -309,6 +314,10 @@ impl SharedState {
         } else {
             index
         }
+    }
+
+    pub fn increment_section_version(&mut self) {
+        self.section_version = self.section_version.wrapping_add(1);
     }
 }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1036,10 +1036,11 @@ impl Node {
         self.chain().map(|chain| chain.prove(target, None))
     }
 
-    /// Returns the age counter of the given node if it is member of the same section as this node,
-    /// `None` otherwise.
+    /// If this node is elder and `name` belongs to a member of our section, returns the age
+    /// counter of that member. Otherwise returns `None`.
     pub fn member_age_counter(&self, name: &XorName) -> Option<u32> {
         self.chain()
+            .filter(|chain| chain.is_self_elder())
             .and_then(|chain| chain.member_age_counter(name))
     }
 

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -625,7 +625,8 @@ impl Approved {
         if bounce {
             if let Some(sender) = sender {
                 debug!(
-                    "Unhandled message - bouncing: {:?}, hash: {:?}",
+                    "Unhandled message from {} - bouncing: {:?}, hash: {:?}",
+                    sender,
                     msg,
                     MessageHash::from_bytes(&msg_bytes)
                 );

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -243,6 +243,7 @@ impl Approved {
     pub fn should_handle_message(&self, msg: &Message) -> bool {
         match &msg.variant {
             Variant::BootstrapRequest(_)
+            | Variant::MemberKnowledge(_)
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
             | Variant::Bounce { .. } => true,
@@ -250,8 +251,7 @@ impl Approved {
             Variant::NeighbourInfo(_)
             | Variant::UserMessage(_)
             | Variant::AckMessage { .. }
-            | Variant::JoinRequest(_)
-            | Variant::MemberKnowledge(_) => self.chain.is_self_elder(),
+            | Variant::JoinRequest(_) => self.chain.is_self_elder(),
 
             Variant::GenesisUpdate(info) => {
                 !self.chain.is_self_elder() && self.is_genesis_update_new(info)

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -40,7 +40,7 @@ fn messages_accumulate_with_quorum() {
         .next()
         .unwrap();
 
-    let dst = DstLocation::Node(nodes[closest_elder_index].name()); // The closest node.
+    let dst = DstLocation::Node(*nodes[closest_elder_index].name()); // The closest node.
     let content = gen_bytes(&mut rng, 8);
 
     // The BLS scheme will require more than `participants / 3`

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -194,7 +194,7 @@ fn churn(params: Params) {
     let mut nodes = if params.initial_prefix_lens.is_empty() {
         create_connected_nodes(&env, env.elder_size())
     } else {
-        create_connected_nodes_until_split(&env, params.initial_prefix_lens)
+        create_connected_nodes_until_split(&env, &params.initial_prefix_lens)
     };
 
     // Grow phase - adding nodes

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -25,7 +25,7 @@ fn send() {
     let mut nodes = create_connected_nodes(&env, elder_size + 1);
 
     let sender_index = gen_elder_index(&mut rng, &nodes);
-    let src = SrcLocation::Node(nodes[sender_index].id());
+    let src = SrcLocation::Node(*nodes[sender_index].id());
     let dst = DstLocation::Section(rng.gen());
     let content = gen_vec(&mut rng, 1024);
     assert!(nodes[sender_index]
@@ -73,7 +73,7 @@ fn send_and_receive() {
     let mut nodes = create_connected_nodes(&env, elder_size + 1);
 
     let sender_index = gen_elder_index(&mut rng, &nodes);
-    let src = SrcLocation::Node(nodes[sender_index].id());
+    let src = SrcLocation::Node(*nodes[sender_index].id());
     let dst = DstLocation::Section(rng.gen());
 
     let req_content = gen_vec(&mut rng, 10);

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -23,7 +23,7 @@ use routing::{
 };
 use std::collections::BTreeMap;
 
-pub const LOWERED_ELDER_SIZE: usize = 3;
+pub const LOWERED_ELDER_SIZE: usize = 4;
 
 // -----  Miscellaneous tests below  -----
 
@@ -39,7 +39,7 @@ fn test_nodes(percentage_size: usize) {
     let size = LOWERED_ELDER_SIZE * percentage_size / 100;
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        safe_section_size: LOWERED_ELDER_SIZE + 1,
     });
     let mut nodes = create_connected_nodes(&env, size);
     verify_invariant_for_all_nodes(&env, &mut nodes);
@@ -273,8 +273,8 @@ fn multiple_joining_nodes() {
 #[test]
 fn single_split() {
     let env = Environment::new(NetworkParams {
-        elder_size: 4,
-        safe_section_size: 4,
+        elder_size: LOWERED_ELDER_SIZE,
+        safe_section_size: LOWERED_ELDER_SIZE + 3,
     });
     let mut nodes = Nodes(vec![]);
     trigger_split(&env, &mut nodes, &Prefix::default());
@@ -284,7 +284,7 @@ fn single_split() {
 fn multi_split() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        safe_section_size: LOWERED_ELDER_SIZE + 1,
     });
     let mut nodes = create_connected_nodes_until_split(&env, &[2, 2, 2, 2]);
     verify_invariant_for_all_nodes(&env, &mut nodes);

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -271,6 +271,16 @@ fn multiple_joining_nodes() {
 }
 
 #[test]
+fn single_split() {
+    let env = Environment::new(NetworkParams {
+        elder_size: 4,
+        safe_section_size: 4,
+    });
+    let mut nodes = Nodes(vec![]);
+    trigger_split(&env, &mut nodes, &Prefix::default());
+}
+
+#[test]
 fn multi_split() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -286,7 +286,7 @@ fn multi_split() {
         elder_size: LOWERED_ELDER_SIZE,
         safe_section_size: LOWERED_ELDER_SIZE,
     });
-    let mut nodes = create_connected_nodes_until_split(&env, vec![2, 2, 2, 2]);
+    let mut nodes = create_connected_nodes_until_split(&env, &[2, 2, 2, 2]);
     verify_invariant_for_all_nodes(&env, &mut nodes);
 }
 
@@ -391,7 +391,7 @@ fn simultaneous_joining_nodes_two_sections() {
         elder_size: LOWERED_ELDER_SIZE,
         safe_section_size: LOWERED_ELDER_SIZE,
     });
-    let nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let nodes = create_connected_nodes_until_split(&env, &[1, 1]);
 
     let prefix_0 = Prefix::default().pushed(false);
     let prefix_1 = Prefix::default().pushed(true);
@@ -419,7 +419,7 @@ fn simultaneous_joining_nodes_two_sections_switch_section() {
         elder_size: LOWERED_ELDER_SIZE,
         safe_section_size: LOWERED_ELDER_SIZE,
     });
-    let nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let nodes = create_connected_nodes_until_split(&env, &[1, 1]);
 
     let prefix_0 = Prefix::default().pushed(false);
     let prefix_1 = Prefix::default().pushed(true);
@@ -452,7 +452,7 @@ fn simultaneous_joining_nodes_three_section_with_one_ready_to_split() {
         elder_size,
         safe_section_size,
     });
-    let mut nodes = create_connected_nodes_until_split(&env, vec![1, 2, 2]);
+    let mut nodes = create_connected_nodes_until_split(&env, &[1, 2, 2]);
 
     // The created sections
     let sections = current_sections(&nodes).collect_vec();
@@ -519,7 +519,7 @@ fn check_section_info_ack() {
 
     // Act
     //
-    let nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let nodes = create_connected_nodes_until_split(&env, &[1, 1]);
     let node_with_sibling_knowledge: Vec<_> = nodes
         .iter()
         .filter(|node| {

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -23,22 +23,16 @@ use routing::{
 };
 use std::collections::BTreeMap;
 
+// The smallest number of elders which allows to reach consensus when one of them goes offline.
 pub const LOWERED_ELDER_SIZE: usize = 4;
 
 // -----  Miscellaneous tests below  -----
-
-// fn nodes_with_candidate(nodes: &[TestNode]) -> Vec<XorName> {
-// nodes
-// .iter()
-// .filter(|node| node.inner.elder_state_unchecked().has_candidate())
-// .map(TestNode::name)
-// .collect()
-// }
 
 fn test_nodes(percentage_size: usize) {
     let size = LOWERED_ELDER_SIZE * percentage_size / 100;
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
+        // Require at least one non-elder to make things more interesting.
         safe_section_size: LOWERED_ELDER_SIZE + 1,
     });
     let mut nodes = create_connected_nodes(&env, size);
@@ -70,58 +64,6 @@ fn disconnect_on_rebootstrap() {
 
     expect_next_event!(unwrap!(nodes.last_mut()), Event::Terminated);
 }
-
-// TODO: either modify this test or remove it
-// #[test]
-// fn candidate_expiration() {
-// let env = Environment::new(LOWERED_ELDER_SIZE, LOWERED_ELDER_SIZE * 2, None);
-// let mut nodes = create_connected_nodes(&env, LOWERED_ELDER_SIZE);
-// let transport_config = TransportConfig::node().with_hard_coded_contact(nodes[0].endpoint());
-// nodes.insert(
-// 0,
-// TestNode::builder(&env)
-// .transport_config(transport_config)
-// .create(),
-// );
-//
-// Initiate connection until the candidate switch to ProvingNode:
-// info!("Candidate joining name: {}", nodes[0].name());
-// poll_and_resend_until(&mut nodes, &|nodes| nodes[0].inner.is_proving_node(), None);
-// let proving_node = nodes.remove(0);
-//
-// assert!(
-// proving_node.inner.is_proving_node(),
-// "Accepted as candidate"
-// );
-//
-// Continue without the joining node until all nodes accept the candidate:
-// info!("Candidate new name: {}", proving_node.name());
-// poll_and_resend_until(
-// &mut nodes,
-// &|nodes| {
-// nodes
-// .iter()
-// .all(|node| node.inner.elder_state_unchecked().has_candidate())
-// },
-// None,
-// );
-//
-// assert_eq!(
-// nodes.iter().map(TestNode::name).collect_vec(),
-// nodes_with_candidate(&nodes),
-// "All members of destination section accepted node as candidate"
-// );
-//
-// Continue after candidate time out:
-// FakeClock::advance_time(1000 * test_consts::CANDIDATE_EXPIRED_TIMEOUT_SECS);
-// poll_and_resend(&mut nodes);
-//
-// assert_eq!(
-// Vec::<XorName>::new(),
-// nodes_with_candidate(&nodes),
-// "All members have rejected the candidate"
-// );
-// }
 
 #[test]
 fn single_section() {
@@ -207,6 +149,9 @@ fn multiple_joining_nodes() {
 fn single_split() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
+        // The smallest `safe_section_size` where when a split happens, the set of elders
+        // post-split in at least one of the sub-sections might be completely different from the
+        // set of elders pre-split. This setup exposed a bug before and we want to have it covered.
         safe_section_size: LOWERED_ELDER_SIZE + 3,
     });
     let mut nodes = vec![];

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -209,7 +209,7 @@ fn single_split() {
         elder_size: LOWERED_ELDER_SIZE,
         safe_section_size: LOWERED_ELDER_SIZE + 3,
     });
-    let mut nodes = Nodes(vec![]);
+    let mut nodes = vec![];
     trigger_split(&env, &mut nodes, &Prefix::default());
 }
 
@@ -235,7 +235,7 @@ struct SimultaneousJoiningNode {
 // Proceed with testing joining nodes at the same time with the given configuration.
 fn simultaneous_joining_nodes(
     env: Environment,
-    mut nodes: Nodes,
+    mut nodes: Vec<TestNode>,
     nodes_to_add_setup: &[SimultaneousJoiningNode],
 ) {
     // Arrange
@@ -481,7 +481,7 @@ fn carry_out_parsec_pruning() {
     let mut nodes = create_connected_nodes(&env, init_network_size);
     poll_and_resend(&mut nodes);
 
-    let parsec_versions = |nodes: &Nodes| {
+    let parsec_versions = |nodes: &[TestNode]| {
         nodes
             .iter()
             .map(|node| node.inner.parsec_last_version())
@@ -551,7 +551,7 @@ fn node_pause_and_resume_during_split() {
 
 // Pause a random node, then add new node with the given id, then resume the paused node and verify
 // everything still works as expected.
-fn node_pause_and_resume(env: Environment, mut nodes: Nodes, new_node_id: FullId) {
+fn node_pause_and_resume(env: Environment, mut nodes: Vec<TestNode>, new_node_id: FullId) {
     let index = env.new_rng().gen_range(0, nodes.len());
     let paused_id = nodes[index].id();
     let state = nodes.remove(index).inner.pause().unwrap();

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -267,7 +267,7 @@ fn simultaneous_joining_nodes(
                 };
 
                 let node = TestNode::builder(&env).transport_config(config).create();
-                if setup.src_section_prefix.matches(&node.name()) {
+                if setup.src_section_prefix.matches(node.name()) {
                     break node;
                 }
             }
@@ -431,7 +431,7 @@ fn check_close_names_for_elder_size_nodes() {
 
     let close_sections_complete = nodes
         .iter()
-        .all(|n| nodes.iter().all(|m| m.close_names().contains(&n.name())));
+        .all(|n| nodes.iter().all(|m| m.close_names().contains(n.name())));
     assert!(close_sections_complete);
 }
 
@@ -553,7 +553,7 @@ fn node_pause_and_resume_during_split() {
 // everything still works as expected.
 fn node_pause_and_resume(env: Environment, mut nodes: Vec<TestNode>, new_node_id: FullId) {
     let index = env.new_rng().gen_range(0, nodes.len());
-    let paused_id = nodes[index].id();
+    let paused_id = *nodes[index].id();
     let state = nodes.remove(index).inner.pause().unwrap();
 
     // Verify the other nodes do not see the node as going offline.

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -394,11 +394,7 @@ fn simultaneous_joining_nodes_three_section_with_one_ready_to_split() {
     let long_prefix_1 = long_prefix_0.sibling();
 
     // Setup the network so the small_prefix will split with one more node in small_prefix_to_add.
-    let _ =
-        *unwrap!(
-            add_connected_nodes_until_one_away_from_split(&env, &mut nodes, &[small_prefix],)
-                .first()
-        );
+    let _ = add_connected_nodes_until_one_away_from_split(&env, &mut nodes, &small_prefix);
 
     // First node will trigger the split: src, destination and proxy together.
     // Other nodes validate getting relocated to a section with a proxy from section splitting
@@ -547,7 +543,7 @@ fn node_pause_and_resume_during_split() {
 
     let mut nodes = create_connected_nodes(&env, env.safe_section_size());
     let prefix =
-        add_connected_nodes_until_one_away_from_split(&env, &mut nodes, &[Prefix::default()])[0];
+        add_connected_nodes_until_one_away_from_split(&env, &mut nodes, &Prefix::default());
 
     let new_node_id = FullId::within_range(&mut env.new_rng(), &prefix.range_inclusive());
     node_pause_and_resume(env, nodes, new_node_id)

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -180,7 +180,7 @@ fn remove_random_node_from_section_except(
     {
         let node = nodes.remove(index);
         info!("Remove node {} from {:?}", node.name(), prefix);
-        (index, node.id())
+        (index, *node.id())
     } else {
         panic!(
             "Section {:?} does not have any nodes that can be removed",
@@ -209,7 +209,7 @@ fn churn_until_age_counter(
     let mut rng = env.new_rng();
 
     loop {
-        let current_age_counter = node_age_counter(nodes, &nodes[node_index].name());
+        let current_age_counter = node_age_counter(nodes, nodes[node_index].name());
 
         info!(
             "churn_until_age_counter - node {}, age_counter {}/{}",

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -36,7 +36,7 @@ fn relocate_without_split() {
     let mut overrides = RelocationOverrides::new();
 
     let mut rng = env.new_rng();
-    let mut nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);
     verify_invariant_for_all_nodes(&env, &mut nodes);
 
     let prefixes: Vec<_> = current_sections(&nodes).collect();
@@ -79,7 +79,7 @@ fn relocate_causing_split() {
     let mut overrides = RelocationOverrides::new();
 
     let mut rng = env.new_rng();
-    let mut nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);
 
     let oldest_age_counter = node_age_counter(&nodes, &nodes[0].name()) as usize;
 
@@ -135,7 +135,7 @@ fn relocate_during_split() {
     let mut overrides = RelocationOverrides::new();
 
     let mut rng = env.new_rng();
-    let mut nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);
     let oldest_age_counter = node_age_counter(&nodes, &nodes[0].name()) as usize;
 
     let prefixes: Vec<_> = current_sections(&nodes).collect();

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -52,7 +52,7 @@ fn message_with_invalid_security(fail_type: FailType) {
     env.expect_panic();
     let mut rng = env.new_rng();
 
-    let mut nodes = create_connected_nodes_until_split(&env, vec![1, 1]);
+    let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);
 
     let their_node_pos = 0;
     let their_prefix = get_prefix(&nodes[their_node_pos]);

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{create_connected_nodes_until_split, poll_all, Nodes, TestNode, LOWERED_ELDER_SIZE};
+use super::{create_connected_nodes_until_split, poll_all, TestNode, LOWERED_ELDER_SIZE};
 use routing::{
     elders_info_for_test, generate_bls_threshold_secret_key, mock::Environment,
     section_proof_slice_for_test, AccumulatingMessage, DstLocation, FullId, Message, NetworkParams,
@@ -18,14 +18,14 @@ fn get_prefix(node: &TestNode) -> Prefix<XorName> {
     *node.inner.our_prefix().unwrap()
 }
 
-fn get_position_with_other_prefix(nodes: &Nodes, prefix: &Prefix<XorName>) -> usize {
+fn get_position_with_other_prefix(nodes: &[TestNode], prefix: &Prefix<XorName>) -> usize {
     nodes
         .iter()
         .position(|node| get_prefix(node) != *prefix)
         .unwrap()
 }
 
-fn send_message(nodes: &mut Nodes, src: usize, dst: usize, message: Message) {
+fn send_message(nodes: &mut [TestNode], src: usize, dst: usize, message: Message) {
     let connection_info = nodes[dst].inner.our_connection_info().unwrap();
     let targets = vec![connection_info];
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -34,9 +34,6 @@ use std::{
 // anticipated upper limit for any test, and if hit is likely to indicate an infinite loop.
 const MAX_POLL_CALLS: usize = 2000;
 
-// ----- Types -----
-type PrefixAndSize = (Prefix<XorName>, usize);
-
 // -----  Random number generation  -----
 
 pub fn gen_range<T: Rng>(rng: &mut T, low: usize, high: usize) -> usize {
@@ -388,130 +385,60 @@ pub fn create_connected_nodes_until_split(env: &Environment, prefix_lengths: &[u
     Nodes(nodes)
 }
 
-// Add connected nodes to the given prefixes until adding one extra node in any of the
-// returned sub-prefixes would trigger a split in the parent prefix.
+// Add connected nodes to the given prefix until adding one extra node into the
+// returned sub-prefix would trigger a split.
 pub fn add_connected_nodes_until_one_away_from_split(
     env: &Environment,
     nodes: &mut Vec<TestNode>,
-    prefixes_to_nearly_split: &[Prefix<XorName>],
-) -> Vec<Prefix<XorName>> {
-    let (prefixes_and_counts, prefixes_to_add_to_split) =
-        prefixes_and_count_to_split_with_only_one_extra_node(nodes, prefixes_to_nearly_split);
+    prefix_to_nearly_split: &Prefix<XorName>,
+) -> Prefix<XorName> {
+    let sub_prefix_last_bit = env.new_rng().gen();
+    let sub_prefix = prefix_to_nearly_split.pushed(sub_prefix_last_bit);
+    let (count0, count1) = if sub_prefix_last_bit {
+        (env.safe_section_size(), env.safe_section_size() - 1)
+    } else {
+        (env.safe_section_size() - 1, env.safe_section_size())
+    };
 
-    add_connected_nodes_until_sized(env, nodes, &prefixes_and_counts);
-    prefixes_to_add_to_split
-}
+    add_mature_nodes(env, nodes, prefix_to_nearly_split, count0, count1);
 
-// Add connected nodes until reaching the requested size for each prefix. No split expected.
-fn add_connected_nodes_until_sized(
-    env: &Environment,
-    nodes: &mut Vec<TestNode>,
-    prefixes_new_count: &[PrefixAndSize],
-) {
-    clear_all_event_queues(nodes, |_, _| {});
-    add_nodes_to_prefixes(env, nodes, prefixes_new_count);
-    clear_all_event_queues(nodes, |_, _| {});
-
-    trace!(
-        "Filled prefixes until ready to split {:?}",
-        prefixes_new_count
-    );
-}
-
-// Start the target number of new nodes under each target prefix.
-fn add_nodes_to_prefixes(
-    env: &Environment,
-    nodes: &mut Vec<TestNode>,
-    prefixes_new_count: &[PrefixAndSize],
-) {
-    for (prefix, target_count) in prefixes_new_count {
-        let num_in_section = nodes
-            .iter()
-            .filter(|node| prefix.matches(&node.name()))
-            .count();
-        // To ensure you don't hit this assert, don't have more than `safe_section_size()` entries in
-        // `nodes` when calling this function.
-        assert!(
-            num_in_section <= *target_count,
-            "The existing nodes' names disallow creation of the requested prefixes. There are {} \
-             nodes which all belong in {:?} which exceeds the limit here of {}.",
-            num_in_section,
-            prefix,
-            target_count
-        );
-        let to_add_count = target_count - num_in_section;
-        for _ in 0..to_add_count {
-            add_node_to_section_and_poll(env, nodes, prefix);
-        }
-    }
-}
-
-// Clear all event queues applying check_event to them.
-fn clear_all_event_queues(nodes: &mut Vec<TestNode>, check_event: impl Fn(&TestNode, Event)) {
-    for node in nodes.iter_mut() {
-        trace!("Start Check with {}", node.name());
-        while let Some(event) = node.try_recv_event() {
-            check_event(node, event)
-        }
-    }
-}
-
-// Returns sub-prefixes target size to reach so we would split with one extra node.
-// The second returned field contains the sub-prefixes to add the final node to trigger the splits.
-fn prefixes_and_count_to_split_with_only_one_extra_node(
-    nodes: &[TestNode],
-    prefixes: &[Prefix<XorName>],
-) -> (Vec<PrefixAndSize>, Vec<Prefix<XorName>>) {
-    let prefixes_to_add_to_split = prefixes
-        .iter()
-        .map(|prefix| prefix_half_with_fewer_nodes(nodes, prefix))
-        .collect_vec();
-
-    let safe_section_size = unwrap!(nodes[0].inner.safe_section_size());
-
-    let mut prefixes_and_counts = Vec::new();
-    for small_prefix in &prefixes_to_add_to_split {
-        prefixes_and_counts.push((*small_prefix, safe_section_size - 1));
-        prefixes_and_counts.push((small_prefix.sibling(), safe_section_size));
-    }
-
-    (prefixes_and_counts, prefixes_to_add_to_split)
-}
-
-// Return the sub-prefix with fewer nodes.
-fn prefix_half_with_fewer_nodes(nodes: &[TestNode], prefix: &Prefix<XorName>) -> Prefix<XorName> {
-    let sub_prefixes = [prefix.pushed(false), prefix.pushed(true)];
-
-    let smaller_prefix = sub_prefixes.iter().min_by_key(|prefix| {
-        nodes
-            .iter()
-            .filter(|node| prefix.matches(&node.name()))
-            .count()
-    });
-    *unwrap!(smaller_prefix)
+    sub_prefix
 }
 
 /// Split the section by adding and/or removing nodes to/from it.
 pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Prefix<XorName>) {
     // To trigger split, we need the section to contain at least `safe_section_size` *mature* nodes
-    // from each sub-prefix. Newly added nodes start as infants and so don't count towards split.
-    // To make them mature, we need to increment their age counters 16 times (they start at age 4
-    // (age counter 16) and we need them to reach at least age 5 (age counter 32)). Age counters
-    // are incremented only when a mature node joins or leaves the section. Joining a mature node
-    // would require relocating it from another section, so to keep things simple (and also to
-    // allow splitting the root section too where there is no other section to relocate from), we
-    // will be only removing mature nodes here. So we need to remove 16 mature nodes and still
-    // remain with enough nodes at the end.
-    //
-    // This algorithm consist of three phases:
-    //
-    // 1. Add nodes to the section until it has exactly 16 nodes. These are the nodes that will be
-    //    removed in phase 3.
-    // 2. Add 2 * `safe_section_size` more nodes. Half from one sub-prefix, other half from the
-    //    other. These are the nodes that will remain in the two sub-sections.
-    // 3. Remove the first 16 nodes in order to make the last 2 * safe_section_size nodes age and
-    //    become mature. This is done carefully so that we only remove nodes that are mature and
-    //    never remove any of the last 2 * safe_section_size nodes.
+    // from each sub-prefix.
+    add_mature_nodes(
+        env,
+        nodes,
+        prefix,
+        env.safe_section_size(),
+        env.safe_section_size(),
+    );
+
+    // Verify the split actually happened.
+    poll_until_split(nodes, prefix);
+    info!("Split finished");
+}
+
+/// Add/remove nodes to the given section until it has exactly `count0` mature nodes from the
+/// 0-ending subprefix and `count1` mature nodes from the 1-ending subprefix.
+/// Note: if `count0` and `count1` are both at least `safe_section_size`, this causes the section
+/// to split.
+pub fn add_mature_nodes(
+    env: &Environment,
+    nodes: &mut Vec<TestNode>,
+    prefix: &Prefix<XorName>,
+    count0: usize,
+    count1: usize,
+) {
+    // New nodes start as infants at age counter 16. We need to increase their age counters to 32
+    // in order for them to become adults. To do that, we need to add or remove 16 other mature
+    // nodes. Adding mature node can be done only by relocating it from another section, so for
+    // simplicity we will be only removing nodes here.
+
+    // TODO: consider using relocations from other sections (if there are any) too.
 
     assert!(
         env.elder_size() > 3,
@@ -521,9 +448,6 @@ pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Pref
 
     let sub_prefix0 = prefix.pushed(false);
     let sub_prefix1 = prefix.pushed(true);
-
-    // The desired number of nodes in each sub-prefix.
-    let target_size = env.safe_section_size();
 
     // Number of times to increment the age counters so all nodes are mature. That is, the number
     // of mature nodes to remove.
@@ -548,8 +472,7 @@ pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Pref
     // promoted to replace previously removed elders and thus themselves being removed too. We want
     // to first add the nodes that will be removed and then the nodes that will remain.
 
-    // These nodes can go into any sub-prefix because they will be removed anyway, together with the
-    // nodes already in the section (if any).
+    // First add the nodes that will be removed later. These can go into any sub-prefix.
     let temp_count = remove_count.saturating_sub(current_count);
     info!("Adding {} temporary nodes", temp_count);
     for _ in 0..temp_count {
@@ -558,11 +481,12 @@ pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Pref
 
     poll_and_resend(nodes);
 
-    // Of the remaining nodes, half must go to one sub-prefix and half to the other. Add them in
-    // random order to avoid accidentally relying on them being in any particular order.
-    info!("Adding {} final nodes", 2 * target_size);
-    let mut remaining0 = target_size;
-    let mut remaining1 = target_size;
+    // Of the remaining nodes, `count0` goes to the 0-ending sub-prefix and `count` to the
+    // 1-ending. Add them in random order to avoid accidentally relying on them being in any
+    // particular order.
+    info!("Adding {} final nodes", count0 + count1);
+    let mut remaining0 = count0;
+    let mut remaining1 = count1;
 
     loop {
         let bit = if remaining0 > 0 && remaining1 > 0 {
@@ -590,21 +514,17 @@ pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Pref
     info!("Removing {} mature nodes", remove_count);
     for _ in 0..remove_count {
         // Note: removing only elders for simplicity. Also making sure we don't remove any of the
-        // last `2 * safe_section_size` nodes.
-        remove_elder_from_section_in_range(nodes, &prefix, 0..nodes.len() - 2 * target_size);
+        // last `count0 + count1` nodes.
+        remove_elder_from_section_in_range(nodes, &prefix, 0..nodes.len() - count0 - count1);
         poll_and_resend(nodes);
     }
 
     // Count the number of nodes in each sub-prefix and verify they are as expected.
-    let new_count0 = nodes_with_prefix(nodes, &sub_prefix0).count();
-    assert_eq!(new_count0, target_size);
+    let actual_count0 = nodes_with_prefix(nodes, &sub_prefix0).count();
+    assert_eq!(actual_count0, count0);
 
-    let new_count1 = nodes_with_prefix(nodes, &sub_prefix1).count();
-    assert_eq!(new_count1, target_size);
-
-    // Verify the split actually happened.
-    poll_until_split(nodes, prefix);
-    info!("Split finished");
+    let actual_count1 = nodes_with_prefix(nodes, &sub_prefix1).count();
+    assert_eq!(actual_count1, count1);
 }
 
 fn poll_until_split(nodes: &mut [TestNode], prefix: &Prefix<XorName>) {
@@ -922,35 +842,6 @@ pub fn add_node_to_section(env: &Environment, nodes: &mut Vec<TestNode>, prefix:
 
     info!("Add node {} to {:?}", node.name(), prefix);
     nodes.push(node);
-}
-
-fn add_node_to_section_and_poll(
-    env: &Environment,
-    nodes: &mut Vec<TestNode>,
-    prefix: &Prefix<XorName>,
-) {
-    // Suppress relocations to prevent unwanted splits of other sections.
-    let mut overrides = RelocationOverrides::new();
-    overrides.suppress_self_and_parents(*prefix);
-
-    add_node_to_section(env, nodes, prefix);
-
-    // Poll until the new node transitions to the `Elder` state.
-    let elder_size = env.elder_size();
-    poll_and_resend_with_options(
-        nodes,
-        PollOptions::default().continue_if(move |nodes| {
-            nodes.len() >= elder_size
-                && nodes.iter().filter(|node| node.inner.is_elder()).count() < elder_size
-        }),
-    );
-    expect_any_event!(nodes[nodes.len() - 1], Event::Connected(_));
-    assert!(
-        prefix.matches(&nodes[nodes.len() - 1].name()),
-        "Prefix {:?} doesn't match the name {}!",
-        prefix,
-        nodes[nodes.len() - 1].name()
-    );
 }
 
 // Remove one elder node from the given prefix but only from nodes in the given index range.

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -245,7 +245,7 @@ pub fn poll_and_resend_with_options(nodes: &mut [TestNode], options: PollOptions
 
     // When all nodes become idle, run a couple more iterations, advancing the time a bit after
     // each one. This should allow the nodes to process failed or bounced messages.
-    let max_final_iterations = 16;
+    let max_final_iterations = 19;
     let mut final_iterations = 0;
 
     for _ in 0..MAX_POLL_CALLS {
@@ -360,7 +360,7 @@ pub fn create_connected_nodes_until_split(
         .iter()
         .flat_map(|node| node.inner.prefixes())
         .collect();
-    assert_eq!(actual_prefixes, final_prefixes.iter().copied().collect(),);
+    assert_eq!(actual_prefixes, final_prefixes.iter().copied().collect());
 
     let actual_prefix_lengths: Vec<_> = actual_prefixes.iter().map(Prefix::bit_count).sorted();
     assert_eq!(&actual_prefix_lengths[..], prefix_lengths);

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -26,7 +26,7 @@ use std::{
     convert::TryInto,
     iter,
     net::SocketAddr,
-    ops::{Deref, DerefMut, Range},
+    ops::Range,
     time::Duration,
 };
 
@@ -46,24 +46,6 @@ pub fn gen_elder_index<R: Rng>(rng: &mut R, nodes: &[TestNode]) -> usize {
         if nodes[index].inner.is_elder() {
             break index;
         }
-    }
-}
-
-/// Wraps a `Vec<TestNode>`s and prints the nodes' routing tables when dropped in a panicking
-/// thread.
-pub struct Nodes(pub Vec<TestNode>);
-
-impl Deref for Nodes {
-    type Target = Vec<TestNode>;
-
-    fn deref(&self) -> &Vec<TestNode> {
-        &self.0
-    }
-}
-
-impl DerefMut for Nodes {
-    fn deref_mut(&mut self) -> &mut Vec<TestNode> {
-        &mut self.0
     }
 }
 
@@ -315,7 +297,7 @@ fn advance_time(duration: Duration) {
     FakeClock::advance_time(duration.as_millis().try_into().expect("time step too long"));
 }
 
-pub fn create_connected_nodes(env: &Environment, size: usize) -> Nodes {
+pub fn create_connected_nodes(env: &Environment, size: usize) -> Vec<TestNode> {
     let mut nodes = Vec::new();
 
     // Create the seed node.
@@ -348,10 +330,13 @@ pub fn create_connected_nodes(env: &Environment, size: usize) -> Nodes {
         }
     }
 
-    Nodes(nodes)
+    nodes
 }
 
-pub fn create_connected_nodes_until_split(env: &Environment, prefix_lengths: &[usize]) -> Nodes {
+pub fn create_connected_nodes_until_split(
+    env: &Environment,
+    prefix_lengths: &[usize],
+) -> Vec<TestNode> {
     let mut rng = env.new_rng();
 
     // The prefixes we want to create.
@@ -382,7 +367,7 @@ pub fn create_connected_nodes_until_split(env: &Environment, prefix_lengths: &[u
 
     trace!("Created testnet comprising {:?}", actual_prefixes);
 
-    Nodes(nodes)
+    nodes
 }
 
 // Add connected nodes to the given prefix until adding one extra node into the

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -380,7 +380,7 @@ pub fn create_connected_nodes_until_split(env: &Environment, prefix_lengths: &[u
         .collect();
     assert_eq!(actual_prefixes, final_prefixes.iter().copied().collect(),);
 
-    let actual_prefix_lengths: Vec<_> = actual_prefixes.iter().map(Prefix::bit_count).collect();
+    let actual_prefix_lengths: Vec<_> = actual_prefixes.iter().map(Prefix::bit_count).sorted();
     assert_eq!(&actual_prefix_lengths[..], prefix_lengths);
 
     trace!("Created testnet comprising {:?}", actual_prefixes);

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -700,19 +700,6 @@ pub fn indexed_nodes_with_prefix<'a>(
         .filter(move |(_, node)| prefix.matches(&node.name()))
 }
 
-/// Returns the age counter of the node with the given name.
-pub fn node_age_counter(nodes: &[TestNode], name: &XorName) -> u32 {
-    if let Some(counter) = nodes
-        .iter()
-        .filter_map(|node| node.inner.member_age_counter(name))
-        .max()
-    {
-        counter
-    } else {
-        panic!("{} is not a member known to any node.", name)
-    }
-}
-
 pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
     let our_prefix = node.our_prefix();
     let our_name = node.name();
@@ -944,7 +931,8 @@ pub fn gen_bytes<R: Rng>(rng: &mut R, size: usize) -> Vec<u8> {
     gen_vec(rng, size)
 }
 
-fn add_node_to_section(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Prefix<XorName>) {
+// Create new node in the given section.
+pub fn add_node_to_section(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Prefix<XorName>) {
     let mut rng = env.new_rng();
     let full_id = FullId::within_range(&mut rng, &prefix.range_inclusive());
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -318,32 +318,6 @@ fn advance_time(duration: Duration) {
     FakeClock::advance_time(duration.as_millis().try_into().expect("time step too long"));
 }
 
-/// Checks each of the last `count` members of `nodes` for a `Connected` event, and removes those
-/// which don't fire one. Returns the number of removed nodes.
-pub fn remove_nodes_which_failed_to_connect(nodes: &mut Vec<TestNode>, count: usize) -> usize {
-    let failed_to_join: Vec<_> = nodes
-        .iter_mut()
-        .enumerate()
-        .rev()
-        .take(count)
-        .filter_map(|(index, ref mut node)| {
-            while let Some(event) = node.try_recv_event() {
-                if let Event::Connected(_) = event {
-                    return None;
-                }
-            }
-            Some(index)
-        })
-        .collect();
-    let removed_nodes: Vec<_> = failed_to_join
-        .iter()
-        .map(|index| nodes.remove(*index).name())
-        .collect();
-    info!("Failed to be Added as Nodes: {:?}", removed_nodes);
-    poll_and_resend(nodes);
-    failed_to_join.len()
-}
-
 pub fn create_connected_nodes(env: &Environment, size: usize) -> Nodes {
     let mut nodes = Vec::new();
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -78,12 +78,12 @@ impl TestNode {
         unwrap!(self.inner.our_connection_info(), "{}", self.name())
     }
 
-    pub fn id(&self) -> PublicId {
-        *self.inner.id()
+    pub fn id(&self) -> &PublicId {
+        self.inner.id()
     }
 
-    pub fn name(&self) -> XorName {
-        *self.inner.name()
+    pub fn name(&self) -> &XorName {
+        self.inner.name()
     }
 
     pub fn close_names(&self) -> Vec<XorName> {
@@ -522,8 +522,8 @@ fn poll_until_split(nodes: &mut [TestNode], prefix: &Prefix<XorName>) {
             let mut pending = nodes
                 .iter()
                 .filter(|node| {
-                    (sub_prefix0.matches(&node.name()) && *node.our_prefix() != sub_prefix0)
-                        || (sub_prefix1.matches(&node.name()) && *node.our_prefix() != sub_prefix1)
+                    (sub_prefix0.matches(node.name()) && *node.our_prefix() != sub_prefix0)
+                        || (sub_prefix1.matches(node.name()) && *node.our_prefix() != sub_prefix1)
                 })
                 .map(|node| node.name())
                 .peekable();
@@ -545,7 +545,7 @@ fn poll_until_split(nodes: &mut [TestNode], prefix: &Prefix<XorName>) {
 /// events have been processed before sorting.
 pub fn sort_nodes_by_distance_to(nodes: &mut [TestNode], name: &XorName) {
     let _ = poll_all(nodes); // Poll
-    nodes.sort_by(|node0, node1| name.cmp_distance(&node0.name(), &node1.name()));
+    nodes.sort_by(|node0, node1| name.cmp_distance(node0.name(), node1.name()));
 }
 
 /// Iterator over all nodes that belong to the given prefix.
@@ -553,9 +553,7 @@ pub fn nodes_with_prefix<'a>(
     nodes: &'a [TestNode],
     prefix: &'a Prefix<XorName>,
 ) -> impl Iterator<Item = &'a TestNode> {
-    nodes
-        .iter()
-        .filter(move |node| prefix.matches(&node.name()))
+    nodes.iter().filter(move |node| prefix.matches(node.name()))
 }
 
 /// Mutable iterator over all nodes that belong to the given prefix.
@@ -565,7 +563,7 @@ pub fn nodes_with_prefix_mut<'a>(
 ) -> impl Iterator<Item = &'a mut TestNode> {
     nodes
         .iter_mut()
-        .filter(move |node| prefix.matches(&node.name()))
+        .filter(move |node| prefix.matches(node.name()))
 }
 
 /// Iterator over all nodes that belong to the given prefix + their indices
@@ -576,7 +574,7 @@ pub fn indexed_nodes_with_prefix<'a>(
     nodes
         .iter()
         .enumerate()
-        .filter(move |(_, node)| prefix.matches(&node.name()))
+        .filter(move |(_, node)| prefix.matches(node.name()))
 }
 
 pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
@@ -585,7 +583,7 @@ pub fn verify_section_invariants_for_node(node: &TestNode, elder_size: usize) {
     let our_section_elders = node.inner.section_elders(our_prefix);
 
     assert!(
-        our_prefix.matches(&our_name),
+        our_prefix.matches(our_name),
         "{} Our prefix doesn't match our name: {:?}, {:?}",
         node.name(),
         our_prefix,
@@ -724,7 +722,7 @@ pub fn verify_section_invariants_between_nodes(nodes: &[TestNode]) {
         // Is this a problem?
         for prefix in iter::once(our_prefix).chain(node.inner.neighbour_prefixes().iter()) {
             let our_info = NodeSectionInfo {
-                node_name: our_name,
+                node_name: *our_name,
                 node_prefix: *our_prefix,
                 view_section_version: node.inner.section_elder_info_version(prefix).unwrap(),
                 view_section_elders: node.inner.section_elders(prefix),

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -413,10 +413,10 @@ pub fn add_connected_nodes_until_split(
     clear_all_event_queues(nodes, |_, _| {});
 
     // Start enough new nodes under each target prefix to trigger a split eventually.
-    let safe_section_size = unwrap!(nodes[0].inner.safe_section_size());
+    let target_size = env.safe_section_size();
     let prefixes_new_count = prefixes
         .iter()
-        .map(|prefix| (*prefix, safe_section_size))
+        .map(|prefix| (*prefix, target_size))
         .collect_vec();
     add_nodes_to_prefixes(env, nodes, &prefixes_new_count);
 

--- a/tests/mock_network_tests.rs
+++ b/tests/mock_network_tests.rs
@@ -79,28 +79,6 @@ macro_rules! expect_next_event {
     };
 }
 
-/// Expects that any event raised by the node matches the given pattern
-/// (with optional pattern guard). Ignores events that do not match the pattern.
-/// Panics if the event channel is exhausted before matching event is found.
-macro_rules! expect_any_event {
-    ($node:expr, $pattern:pat) => {
-        expect_any_event!($node, $pattern if true)
-    };
-    ($node:expr, $pattern:pat if $guard:expr) => {
-        loop {
-            match $node.try_recv_event() {
-                Some($pattern) if $guard => break,
-                Some(_) => (),
-                None => panic!(
-                    "Expected Some({}) at {}, got None",
-                    stringify!($pattern),
-                    $node.name(),
-                ),
-            }
-        }
-    };
-}
-
 /// Expects that the node did not raise an even matching the given pattern, panics otherwise
 /// (ignores ticks). If no pattern given, expects that no event (except ticks) were raised.
 macro_rules! expect_no_event {


### PR DESCRIPTION
This PR makes infants different from adults in these two ways:

1. Infant joining or leaving a section no longer causes ageing of the other section nodes
2. Infants are not taken into account when deciding splits

This change makes the network more resilient against [sybil attacks](https://en.wikipedia.org/wiki/Sybil_attack) because it makes it much more difficult for an attacker to attempt to take over a section by spawning large number of nodes under their control. 

The bulk of this PR however is in the test code, namely in the utilities to trigger splits. This now requires more work as it's no longer sufficient to just add new nodes until the section splits.

This PR also contains two seemingly unrelated changes:

1. It fixes a bug that was probably introduced in one of the recent PRs where adults would not handle `MemberKnowledge` messages. This caused issues when a section split and none of the new elders were elder before the split. Then the new to-be-elders would try to send `MemberKnowledge` to the old elders in order to get parsec gossip back (to make them see the event which promoted them), but the old elders would ignore the message thus stalling the section.

2. It introduces a new shared value called `section_version` which is a number that gets incremented every time a node joins or leaves the section. This number is then assigned to every node in the section when it joins and serves as additional differentiation when deciding which node to promote in case there are multiple candidates with the same age. Previously we would accidentally prefer nodes with smaller names (according to the xor metric) because the member infos are internally stored in a container sorted by the name. So with this change the process is more "just" as it prefers nodes that joined earlier. The main reason for this change though is to make the split triggering test utility work. 

Finally this PR contains some minor refactoring of the test code.

Closes #1953 