### PR TITLE
only handle UserMessage as non-elder if addressed directly to us

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,9 @@
 macro_rules! log_or_panic {
     ($log_level:expr, $($arg:tt)*) => {
         if cfg!(feature = "mock_base") && !::std::thread::panicking() {
-            panic!($($arg)*);
+            $crate::log_utils::with_ident(|ident| {
+                panic!("{}{}", ident, format_args!($($arg)*));
+            })
         } else {
             log!($log_level, $($arg)*);
         }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -558,7 +558,7 @@ impl Node {
         match &self.stage {
             Stage::Bootstrapping(stage) => stage.should_handle_message(msg),
             Stage::Joining(stage) => stage.should_handle_message(msg),
-            Stage::Approved(stage) => stage.should_handle_message(msg),
+            Stage::Approved(stage) => stage.should_handle_message(self.core.id(), msg),
             Stage::Terminated => false,
         }
     }


### PR DESCRIPTION
Messages for `DstLocation::Section` or `DstLocation::Prefix` are only meant to be handled by elders and could fail validation if attempted to be handled by non-elder.

Also use the log ident in the panic branch of the `log_or_panic` macro.