### PR TITLE
Test improvements

### DIFF
--- a/src/message_filter.rs
+++ b/src/message_filter.rs
@@ -84,6 +84,12 @@ impl MessageFilter {
             FilteringResult::NewMessage
         }
     }
+
+    // Resets both incoming and outgoing filters.
+    pub fn reset(&mut self) {
+        self.incoming.clear();
+        self.outgoing.clear();
+    }
 }
 
 impl Default for MessageFilter {

--- a/src/mock/env.rs
+++ b/src/mock/env.rs
@@ -100,17 +100,6 @@ impl Environment {
     }
 }
 
-impl Clone for Environment {
-    fn clone(&self) -> Self {
-        Self {
-            rng: RefCell::new(self.new_rng()),
-            network: self.network.clone(),
-            network_params: self.network_params,
-            seed_printer: None,
-        }
-    }
-}
-
 impl Deref for Environment {
     type Target = Network;
 

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -262,24 +262,6 @@ where
         }) || self.our_unpolled_observations().next().is_some()
     }
 
-    pub fn unpolled_observations_string(&self) -> String {
-        use itertools::Itertools;
-        let value = state::with::<T, S::PublicId, _, _>(self.section_hash, |state| {
-            format!(
-                "unconsensused_observations_for_peers: {:?}, first_unconsensused block: {:?}",
-                state
-                    .unconsensused_observations_for_peers(&self.peer_list)
-                    .format(", "),
-                state.get_block(self.first_unconsensused),
-            )
-        });
-        format!(
-            "{}, our_unpolled_observations: {:?}",
-            value,
-            self.our_unpolled_observations().format(", "),
-        )
-    }
-
     pub fn our_unpolled_observations(&self) -> impl Iterator<Item = &Observation<T, S::PublicId>> {
         self.observations
             .iter()

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -857,26 +857,23 @@ impl Node {
     fn set_log_ident(&self) -> log_utils::Guard {
         use std::fmt::Write;
         log_utils::set_ident(|buffer| match &self.stage {
-            Stage::Bootstrapping(_) => write!(buffer, "Bootstrapping({}) ", self.name()),
+            Stage::Bootstrapping(_) => write!(buffer, "{}(?) ", self.name()),
             Stage::Joining(stage) => write!(
                 buffer,
-                "Joining({}({:b})) ",
+                "{}({:b}v{}?) ",
                 self.name(),
-                stage.target_section_prefix()
-            ),
-            Stage::Approved(stage) if !stage.chain.is_self_elder() => write!(
-                buffer,
-                "Adult({}({:b})) ",
-                self.core.name(),
-                stage.chain.our_prefix()
+                stage.target_section_elders_info().prefix(),
+                stage.target_section_elders_info().version(),
             ),
             Stage::Approved(stage) => write!(
                 buffer,
-                "Elder({}({:b})) ",
+                "{}({:b}v{}{}) ",
                 self.core.name(),
-                stage.chain.our_prefix()
+                stage.chain.our_prefix(),
+                stage.chain.our_info().version(),
+                if stage.chain.is_self_elder() { "!" } else { "" },
             ),
-            Stage::Terminated => write!(buffer, "Terminated"),
+            Stage::Terminated => write!(buffer, "[terminated]"),
         })
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -916,14 +916,6 @@ impl Node {
             .unwrap_or_else(String::new)
     }
 
-    /// Returns whether the given peer is an elder of our section.
-    pub fn is_peer_our_elder(&self, pub_id: &PublicId) -> bool {
-        self.stage
-            .approved()
-            .map(|stage| stage.chain.is_peer_our_elder(pub_id))
-            .unwrap_or(false)
-    }
-
     /// Send a message to the given targets using the given delivery group size.
     pub fn send_message_to_targets(
         &mut self,
@@ -997,6 +989,20 @@ impl Node {
     /// Returns the elders in our and neighbouring sections.
     pub fn elder_nodes(&self) -> impl Iterator<Item = &P2pNode> {
         self.chain().into_iter().flat_map(Chain::elders)
+    }
+
+    /// Returns whether the given peer is an elder known to us.
+    pub fn is_peer_elder(&self, pub_id: &PublicId) -> bool {
+        self.chain()
+            .map(|chain| chain.is_peer_elder(pub_id))
+            .unwrap_or(false)
+    }
+
+    /// Returns whether the given peer is an elder of our section.
+    pub fn is_peer_our_elder(&self, pub_id: &PublicId) -> bool {
+        self.chain()
+            .map(|chain| chain.is_peer_our_elder(pub_id))
+            .unwrap_or(false)
     }
 
     /// Returns the members in our section and elders we know.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -908,14 +908,6 @@ impl Node {
             .unwrap_or(false)
     }
 
-    /// Indicates if there are any pending observations in the parsec object
-    pub fn unpolled_observations_string(&self) -> String {
-        self.stage
-            .approved()
-            .map(|stage| stage.parsec_map.unpolled_observations_string())
-            .unwrap_or_else(String::new)
-    }
-
     /// Send a message to the given targets using the given delivery group size.
     pub fn send_message_to_targets(
         &mut self,

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -349,8 +349,7 @@ impl Approved {
         }
 
         self.gen_pfx_info = gen_pfx_info.clone();
-        self.parsec_map
-            .init(&mut core.rng, core.full_id.clone(), &self.gen_pfx_info);
+        self.init_parsec(core);
         self.chain = Chain::new(self.chain.network_params(), *core.id(), gen_pfx_info, None);
 
         Ok(())

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -341,6 +341,8 @@ impl Approved {
     ) -> Result<()> {
         info!("Received GenesisUpdate: {:?}", gen_pfx_info);
 
+        core.msg_filter.reset();
+
         self.gen_pfx_info = gen_pfx_info.clone();
         self.init_parsec(core);
         self.chain = Chain::new(self.chain.network_params(), *core.id(), gen_pfx_info, None);
@@ -994,6 +996,8 @@ impl Approved {
         let info_version = elders_info.version();
         let is_elder = elders_info.is_member(core.id());
         let is_split = info_prefix.is_extension_of(&old_pfx);
+
+        core.msg_filter.reset();
 
         if was_elder || is_elder {
             info!("handle SectionInfo: {:?}", elders_info);

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -181,9 +181,9 @@ impl Joining {
         }
     }
 
-    // Prefix of the section we are joining.
-    pub fn target_section_prefix(&self) -> &Prefix<XorName> {
-        self.elders_info.prefix()
+    // The EldersInfo of the section we are joining.
+    pub fn target_section_elders_info(&self) -> &EldersInfo {
+        &self.elders_info
     }
 
     // Are we relocating or joining for the first time?

--- a/src/node/tests/bootstrapping.rs
+++ b/src/node/tests/bootstrapping.rs
@@ -107,7 +107,7 @@ fn step_at_least_once(node: &mut Node) {
 
     // Step for the first one.
     let op_index = sel.try_ready().unwrap();
-    let _ = node.handle_selected_operation(op_index).unwrap();
+    node.handle_selected_operation(op_index).unwrap();
 
     // Exhaust any remaining steps
     loop {
@@ -115,7 +115,7 @@ fn step_at_least_once(node: &mut Node) {
         node.register(&mut sel);
 
         if let Ok(op_index) = sel.try_ready() {
-            let _ = node.handle_selected_operation(op_index).unwrap();
+            node.handle_selected_operation(op_index).unwrap();
         } else {
             break;
         }

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -288,35 +288,6 @@ impl ParsecMap {
         parsec.has_unpolled_observations()
     }
 
-    #[cfg(feature = "mock")]
-    pub fn unpolled_observations_string(&self) -> String {
-        let parsec = if let Some(parsec) = self.map.values().last() {
-            parsec
-        } else {
-            return String::new();
-        };
-
-        parsec.unpolled_observations_string()
-    }
-
-    #[cfg(all(not(feature = "mock"), feature = "mock_base"))]
-    pub fn unpolled_observations_string(&self) -> String {
-        use itertools::Itertools;
-
-        let parsec = if let Some(parsec) = self.map.values().last() {
-            parsec
-        } else {
-            return String::new();
-        };
-
-        // This doesn't contain as much info as the `mock` version but it's better than
-        // nothing.
-        format!(
-            "our_unpolled_observations: {:?}",
-            parsec.our_unpolled_observations().format(", ")
-        )
-    }
-
     pub fn prune_if_needed(&mut self) {
         if self.size_counter.needs_pruning() {
             self.vote_for(AccumulatingEvent::ParsecPrune.into_network_event());

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -244,7 +244,8 @@ mod overrides {
 
     #[derive(Default)]
     struct OverrideInfo {
-        // Name that will be used as the next relocation destination.
+        // If `Some`, the relocation destinations are overridden with this name, otherwise they are
+        // not.
         next: Option<XorName>,
         // Map of original relocation destinations to the overridden ones. As this map is shared
         // among all nodes in the network, this assures that every node will pick the same

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -25,7 +25,7 @@ fn messages_accumulate_with_quorum() {
 
     let src_name: XorName = rng.gen();
     let src = SrcLocation::Section(Prefix::default());
-    sort_nodes_by_distance_to(&mut nodes, &src_name);
+    sort_nodes_by_distance_to(&env, &mut nodes, &src_name);
 
     let send = |node: &mut TestNode, dst: &DstLocation, content: Vec<u8>| {
         assert!(node.inner.send_message(src, *dst, content).is_ok());
@@ -59,7 +59,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst, content.clone());
     }
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
     expect_no_event!(nodes[closest_elder_index]);
     for node in nodes
         .iter_mut()
@@ -69,7 +69,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst, content.clone());
     }
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
     expect_next_event!(nodes[closest_elder_index], Event::MessageReceived { .. });
     for node in nodes
         .iter_mut()
@@ -80,7 +80,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst, content.clone());
     }
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
     expect_no_event!(nodes[closest_elder_index]);
 
     let dst_grp = DstLocation::Section(src_name); // The whole section.
@@ -95,7 +95,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst_grp, content.clone());
     }
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
     for node in &mut *nodes {
         expect_no_event!(node);
     }
@@ -107,7 +107,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst_grp, content.clone());
     }
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
     for node in nodes.iter_mut().filter(|node| node.inner.is_elder()) {
         expect_next_event!(node, Event::MessageReceived { .. });
     }
@@ -120,7 +120,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst_grp, content.clone());
     }
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
     for node in &mut *nodes {
         expect_no_event!(node);
     }

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -59,7 +59,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst, content.clone());
     }
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
     expect_no_event!(nodes[closest_elder_index]);
     for node in nodes
         .iter_mut()
@@ -69,7 +69,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst, content.clone());
     }
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
     expect_next_event!(nodes[closest_elder_index], Event::MessageReceived { .. });
     for node in nodes
         .iter_mut()
@@ -80,7 +80,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst, content.clone());
     }
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
     expect_no_event!(nodes[closest_elder_index]);
 
     let dst_grp = DstLocation::Section(src_name); // The whole section.
@@ -95,7 +95,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst_grp, content.clone());
     }
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
     for node in &mut *nodes {
         expect_no_event!(node);
     }
@@ -107,7 +107,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst_grp, content.clone());
     }
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
     for node in nodes.iter_mut().filter(|node| node.inner.is_elder()) {
         expect_next_event!(node, Event::MessageReceived { .. });
     }
@@ -120,7 +120,7 @@ fn messages_accumulate_with_quorum() {
     {
         send(node, &dst_grp, content.clone());
     }
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
     for node in &mut *nodes {
         expect_no_event!(node);
     }

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -25,7 +25,7 @@ fn messages_accumulate_with_quorum() {
 
     let src_name: XorName = rng.gen();
     let src = SrcLocation::Section(Prefix::default());
-    sort_nodes_by_distance_to(&env, &mut nodes, &src_name);
+    sort_nodes_by_distance_to(&mut nodes, &src_name);
 
     let send = |node: &mut TestNode, dst: &DstLocation, content: Vec<u8>| {
         assert!(node.inner.send_message(src, *dst, content).is_ok());

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -8,7 +8,7 @@
 
 use super::{
     count_sections, create_connected_nodes, create_connected_nodes_until_split, current_sections,
-    gen_elder_index, gen_range, gen_vec, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
+    gen_elder_index, gen_range, gen_vec, poll_and_resend, verify_invariants_for_nodes, TestNode,
 };
 use itertools::Itertools;
 use rand::{
@@ -523,7 +523,7 @@ fn progress_and_verify<R: Rng>(
     };
 
     expectations.verify(nodes);
-    verify_invariant_for_all_nodes(env, nodes);
+    verify_invariants_for_nodes(env, nodes);
     shuffle_nodes(rng, nodes);
 }
 

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -582,7 +582,7 @@ impl Expectations {
         let mut sent_count = 0;
         for node in nodes
             .iter_mut()
-            .filter(|node| node.inner.is_elder() && node.in_src_location(&key.src))
+            .filter(|node| node.inner.is_elder() && node.inner.in_src_location(&key.src))
         {
             trace!("send message {} from {}", key, node.name());
 

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -502,8 +502,8 @@ fn progress_and_verify<R: Rng>(
     shuffle_nodes(rng, nodes);
 }
 
-// Poll until all the nodes at `added_indices` are added and all the nodes from `dropped_ids` are
-// removed.
+// Poll until all the nodes at `added_indices` join the network and all the nodes from
+// `dropped_ids` leave it.
 fn poll_until_churn_complete(
     env: &Environment,
     nodes: &mut [TestNode],
@@ -555,8 +555,10 @@ impl Display for MessageKey {
     }
 }
 
-// A set of expectations: Which nodes, groups and sections are supposed to receive a message.
+// A set of message delivery expectations.
 struct Expectations {
+    // Maps the message to the nodes which are expected to receive it. Each node name is mapped to
+    // a flag indicating whether it already received it.
     messages: HashMap<MessageKey, HashMap<XorName, bool>>,
 }
 

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -12,12 +12,12 @@ use super::{
 use routing::{mock::Environment, NetworkParams};
 
 // Drop node at index and verify its own section detected it.
-fn drop_node(nodes: &mut Vec<TestNode>, index: usize) {
+fn drop_node(env: &Environment, nodes: &mut Vec<TestNode>, index: usize) {
     let _ = nodes.remove(index);
 
     // Using poll_all instead of poll_and_resend here to only let the other nodes realise the node
     // got disconnected, but not make more progress.
-    let _ = poll_all(nodes);
+    let _ = poll_all(env, nodes);
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn node_drops() {
         safe_section_size,
     });
     let mut nodes = create_connected_nodes(&env, elder_size + 2);
-    drop_node(&mut nodes, 0);
+    drop_node(&env, &mut nodes, 0);
 
     // Trigger poll_and_resend to allow remaining nodes to gossip and
     // update their chain accordingly.

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    create_connected_nodes, poll_all, poll_and_resend, verify_invariant_for_all_nodes, TestNode,
+    create_connected_nodes, poll_all, poll_and_resend, verify_invariants_for_nodes, TestNode,
 };
 use routing::{mock::Environment, NetworkParams};
 
@@ -34,5 +34,5 @@ fn node_drops() {
     // Trigger poll_and_resend to allow remaining nodes to gossip and
     // update their chain accordingly.
     poll_and_resend(&mut nodes);
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    verify_invariants_for_nodes(&env, &nodes);
 }

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -33,7 +33,7 @@ fn send() {
         .send_message(src, dst, content.clone())
         .is_ok());
 
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
 
     let mut message_received_count = 0;
     for node in nodes
@@ -84,7 +84,7 @@ fn send_and_receive() {
         .send_message(src, dst, req_content.clone())
         .is_ok());
 
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
 
     let mut request_received_count = 0;
 
@@ -120,7 +120,7 @@ fn send_and_receive() {
 
     assert!(request_received_count >= quorum);
 
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
 
     let mut response_received_count = 0;
 

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -426,18 +426,6 @@ fn carry_out_parsec_pruning() {
             .collect_vec()
     };
 
-    let consensus_reached = |nodes: &[TestNode], expected_content: &[u8], counter: &mut usize| {
-        for node in nodes {
-            if let Some(Event::Consensus(actual_content)) = node.try_recv_event() {
-                if &actual_content[..] == expected_content {
-                    *counter += 1;
-                }
-            }
-        }
-
-        *counter == nodes.len()
-    };
-
     // There is less than `elder_size` nodes so everyone should become elder.
     poll_until(&env, &mut nodes, |nodes| {
         nodes.iter().all(|node| node.inner.is_elder())
@@ -456,7 +444,7 @@ fn carry_out_parsec_pruning() {
 
         let mut consensus_counter = 0;
         poll_until(&env, &mut nodes, |nodes| {
-            consensus_reached(nodes, &event, &mut consensus_counter)
+            consensus_reached(nodes, &event, nodes.len(), &mut consensus_counter)
         });
 
         let new_parsec_versions = parsec_versions(&nodes);

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -57,7 +57,7 @@ fn disconnect_on_rebootstrap() {
     // Try to bootstrap to another than the first node. With network size 2, this should fail.
     let config = TransportConfig::node().with_hard_coded_contact(nodes[1].endpoint());
     nodes.push(TestNode::builder(&env).transport_config(config).create());
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
 
     // When retrying to bootstrap, we should have disconnected from the bootstrap node.
     assert!(!env.is_connected(&nodes[2].endpoint(), &nodes[1].endpoint()));

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -35,8 +35,8 @@ fn test_nodes(percentage_size: usize) {
         // Require at least one non-elder to make things more interesting.
         safe_section_size: LOWERED_ELDER_SIZE + 1,
     });
-    let mut nodes = create_connected_nodes(&env, size);
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    let nodes = create_connected_nodes(&env, size);
+    verify_invariants_for_nodes(&env, &nodes);
 }
 
 fn create_node_with_contact(env: &Environment, contact: &mut TestNode) -> TestNode {
@@ -72,8 +72,8 @@ fn single_section() {
         elder_size: sec_size,
         safe_section_size: sec_size,
     });
-    let mut nodes = create_connected_nodes(&env, sec_size);
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    let nodes = create_connected_nodes(&env, sec_size);
+    verify_invariants_for_nodes(&env, &nodes);
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn node_joins_in_front() {
     );
     poll_and_resend(&mut nodes);
 
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    verify_invariants_for_nodes(&env, &nodes);
 }
 
 #[test]
@@ -164,8 +164,8 @@ fn multi_split() {
         elder_size: LOWERED_ELDER_SIZE,
         safe_section_size: LOWERED_ELDER_SIZE + 1,
     });
-    let mut nodes = create_connected_nodes_until_split(&env, &[2, 2, 2, 2]);
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    let nodes = create_connected_nodes_until_split(&env, &[2, 2, 2, 2]);
+    verify_invariants_for_nodes(&env, &nodes);
 }
 
 struct SimultaneousJoiningNode {
@@ -259,7 +259,7 @@ fn simultaneous_joining_nodes(
         "Prefixes with too few elders: {:?}",
         prefixes_not_enough_elders
     );
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    verify_invariants_for_nodes(&env, &nodes);
 }
 
 #[test]
@@ -464,7 +464,7 @@ fn carry_out_parsec_pruning() {
 
     poll_and_resend(&mut nodes);
 
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    verify_invariants_for_nodes(&env, &nodes);
 }
 
 // The paused node does not participate until resumed, so we need enough elders to reach
@@ -524,5 +524,5 @@ fn node_pause_and_resume(env: Environment, mut nodes: Vec<TestNode>, new_node_id
     // Resume the node and verify it caugh up to the changes in the network.
     nodes.push(TestNode::resume(&env, state));
     poll_and_resend(&mut nodes);
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    verify_invariants_for_nodes(&env, &nodes);
 }

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -58,7 +58,7 @@ fn disconnect_on_rebootstrap() {
     // Try to bootstrap to another than the first node. With network size 2, this should fail.
     let config = TransportConfig::node().with_hard_coded_contact(nodes[1].endpoint());
     nodes.push(TestNode::builder(&env).transport_config(config).create());
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
 
     // When retrying to bootstrap, we should have disconnected from the bootstrap node.
     assert!(!env.is_connected(&nodes[2].endpoint(), &nodes[1].endpoint()));

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -484,7 +484,7 @@ fn node_pause_and_resume_simple() {
     });
     let new_id = *nodes.last().unwrap().id();
 
-    nodes.push(TestNode::resume(&env, paused_state));
+    nodes.push(TestNode::resume(paused_state));
 
     // If the paused node is elder, verify it caught up to the new node joining.
     if nodes.last().unwrap().inner.is_elder() {
@@ -513,7 +513,7 @@ fn node_pause_and_resume_during_split() {
     );
 
     let paused_state = pause_node_and_poll(&env, &mut nodes);
-    nodes.push(TestNode::resume(&env, paused_state));
+    nodes.push(TestNode::resume(paused_state));
 
     poll_until(&env, &mut nodes, |nodes| {
         section_split(nodes, &Prefix::default())

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -10,7 +10,7 @@ use super::{
     add_connected_nodes_until_one_away_from_split, add_node_to_section,
     create_connected_nodes_until_split, current_sections, indexed_nodes_with_prefix,
     nodes_with_prefix, poll_and_resend, poll_and_resend_with_options,
-    verify_invariant_for_all_nodes, PollOptions, TestNode, LOWERED_ELDER_SIZE,
+    verify_invariant_for_all_nodes, TestNode, LOWERED_ELDER_SIZE,
 };
 use rand::{
     distributions::{Distribution, Standard},
@@ -144,12 +144,9 @@ fn relocate_during_split() {
     relocate_index = churn_until_age_counter(&env, &mut nodes, &source_prefix, relocate_index, 32);
 
     // Poll now, so the add and the relocation happen simultaneously.
-    poll_and_resend_with_options(
-        &mut nodes,
-        PollOptions::default().continue_if(move |nodes| {
-            !node_relocated(nodes, relocate_index, &source_prefix, &target_prefix)
-        }),
-    )
+    poll_and_resend_with_options(&mut nodes, move |nodes| {
+        !node_relocated(nodes, relocate_index, &source_prefix, &target_prefix)
+    })
 }
 
 fn choose_other_prefix<'a, R: Rng>(
@@ -234,11 +231,7 @@ fn churn_until_age_counter(
         match churn {
             Churn::Add => {
                 add_node_to_section(env, nodes, prefix);
-                poll_and_resend_with_options(
-                    nodes,
-                    PollOptions::default()
-                        .continue_if(|nodes| !node_joined(nodes, nodes.len() - 1)),
-                );
+                poll_and_resend_with_options(nodes, |nodes| !node_joined(nodes, nodes.len() - 1));
             }
             Churn::Remove => {
                 let (removed_index, id) =
@@ -248,10 +241,7 @@ fn churn_until_age_counter(
                     node_index -= 1;
                 }
 
-                poll_and_resend_with_options(
-                    nodes,
-                    PollOptions::default().continue_if(move |nodes| !node_left(nodes, &id)),
-                );
+                poll_and_resend_with_options(nodes, move |nodes| !node_left(nodes, &id));
             }
         }
     }

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -204,10 +204,13 @@ fn churn_until_age_counter(
     let max_section_size = NETWORK_PARAMS.safe_section_size - 1;
     assert!(min_section_size < max_section_size);
 
+    // Store the name here in case it changes due to relocation.
+    let node_name = *nodes[node_index].name();
+
     let mut rng = env.new_rng();
 
     loop {
-        let current_age_counter = node_age_counter(nodes, nodes[node_index].name());
+        let current_age_counter = node_age_counter(nodes, &node_name);
 
         info!(
             "churn_until_age_counter - node {}, age_counter {}/{}",

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -9,8 +9,8 @@
 use super::{
     add_connected_nodes_until_one_away_from_split, add_node_to_section,
     create_connected_nodes_until_split, current_sections, indexed_nodes_with_prefix,
-    nodes_with_prefix, poll_and_resend, poll_and_resend_with_options,
-    verify_invariant_for_all_nodes, TestNode, LOWERED_ELDER_SIZE,
+    nodes_with_prefix, poll_and_resend, poll_and_resend_with_options, verify_invariants_for_nodes,
+    TestNode, LOWERED_ELDER_SIZE,
 };
 use rand::{
     distributions::{Distribution, Standard},
@@ -36,7 +36,7 @@ fn relocate_without_split() {
 
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);
-    verify_invariant_for_all_nodes(&env, &mut nodes);
+    verify_invariants_for_nodes(&env, &nodes);
 
     let prefixes: Vec<_> = current_sections(&nodes).collect();
     let source_prefix = *prefixes.choose(&mut rng).unwrap();

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -101,7 +101,7 @@ fn message_with_invalid_security(fail_type: FailType) {
     // and detect an invalid signature or proof.
     //
     send_message(&mut nodes, our_node_pos, their_node_pos, message);
-    let _ = poll_all(&env, &mut nodes);
+    poll_all(&env, &mut nodes);
 }
 
 #[test]

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -101,7 +101,7 @@ fn message_with_invalid_security(fail_type: FailType) {
     // and detect an invalid signature or proof.
     //
     send_message(&mut nodes, our_node_pos, their_node_pos, message);
-    let _ = poll_all(&mut nodes);
+    let _ = poll_all(&env, &mut nodes);
 }
 
 #[test]

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -276,15 +276,16 @@ pub fn section_split(nodes: &[TestNode], prefix: &Prefix<XorName>) -> bool {
     let mut pending = nodes
         .iter()
         .filter(|node| {
-            if sub_prefix0.matches(node.name()) && *node.our_prefix() != sub_prefix0 {
-                return true;
-            }
-
-            if sub_prefix1.matches(node.name()) && *node.our_prefix() != sub_prefix1 {
+            if prefix.matches(node.name())
+                && *node.our_prefix() != sub_prefix0
+                && *node.our_prefix() != sub_prefix1
+            {
+                // The node hasn't progressed through the split of its own section yet.
                 return true;
             }
 
             if node.inner.prefixes().contains(prefix) {
+                // The node still has the pre-split section among its neighbours.
                 return true;
             }
 
@@ -583,11 +584,8 @@ fn poll_until_last_nodes_joined(env: &Environment, nodes: &mut [TestNode], first
 
 // -----  Small misc functions  -----
 
-/// Sorts the given nodes by their distance to `name`. Note that this will call the `name()`
-/// function on them which causes polling, so it calls `poll_all` to make sure that all other
-/// events have been processed before sorting.
-pub fn sort_nodes_by_distance_to(env: &Environment, nodes: &mut [TestNode], name: &XorName) {
-    poll_all(env, nodes); // Poll
+/// Sorts the given nodes by their distance to `name`.
+pub fn sort_nodes_by_distance_to(nodes: &mut [TestNode], name: &XorName) {
     nodes.sort_by(|node0, node1| name.cmp_distance(node0.name(), node1.name()));
 }
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -17,8 +17,8 @@ use routing::{
     event::{Connected, Event},
     mock::Environment,
     rng::MainRng,
-    test_consts, DstLocation, FullId, Node, NodeConfig, PausedState, Prefix, PublicId,
-    RelocationOverrides, SrcLocation, TransportConfig, XorName, Xorable,
+    test_consts, FullId, Node, NodeConfig, PausedState, Prefix, PublicId, RelocationOverrides,
+    TransportConfig, XorName, Xorable,
 };
 use std::{
     cmp, collections::BTreeSet, convert::TryInto, iter, net::SocketAddr, ops::Range, time::Duration,
@@ -88,14 +88,6 @@ impl TestNode {
 
     pub fn our_prefix(&self) -> &Prefix<XorName> {
         unwrap!(self.inner.our_prefix(), "{}", self.name())
-    }
-
-    pub fn in_src_location(&self, src: &SrcLocation) -> bool {
-        self.inner.in_src_location(src)
-    }
-
-    pub fn in_dst_location(&self, dst: &DstLocation) -> bool {
-        self.inner.in_dst_location(dst)
     }
 
     pub fn poll(&mut self) -> bool {
@@ -205,17 +197,12 @@ where
     let time_step = test_consts::GOSSIP_PERIOD + Duration::from_millis(1);
 
     for _ in 0..MAX_POLL_CALLS {
-        if poll_all(env, nodes) {
-            advance_time(time_step);
-            continue;
+        if predicate(nodes) {
+            return;
         }
 
-        if !predicate(nodes) {
-            advance_time(time_step);
-            continue;
-        }
-
-        return;
+        let _ = poll_all(env, nodes);
+        advance_time(time_step);
     }
 
     panic!("poll_until has been called {} times.", MAX_POLL_CALLS);

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -347,6 +347,26 @@ pub fn section_split(nodes: &[TestNode], prefix: &Prefix<XorName>) -> bool {
     }
 }
 
+// Returns whether consensus on the given user event has been reached by at least the given number
+// of nodes.
+// `current_count` must point to a variable that is initialized to zero before the polling starts.
+pub fn consensus_reached(
+    nodes: &[TestNode],
+    expected_content: &[u8],
+    expected_count: usize,
+    current_count: &mut usize,
+) -> bool {
+    for node in nodes {
+        if let Some(Event::Consensus(actual_content)) = node.try_recv_event() {
+            if &actual_content[..] == expected_content {
+                *current_count += 1;
+            }
+        }
+    }
+
+    *current_count >= expected_count
+}
+
 pub fn create_connected_nodes(env: &Environment, size: usize) -> Vec<TestNode> {
     let mut nodes = Vec::new();
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -222,15 +222,6 @@ where
 
 /// Polls and processes all events, until there are no unacknowledged messages left.
 pub fn poll_and_resend(nodes: &mut [TestNode]) {
-    poll_and_resend_with_options(nodes, |_| false)
-}
-
-/// Polls the network until all the nodes become idle.
-/// If `continue_if` is set, keeps polling until the predicate returns `false`.
-pub fn poll_and_resend_with_options<F>(nodes: &mut [TestNode], mut continue_if: F)
-where
-    F: FnMut(&[TestNode]) -> bool,
-{
     let env = nodes[0].env.clone();
 
     let node_busy = |node: &TestNode| node.inner.has_unpolled_observations();
@@ -242,10 +233,6 @@ where
 
     poll_until(&env, nodes, |nodes| {
         if nodes.iter().any(node_busy) {
-            return false;
-        }
-
-        if continue_if(nodes) {
             return false;
         }
 

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -252,6 +252,10 @@ fn advance_time(duration: Duration) {
 // Returns whether all nodes from its section recognize the node at the given index as joined.
 pub fn node_joined(nodes: &[TestNode], index: usize) -> bool {
     if !nodes[index].inner.is_approved() {
+        trace!(
+            "Node {} is not yet member according to itself",
+            nodes[index].name()
+        );
         return false;
     }
 
@@ -266,7 +270,18 @@ pub fn node_joined(nodes: &[TestNode], index: usize) -> bool {
                 .map(|prefix| prefix.matches(id.name()))
                 .unwrap_or(false)
         })
-        .all(|node| node.inner.is_peer_our_member(&id))
+        .all(|node| {
+            if node.inner.is_peer_our_member(&id) {
+                true
+            } else {
+                trace!(
+                    "Node {} is not yet member according to {}",
+                    id.name(),
+                    node.name()
+                );
+                false
+            }
+        })
 }
 
 pub fn all_nodes_joined(nodes: &[TestNode], indices: impl IntoIterator<Item = usize>) -> bool {

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -51,7 +51,6 @@ pub fn gen_elder_index<R: Rng>(rng: &mut R, nodes: &[TestNode]) -> usize {
 
 pub struct TestNode {
     pub inner: Node,
-    _env: Environment,
     user_event_rx: mpmc::Receiver<Event>,
 }
 
@@ -63,11 +62,10 @@ impl TestNode {
         }
     }
 
-    pub fn resume(env: &Environment, state: PausedState) -> Self {
+    pub fn resume(state: PausedState) -> Self {
         let (inner, user_event_rx) = Node::resume(state);
         Self {
             inner,
-            _env: env.clone(),
             user_event_rx,
         }
     }
@@ -168,7 +166,6 @@ impl<'a> TestNodeBuilder<'a> {
 
         TestNode {
             inner,
-            _env: self.env.clone(),
             user_event_rx,
         }
     }


### PR DESCRIPTION
This PR changes the testing strategy. Instead of using `poll_and_resend` which kept polling the network until some mythical "idle" state, we now have `poll_until` where the termination condition is specified explicitly. This condition differs from test to test - for example: "poll until node joined", "poll until node becomes elder", "poll until section splits", "poll until a message gets delivered", and so on.

Also the `verify_section_invariants_between_nodes` function was removed because it was based on unrealistic assumptions that all the nodes in the network can ever get to the same state at the same time. Instead of this, we now check only that the nodes got to a given state at some point, but never that they all are in it at the same time.

These changes uncovered a bug in the `JoinRequest` handling logic which this PR fixes.

This PR also removes some no longer needed hacks and workarounds resulting in slightly cleaner code.

Note this PR contains almost the minimal amount of change needed to achieve these goals. There is definitely room for further improvements, for example by making the tests more event-driven, etc...