### PR TITLE
handle Relocate message also as elder

### DIFF
--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -242,7 +242,8 @@ impl Approved {
 
     pub fn should_handle_message(&self, msg: &Message) -> bool {
         match &msg.variant {
-            Variant::BootstrapRequest(_)
+            Variant::Relocate(_)
+            | Variant::BootstrapRequest(_)
             | Variant::MemberKnowledge(_)
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
@@ -255,7 +256,6 @@ impl Approved {
             }
 
             Variant::GenesisUpdate(info) => self.should_handle_genesis_update(info),
-            Variant::Relocate(_) => !self.chain.is_self_elder(),
 
             Variant::MessageSignature(accumulating_msg) => {
                 match &accumulating_msg.content.variant {


### PR DESCRIPTION
When relocating an elder, we first demote them to adult, then wait for a "relocation cool-down period" and only then send them the `Relocate` message. This makes it very unlikely that they would still see themselves as elder by the time they receive it. It's not impossible however and when it happens, the node must still proceed with the relocation because it must always obey section decisions. However, we weren't doing it and so this commit fixes it.