### PR TITLE
Node ageing during network startup

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -376,7 +376,7 @@ impl Chain {
             our_prefix == Prefix::default() && our_section_size < self.safe_section_size();
 
         // As a measure against sybil attacks, we don't increment the age counters on infant churn
-        // once we are past the startup phase.
+        // once we completed the startup phase.
         if !startup
             && self
                 .state

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -16,7 +16,7 @@ impl AgeCounter {
     /// Create `AgeCounter` with the given age. Minimal valid age is `MIN_AGE` so if a smaller
     /// value is passed in, it's silently changed to `MIN_AGE`.
     pub fn from_age(age: u8) -> Self {
-        Self(2_u32.pow(u32::from(age.max(MIN_AGE))))
+        Self(2_u32.saturating_pow(u32::from(age.max(MIN_AGE))))
     }
 
     pub fn age(self) -> u8 {
@@ -80,6 +80,10 @@ impl MemberInfo {
     // Increment the age counter and return whether the age increased.
     pub fn increment_age_counter(&mut self) -> bool {
         self.age_counter.increment()
+    }
+
+    pub fn increment_age(&mut self) {
+        self.age_counter = AgeCounter::from_age(self.age_counter.age().saturating_add(1))
     }
 
     pub fn is_mature(&self) -> bool {

--- a/src/chain/member_info.rs
+++ b/src/chain/member_info.rs
@@ -20,7 +20,9 @@ impl AgeCounter {
     }
 
     pub fn age(self) -> u8 {
-        f64::from(self.0).log2() as u8
+        // This is the same as `(self.0 as f64).log2() as u8` but without floating point
+        // arithmetic.
+        (32 - self.0.leading_zeros() - 1) as u8
     }
 
     /// Increment the counter and return whether the age increased.
@@ -126,9 +128,10 @@ mod tests {
 
     #[test]
     fn age_counter_to_age() {
+        let max_age = 16;
         let mut age_counter = AgeCounter::default();
 
-        for age in MIN_AGE..16 {
+        for age in MIN_AGE..max_age {
             for _ in 0..2u32.pow(u32::from(age)) - 1 {
                 assert_eq!(age_counter.age(), age);
                 assert!(!age_counter.increment());
@@ -136,5 +139,7 @@ mod tests {
 
             assert!(age_counter.increment());
         }
+
+        assert_eq!(age_counter.age(), max_age);
     }
 }

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -172,7 +172,7 @@ fn startup_phase() {
     }
 }
 
-// Verify that the age counters of all the nodes in the root section are as expected assuming we
+// Verify that the age counters of all the nodes in the root section are as expected, assuming we
 // were only adding nodes, not removing.
 fn check_root_section_age_counters_after_only_adds(env: &Environment, nodes: &[TestNode]) -> bool {
     // Maximum number of churn events a node can experience during the startup phase:
@@ -191,7 +191,7 @@ fn check_root_section_age_counters_after_only_adds(env: &Environment, nodes: &[T
             "the root section has split"
         );
 
-        // The number of churn events the i-th node experienced during the startup phase.
+        // The number of churn events that the i-th node experienced during the startup phase.
         let startup_churn_events = max_startup_churn_events.saturating_sub(i) as u8;
 
         let expected_age = (MIN_AGE + startup_churn_events) as u32;


### PR DESCRIPTION
This PR changes the node ageing logic so during the network startup, all churn events cause age increments. 

Partially addresses #2078 