### PR TITLE
Miscellaneous minor refactoring

### DIFF
--- a/src/consensus/event_accumulator.rs
+++ b/src/consensus/event_accumulator.rs
@@ -354,7 +354,8 @@ mod test {
             EventType::WithSignature => {
                 let elders_info = empty_elders_info();
                 let (sig_payload, keys) = random_section_info_sig_payload(rng);
-                let key_info = SectionKeyInfo::from_elders_info(&elders_info, keys.public_key());
+                let key_info =
+                    SectionKeyInfo::new(elders_info.prefix, elders_info.version, keys.public_key());
                 let event = AccumulatingEvent::SectionInfo(elders_info, key_info);
 
                 TestData {

--- a/src/consensus/event_accumulator.rs
+++ b/src/consensus/event_accumulator.rs
@@ -303,7 +303,7 @@ mod test {
     }
 
     fn empty_elders_info() -> EldersInfo {
-        EldersInfo::new(Default::default(), Default::default(), Default::default()).unwrap()
+        EldersInfo::new(Default::default(), Default::default(), Default::default())
     }
 
     fn random_section_info_sig_payload(rng: &mut MainRng) -> (EventSigPayload, bls::PublicKeySet) {

--- a/src/consensus/event_accumulator.rs
+++ b/src/consensus/event_accumulator.rs
@@ -303,11 +303,7 @@ mod test {
     }
 
     fn empty_elders_info() -> EldersInfo {
-        unwrap!(EldersInfo::new_for_test(
-            Default::default(),
-            Default::default(),
-            Default::default(),
-        ))
+        EldersInfo::new(Default::default(), Default::default(), Default::default()).unwrap()
     }
 
     fn random_section_info_sig_payload(rng: &mut MainRng) -> (EventSigPayload, bls::PublicKeySet) {

--- a/src/consensus/genesis_prefix_info.rs
+++ b/src/consensus/genesis_prefix_info.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    id::PublicId,
     section::{AgeCounter, EldersInfo},
+    xor_space::XorName,
 };
 use std::{
     collections::BTreeMap,
@@ -21,7 +21,7 @@ pub struct GenesisPrefixInfo {
     pub elders_info: EldersInfo,
     pub public_keys: bls::PublicKeySet,
     pub state_serialized: Vec<u8>,
-    pub ages: BTreeMap<PublicId, AgeCounter>,
+    pub ages: BTreeMap<XorName, AgeCounter>,
     pub parsec_version: u64,
 }
 

--- a/src/consensus/genesis_prefix_info.rs
+++ b/src/consensus/genesis_prefix_info.rs
@@ -20,21 +20,8 @@ use std::{
 pub struct GenesisPrefixInfo {
     pub elders_info: EldersInfo,
     pub public_keys: bls::PublicKeySet,
-    pub state_serialized: Vec<u8>,
     pub ages: BTreeMap<XorName, AgeCounter>,
     pub parsec_version: u64,
-}
-
-impl GenesisPrefixInfo {
-    pub fn trimmed(&self) -> Self {
-        Self {
-            elders_info: self.elders_info.clone(),
-            public_keys: self.public_keys.clone(),
-            state_serialized: Vec::new(),
-            ages: self.ages.clone(),
-            parsec_version: self.parsec_version,
-        }
-    }
 }
 
 impl Debug for GenesisPrefixInfo {

--- a/src/consensus/genesis_prefix_info.rs
+++ b/src/consensus/genesis_prefix_info.rs
@@ -42,9 +42,7 @@ impl Debug for GenesisPrefixInfo {
         write!(
             formatter,
             "GenesisPrefixInfo({:?}, elders_version: {}, parsec_version: {})",
-            self.elders_info.prefix(),
-            self.elders_info.version(),
-            self.parsec_version,
+            self.elders_info.prefix, self.elders_info.version, self.parsec_version,
         )
     }
 }

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -53,10 +53,12 @@ impl ConsensusEngine {
     pub fn new(
         rng: &mut MainRng,
         full_id: FullId,
-        genesis_prefix_info: &GenesisPrefixInfo,
+        elders_info: &EldersInfo,
+        serialised_state: Vec<u8>,
+        parsec_version: u64,
     ) -> Self {
         let mut parsec_map = ParsecMap::default();
-        parsec_map.init(rng, full_id, genesis_prefix_info);
+        parsec_map.init(rng, full_id, elders_info, serialised_state, parsec_version);
 
         Self {
             parsec_map,
@@ -246,9 +248,12 @@ impl ConsensusEngine {
         &mut self,
         rng: &mut MainRng,
         full_id: FullId,
-        genesis_prefix_info: &GenesisPrefixInfo,
+        elders_info: &EldersInfo,
+        serialised_state: Vec<u8>,
+        parsec_version: u64,
     ) {
-        self.parsec_map.init(rng, full_id, genesis_prefix_info)
+        self.parsec_map
+            .init(rng, full_id, elders_info, serialised_state, parsec_version)
     }
 
     pub fn detect_unresponsive<'a>(

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -185,25 +185,8 @@ impl ConsensusEngine {
         our_elders: &EldersInfo,
     ) -> bool {
         match event {
-            AccumulatingEvent::SectionInfo(info, _) => {
-                if !our_elders.is_quorum(proofs) {
-                    return false;
-                }
-
-                if !info.is_successor_of(our_elders) {
-                    log_or_panic!(
-                        log::Level::Error,
-                        "We shouldn't have a SectionInfo that is not a direct descendant. our: \
-                         {:?}, new: {:?}",
-                        our_elders,
-                        info
-                    );
-                }
-
-                true
-            }
-
-            AccumulatingEvent::Online(_)
+            AccumulatingEvent::SectionInfo(..)
+            | AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::NeighbourInfo(_)
             | AccumulatingEvent::TheirKeyInfo(_)

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -377,7 +377,8 @@ fn create(rng: &mut MainRng, full_id: FullId, genesis_prefix_info: &GenesisPrefi
     #[cfg(feature = "mock")]
     let hash = {
         let fields = (
-            genesis_prefix_info.elders_info.hash(),
+            genesis_prefix_info.elders_info.prefix(),
+            genesis_prefix_info.elders_info.version(),
             genesis_prefix_info.parsec_version,
         );
         crypto::sha3_256(&unwrap!(bincode::serialize(&fields)))
@@ -482,13 +483,14 @@ mod tests {
         let socket_addr: SocketAddr = ([127, 0, 0, 1], 9999).into();
         let members = full_ids
             .iter()
-            .map(|id| (*id.public_id(), P2pNode::new(*id.public_id(), socket_addr)))
+            .map(|id| {
+                (
+                    *id.public_id().name(),
+                    P2pNode::new(*id.public_id(), socket_addr),
+                )
+            })
             .collect();
-        let elders_info = unwrap!(EldersInfo::new_for_test(
-            members,
-            Prefix::<XorName>::default(),
-            version
-        ));
+        let elders_info = EldersInfo::new(members, Prefix::<XorName>::default(), version).unwrap();
         let ages = elders_info
             .elder_ids()
             .map(|pub_id| (*pub_id, MIN_AGE_COUNTER))

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -493,8 +493,9 @@ mod tests {
             .collect();
         let elders_info = EldersInfo::new(members, Prefix::<XorName>::default(), version);
         let ages = elders_info
-            .elder_ids()
-            .map(|pub_id| (*pub_id, MIN_AGE_COUNTER))
+            .elders
+            .keys()
+            .map(|name| (*name, MIN_AGE_COUNTER))
             .collect();
         GenesisPrefixInfo {
             elders_info,

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -14,7 +14,7 @@ use crate::{
     time::Duration,
 };
 #[cfg(feature = "mock")]
-use crate::{crypto, mock::parsec as inner, unwrap};
+use crate::{crypto, mock::parsec as inner};
 #[cfg(not(feature = "mock"))]
 use parsec as inner;
 #[cfg(all(test, feature = "mock"))]
@@ -377,11 +377,11 @@ fn create(rng: &mut MainRng, full_id: FullId, genesis_prefix_info: &GenesisPrefi
     #[cfg(feature = "mock")]
     let hash = {
         let fields = (
-            genesis_prefix_info.elders_info.prefix(),
-            genesis_prefix_info.elders_info.version(),
+            genesis_prefix_info.elders_info.prefix,
+            genesis_prefix_info.elders_info.version,
             genesis_prefix_info.parsec_version,
         );
-        crypto::sha3_256(&unwrap!(bincode::serialize(&fields)))
+        crypto::sha3_256(&bincode::serialize(&fields).unwrap())
     };
 
     if genesis_prefix_info

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -386,7 +386,8 @@ fn create(rng: &mut MainRng, full_id: FullId, genesis_prefix_info: &GenesisPrefi
 
     if genesis_prefix_info
         .elders_info
-        .contains_elder(full_id.public_id())
+        .elders
+        .contains_key(full_id.public_id().name())
     {
         Parsec::from_genesis(
             #[cfg(feature = "mock")]

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -490,7 +490,7 @@ mod tests {
                 )
             })
             .collect();
-        let elders_info = EldersInfo::new(members, Prefix::<XorName>::default(), version).unwrap();
+        let elders_info = EldersInfo::new(members, Prefix::<XorName>::default(), version);
         let ages = elders_info
             .elder_ids()
             .map(|pub_id| (*pub_id, MIN_AGE_COUNTER))

--- a/src/consensus/proof.rs
+++ b/src/consensus/proof.rs
@@ -9,8 +9,6 @@
 use crate::{crypto::signing::Signature, id::PublicId};
 #[cfg(test)]
 use crate::{error::Result, id::FullId};
-#[cfg(any(test, feature = "mock_base"))]
-use bincode::serialize;
 use itertools::Itertools;
 use serde::Serialize;
 use std::{
@@ -38,9 +36,8 @@ impl Proof {
 
     /// Create a new proof for `payload`
     #[cfg(test)]
-    #[allow(clippy::new_ret_no_self)]
     pub fn new<S: Serialize>(full_id: &FullId, payload: &S) -> Result<Self> {
-        let sig = full_id.sign(&serialize(&payload)?[..]);
+        let sig = full_id.sign(&bincode::serialize(&payload)?[..]);
         Ok(Self {
             pub_id: *full_id.public_id(),
             sig,
@@ -48,9 +45,9 @@ impl Proof {
     }
 
     /// Validates `payload` against this `Proof`'s `key` and `sig`.
-    #[cfg(any(test, feature = "mock_base"))]
+    #[cfg(test)]
     pub fn validate_signature<S: Serialize>(&self, payload: &S) -> bool {
-        match serialize(payload) {
+        match bincode::serialize(payload) {
             Ok(data) => self.pub_id.verify(&data[..], &self.sig),
             _ => false,
         }
@@ -81,36 +78,9 @@ impl ProofSet {
         self.sigs.contains_key(id)
     }
 
-    /// Validates `payload` against all signatures.
-    #[cfg(feature = "mock_base")]
-    pub fn validate_signatures<S: Serialize>(&self, payload: &S) -> bool {
-        match serialize(payload) {
-            Ok(data) => self.validate_signatures_for_bytes(data.as_slice()),
-            _ => false,
-        }
-    }
-
-    /// Validates `data` against all signatures.
-    #[cfg(feature = "mock_base")]
-    fn validate_signatures_for_bytes(&self, data: &[u8]) -> bool {
-        self.sigs.iter().all(|(id, sig)| id.verify(data, sig))
-    }
-
     /// Returns an iterator of all public IDs that have signed.
     pub fn ids(&self) -> impl Iterator<Item = &PublicId> {
         self.sigs.keys()
-    }
-
-    /// Removes the node's signature. Returns `false` if it already didn't exist.
-    #[cfg(feature = "mock_base")]
-    pub fn remove(&mut self, id: &PublicId) -> bool {
-        self.sigs.remove(id).is_some()
-    }
-
-    /// Merges the other proof set into this one.
-    #[cfg(feature = "mock_base")]
-    pub fn merge(&mut self, other: Self) {
-        self.sigs.extend(other.sigs);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,7 @@ pub use self::{
     network_params::NetworkParams,
     relocation::Overrides as RelocationOverrides,
     routing_table::delivery_group_size,
-    section::{
-        elders_info_for_test, quorum_count, section_proof_slice_for_test, SectionKeyShare, MIN_AGE,
-    },
+    section::{quorum_count, section_proof_slice_for_test, EldersInfo, SectionKeyShare, MIN_AGE},
     xor_space::Xorable,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,11 +169,11 @@ const QUORUM_NUMERATOR: usize = 2;
 /// See `QUORUM_NUMERATOR`.
 const QUORUM_DENOMINATOR: usize = 3;
 
-/// Minimal safe section size. Routing will keep adding nodes until the section reaches this size.
+/// Recommended section size. Routing will keep adding nodes until the section reaches this size.
 /// More nodes might be added if requested by the upper layers.
 /// This number also detemines when split happens - if both post-split sections would have at least
 /// this number of nodes.
-const SAFE_SECTION_SIZE: usize = 100;
+const RECOMMENDED_SECTION_SIZE: usize = 100;
 
 /// Number of elders per section.
 const ELDER_SIZE: usize = 7;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ const QUORUM_DENOMINATOR: usize = 3;
 /// More nodes might be added if requested by the upper layers.
 /// This number also detemines when split happens - if both post-split sections would have at least
 /// this number of nodes.
-const RECOMMENDED_SECTION_SIZE: usize = 100;
+const RECOMMENDED_SECTION_SIZE: usize = 60;
 
 /// Number of elders per section.
 const ELDER_SIZE: usize = 7;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,9 @@ pub use self::{
     network_params::NetworkParams,
     relocation::Overrides as RelocationOverrides,
     routing_table::delivery_group_size,
-    section::{quorum_count, section_proof_slice_for_test, EldersInfo, SectionKeyShare, MIN_AGE},
+    section::{
+        quorum_count, EldersInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain, MIN_AGE,
+    },
     xor_space::Xorable,
 };
 

--- a/src/messages/accumulating_message.rs
+++ b/src/messages/accumulating_message.rs
@@ -262,9 +262,9 @@ mod tests {
     }
 
     fn make_section_key_info(pk_set: &bls::PublicKeySet) -> SectionKeyInfo {
-        let version = 0u64;
         let prefix = Prefix::default();
-        SectionKeyInfo::new(version, prefix, pk_set.public_key())
+        let version = 0u64;
+        SectionKeyInfo::new(prefix, version, pk_set.public_key())
     }
 
     fn make_proof_chain(pk_set: &bls::PublicKeySet) -> SectionProofChain {
@@ -275,7 +275,7 @@ mod tests {
         pk_set: &bls::PublicKeySet,
     ) -> BTreeMap<Prefix<XorName>, SectionKeyInfo> {
         let key_info = make_section_key_info(pk_set);
-        iter::once((*key_info.prefix(), key_info)).collect()
+        iter::once((key_info.prefix, key_info)).collect()
     }
 
     fn gen_message(rng: &mut MainRng) -> PlainMessage {

--- a/src/messages/accumulating_message.rs
+++ b/src/messages/accumulating_message.rs
@@ -9,7 +9,7 @@
 use super::{DstLocation, Message, MessageHash, SrcAuthority, Variant};
 use crate::{
     error::Result,
-    section::{SectionKeyShare, SectionProofSlice},
+    section::{SectionKeyShare, SectionProofChain},
     xor_space::{Prefix, XorName},
 };
 use bincode::serialize;
@@ -22,7 +22,7 @@ use std::{collections::BTreeSet, mem};
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 pub struct AccumulatingMessage {
     pub content: PlainMessage,
-    pub proof: SectionProofSlice,
+    pub proof: SectionProofChain,
     pub public_key_set: bls::PublicKeySet,
     pub signature_shares: BTreeSet<(usize, bls::SignatureShare)>,
 }
@@ -33,7 +33,7 @@ impl AccumulatingMessage {
         content: PlainMessage,
         section_share: &SectionKeyShare,
         public_key_set: bls::PublicKeySet,
-        proof: SectionProofSlice,
+        proof: SectionProofChain,
     ) -> Result<Self> {
         let bytes = content.serialize_for_signing()?;
         let mut signature_shares = BTreeSet::new();
@@ -267,8 +267,8 @@ mod tests {
         SectionKeyInfo::new(version, prefix, pk_set.public_key())
     }
 
-    fn make_proof_chain(pk_set: &bls::PublicKeySet) -> SectionProofSlice {
-        SectionProofSlice::from_genesis(make_section_key_info(pk_set))
+    fn make_proof_chain(pk_set: &bls::PublicKeySet) -> SectionProofChain {
+        SectionProofChain::new(make_section_key_info(pk_set))
     }
 
     fn make_their_key_infos(

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -96,7 +96,7 @@ impl Message {
     pub fn source_section_key_info(&self) -> Option<&SectionKeyInfo> {
         match &self.src {
             SrcAuthority::Node { .. } => None,
-            SrcAuthority::Section { proof, .. } => proof.last_key_info(),
+            SrcAuthority::Section { proof, .. } => Some(proof.last_key_info()),
         }
     }
 

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{Result, RoutingError},
     id::{P2pNode, PublicId},
     location::{DstLocation, SrcLocation},
-    section::{SectionKeyInfo, SectionProofSlice, TrustStatus},
+    section::{SectionKeyInfo, SectionProofChain, TrustStatus},
     xor_space::{Prefix, XorName},
 };
 use std::net::SocketAddr;
@@ -26,7 +26,7 @@ pub enum SrcAuthority {
     Section {
         prefix: Prefix<XorName>,
         signature: bls::Signature,
-        proof: SectionProofSlice,
+        proof: SectionProofChain,
     },
 }
 

--- a/src/mock/env.rs
+++ b/src/mock/env.rs
@@ -76,9 +76,9 @@ impl Environment {
         self.network_params.elder_size
     }
 
-    /// Get the safe section size
-    pub fn safe_section_size(&self) -> usize {
-        self.network_params.safe_section_size
+    /// Get the recommended section size
+    pub fn recommended_section_size(&self) -> usize {
+        self.network_params.recommended_section_size
     }
 
     /// Poll the mock network.

--- a/src/network_params.rs
+++ b/src/network_params.rs
@@ -6,22 +6,22 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{ELDER_SIZE, SAFE_SECTION_SIZE};
+use crate::{ELDER_SIZE, RECOMMENDED_SECTION_SIZE};
 
-/// Network parameters: number of elders, safe section size
+/// Network parameters: number of elders, recommended section size
 #[derive(Clone, Copy, Debug)]
 pub struct NetworkParams {
     /// The number of elders per section
     pub elder_size: usize,
-    /// Minimum number of nodes we consider safe in a section
-    pub safe_section_size: usize,
+    /// Recommended number of nodes in a section.
+    pub recommended_section_size: usize,
 }
 
 impl Default for NetworkParams {
     fn default() -> Self {
         Self {
             elder_size: ELDER_SIZE,
-            safe_section_size: SAFE_SECTION_SIZE,
+            recommended_section_size: RECOMMENDED_SECTION_SIZE,
         }
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -758,7 +758,7 @@ impl Node {
             Stage::Approved(stage) => stage
                 .shared_state
                 .find_section_by_member(sender.public_id())
-                .map(|info| info.version()),
+                .map(|info| info.version),
             Stage::Terminated => unreachable!(),
         };
 
@@ -827,7 +827,7 @@ impl Node {
     fn approve(&mut self, connect_type: Connected, genesis_prefix_info: GenesisPrefixInfo) {
         info!(
             "This node has been approved to join the network at {:?}!",
-            genesis_prefix_info.elders_info.prefix(),
+            genesis_prefix_info.elders_info.prefix,
         );
 
         let stage = Approved::new(&mut self.core, genesis_prefix_info, None);
@@ -867,15 +867,15 @@ impl Node {
                 buffer,
                 "{}({:b}v{}?) ",
                 self.name(),
-                stage.target_section_elders_info().prefix(),
-                stage.target_section_elders_info().version(),
+                stage.target_section_elders_info().prefix,
+                stage.target_section_elders_info().version,
             ),
             Stage::Approved(stage) => write!(
                 buffer,
                 "{}({:b}v{}{}) ",
                 self.core.name(),
                 stage.shared_state.our_prefix(),
-                stage.shared_state.our_info().version(),
+                stage.shared_state.our_info().version,
                 if stage.is_our_elder(self.core.id()) {
                     "!"
                 } else {
@@ -940,8 +940,7 @@ impl Node {
                 state
                     .sections
                     .other()
-                    .map(|(_, info)| info.prefix())
-                    .copied()
+                    .map(|(_, info)| info.prefix)
                     .collect()
             })
             .unwrap_or_default()
@@ -960,7 +959,7 @@ impl Node {
     pub fn section_elder_info_version(&self, prefix: &Prefix<XorName>) -> Option<u64> {
         self.shared_state()
             .and_then(|state| state.sections.get(prefix))
-            .map(|info| info.version())
+            .map(|info| info.version)
     }
 
     /// Returns the elders of a section with the given prefix.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -283,7 +283,8 @@ impl Node {
                     .shared_state
                     .sections
                     .our()
-                    .contains_elder(self.core.id())
+                    .elders
+                    .contains_key(self.core.name())
             })
             .unwrap_or(false)
     }
@@ -307,7 +308,7 @@ impl Node {
         self.stage
             .approved()
             .into_iter()
-            .flat_map(move |stage| stage.shared_state.sections.closest(name).1.elder_nodes())
+            .flat_map(move |stage| stage.shared_state.sections.closest(name).1.elders.values())
     }
 
     /// Returns the information of all the current section adults.
@@ -967,7 +968,7 @@ impl Node {
     pub fn section_elders(&self, prefix: &Prefix<XorName>) -> BTreeSet<XorName> {
         self.shared_state()
             .and_then(|state| state.sections.get(prefix))
-            .map(|info| info.elder_names().copied().collect())
+            .map(|info| info.elders.keys().copied().collect())
             .unwrap_or_default()
     }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1044,8 +1044,8 @@ impl Node {
 
     /// Size at which our section splits. Since this is configurable, this method is used to
     /// obtain it.
-    pub fn safe_section_size(&self) -> usize {
-        self.core.network_params.safe_section_size
+    pub fn recommended_section_size(&self) -> usize {
+        self.core.network_params.recommended_section_size
     }
 
     /// Provide a SectionProofSlice that proves the given signature to the given destination.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 #[cfg(feature = "mock_base")]
 use {
-    crate::section::{SectionProofSlice, SharedState},
+    crate::section::{SectionProofChain, SharedState},
     std::collections::{BTreeMap, BTreeSet},
 };
 
@@ -1049,7 +1049,7 @@ impl Node {
     }
 
     /// Provide a SectionProofSlice that proves the given signature to the given destination.
-    pub fn prove(&self, target: &DstLocation) -> Option<SectionProofSlice> {
+    pub fn prove(&self, target: &DstLocation) -> Option<SectionProofChain> {
         self.shared_state().map(|state| state.prove(target, None))
     }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -758,7 +758,7 @@ impl Node {
             }
             Stage::Approved(stage) => stage
                 .shared_state
-                .find_section_by_member(sender.public_id())
+                .find_section_by_member(sender.name())
                 .map(|info| info.version),
             Stage::Terminated => unreachable!(),
         };
@@ -985,16 +985,16 @@ impl Node {
     }
 
     /// Returns whether the given peer is an elder known to us.
-    pub fn is_peer_elder(&self, pub_id: &PublicId) -> bool {
+    pub fn is_peer_elder(&self, name: &XorName) -> bool {
         self.shared_state()
-            .map(|state| state.is_peer_elder(pub_id))
+            .map(|state| state.is_peer_elder(name))
             .unwrap_or(false)
     }
 
     /// Returns whether the given peer is an elder of our section.
-    pub fn is_peer_our_elder(&self, pub_id: &PublicId) -> bool {
+    pub fn is_peer_our_elder(&self, name: &XorName) -> bool {
         self.shared_state()
-            .map(|state| state.is_peer_our_elder(pub_id))
+            .map(|state| state.is_peer_our_elder(name))
             .unwrap_or(false)
     }
 
@@ -1005,10 +1005,10 @@ impl Node {
             .flat_map(|state| state.known_nodes())
     }
 
-    /// Returns whether the given `PublicId` is a member of our section.
-    pub fn is_peer_our_member(&self, id: &PublicId) -> bool {
+    /// Returns whether the given `XorName` is a member of our section.
+    pub fn is_peer_our_member(&self, name: &XorName) -> bool {
         self.shared_state()
-            .map(|state| state.our_members.contains(id))
+            .map(|state| state.our_members.contains(name))
             .unwrap_or(false)
     }
 

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -562,7 +562,7 @@ impl Approved {
                 return;
             }
 
-            (details.age, Some(details.destination_key_info.version()))
+            (details.age, Some(details.destination_key_info.version))
         } else {
             (MIN_AGE, None)
         };
@@ -1311,8 +1311,8 @@ impl Approved {
         }
 
         self.vote_for_send_ack_message(SendAckMessagePayload {
-            ack_prefix: *key_info.prefix(),
-            ack_version: key_info.version(),
+            ack_prefix: key_info.prefix,
+            ack_version: key_info.version,
         });
         Ok(())
     }
@@ -1555,7 +1555,7 @@ impl Approved {
         elders_info: EldersInfo,
         section_key: bls::PublicKey,
     ) -> Result<(), RoutingError> {
-        let key_info = SectionKeyInfo::from_elders_info(&elders_info, section_key);
+        let key_info = SectionKeyInfo::new(elders_info.prefix, elders_info.version, section_key);
         let signature_payload = EventSigPayload::new_for_section_key_info(
             &self.section_keys_provider.secret_key_share()?.key,
             &key_info,
@@ -1569,7 +1569,7 @@ impl Approved {
 
     fn vote_for_send_ack_message(&mut self, ack_payload: SendAckMessagePayload) {
         let has_their_keys = self.shared_state.sections.keys().any(|(_, info)| {
-            *info.prefix() == ack_payload.ack_prefix && info.version() == ack_payload.ack_version
+            info.prefix == ack_payload.ack_prefix && info.version == ack_payload.ack_version
         });
 
         if has_their_keys {
@@ -1951,8 +1951,8 @@ impl Approved {
             .shared_state
             .sections
             .keys()
-            .find(|(prefix, _)| prefix.is_compatible(key_info.prefix()))
-            .map_or(false, |(_, info)| info.version() < key_info.version());
+            .find(|(prefix, _)| prefix.is_compatible(&key_info.prefix))
+            .map_or(false, |(_, info)| info.version < key_info.version);
 
         if new_key_info {
             self.vote_for_event(AccumulatingEvent::TheirKeyInfo(key_info.clone()));

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -2012,7 +2012,7 @@ pub struct RelocateParams {
 fn create_first_elders_info(p2p_node: P2pNode) -> Result<EldersInfo> {
     let name = *p2p_node.name();
     let node = (name, p2p_node);
-    EldersInfo::new(iter::once(node).collect(), Prefix::default(), None).map_err(|err| {
+    EldersInfo::new(iter::once(node).collect(), Prefix::default(), 0).map_err(|err| {
         error!(
             "FirstNode({:?}) - Failed to create first EldersInfo: {:?}",
             name, err

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1258,7 +1258,7 @@ impl Approved {
         self.section_keys_provider
             .finalise_dkg(our_id, &elders_info)?;
         self.shared_state
-            .push_our_new_info(elders_info, proof_block);
+            .update_our_section(elders_info, proof_block);
         self.churn_in_progress = false;
         Ok(())
     }

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -121,7 +121,7 @@ impl Approved {
             ConsensusEngine::new(&mut core.rng, core.full_id.clone(), &genesis_prefix_info);
         let shared_state = SharedState::new(
             genesis_prefix_info.elders_info.clone(),
-            genesis_prefix_info.public_keys.clone(),
+            genesis_prefix_info.public_keys.public_key(),
             genesis_prefix_info.ages.clone(),
         );
 
@@ -1509,7 +1509,7 @@ impl Approved {
         );
         self.shared_state = SharedState::new(
             genesis_prefix_info.elders_info.clone(),
-            genesis_prefix_info.public_keys.clone(),
+            genesis_prefix_info.public_keys.public_key(),
             genesis_prefix_info.ages.clone(),
         );
         self.genesis_prefix_info = genesis_prefix_info;

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -976,7 +976,7 @@ impl Approved {
         if self.shared_state.add_member(
             payload.p2p_node.clone(),
             payload.age,
-            core.network_params.safe_section_size,
+            core.network_params.recommended_section_size,
         ) {
             info!("handle Online: {:?}.", payload);
 
@@ -1002,7 +1002,7 @@ impl Approved {
 
         if let (Some(addr), _) = self
             .shared_state
-            .remove_member(&pub_id, core.network_params.safe_section_size)
+            .remove_member(&pub_id, core.network_params.recommended_section_size)
         {
             info!("handle Offline: {}", pub_id);
 
@@ -1038,7 +1038,10 @@ impl Approved {
     ) -> Result<(), RoutingError> {
         let node_knowledge = match self
             .shared_state
-            .remove_member(&details.pub_id, core.network_params.safe_section_size)
+            .remove_member(
+                &details.pub_id,
+                core.network_params.recommended_section_size,
+            )
             .1
         {
             MemberState::Relocating { node_knowledge } => {

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -196,7 +196,7 @@ impl Bootstrapping {
         // Use a name that will match the destination even after multiple splits
         let extra_split_count = 3;
         let name_prefix = Prefix::new(
-            elders_info.prefix().bit_count() + extra_split_count,
+            elders_info.prefix.bit_count() + extra_split_count,
             destination,
         );
 

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -62,7 +62,12 @@ impl Joining {
         if join_token == token {
             debug!("Timeout when trying to join a section.");
 
-            for addr in self.elders_info.elder_nodes().map(|node| *node.peer_addr()) {
+            for addr in self
+                .elders_info
+                .elders
+                .values()
+                .map(|node| *node.peer_addr())
+            {
                 core.transport.disconnect(addr);
             }
 
@@ -193,7 +198,7 @@ impl Joining {
             JoinType::Relocate(payload) => Some(payload),
         };
 
-        for dst in self.elders_info.elder_nodes() {
+        for dst in self.elders_info.elders.values() {
             let join_request = JoinRequest {
                 elders_version: self.elders_info.version,
                 relocate_payload: relocate_payload.cloned(),

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -99,11 +99,11 @@ impl Joining {
         sender: P2pNode,
         new_elders_info: EldersInfo,
     ) -> Result<()> {
-        if new_elders_info.version() <= self.elders_info.version() {
+        if new_elders_info.version <= self.elders_info.version {
             return Ok(());
         }
 
-        if new_elders_info.prefix().matches(core.name()) {
+        if new_elders_info.prefix.matches(core.name()) {
             info!(
                 "Newer Join response for our prefix {:?} from {:?}",
                 new_elders_info, sender
@@ -195,7 +195,7 @@ impl Joining {
 
         for dst in self.elders_info.elder_nodes() {
             let join_request = JoinRequest {
-                elders_version: self.elders_info.version(),
+                elders_version: self.elders_info.version,
                 relocate_payload: relocate_payload.cloned(),
             };
 

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -236,5 +236,5 @@ fn as_iter(
 ) -> impl Iterator<Item = (&Prefix<XorName>, &SectionKeyInfo)> {
     key_info
         .into_iter()
-        .map(|key_info| (key_info.prefix(), key_info))
+        .map(|key_info| (&key_info.prefix, key_info))
 }

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -121,7 +121,7 @@ fn create_elders(
         .map(|(index, (_, full_id))| {
             let state = SharedState::new(
                 genesis_prefix_info.elders_info.clone(),
-                genesis_prefix_info.public_keys.clone(),
+                genesis_prefix_info.public_keys.public_key(),
                 genesis_prefix_info.ages.clone(),
             );
             let section_keys_provider = SectionKeysProvider::new(

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -76,7 +76,7 @@ impl Env {
     }
 
     fn perform_elders_change(&mut self) {
-        let current_version = self.elders[0].state.our_info().version();
+        let current_version = self.elders[0].state.our_info().version;
         self.elders = create_elders(&mut self.rng, &self.network, current_version + 1);
     }
 

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -25,7 +25,7 @@ use std::net::SocketAddr;
 const ELDER_SIZE: usize = 3;
 const NETWORK_PARAMS: NetworkParams = NetworkParams {
     elder_size: ELDER_SIZE,
-    safe_section_size: ELDER_SIZE + 1,
+    recommended_section_size: ELDER_SIZE + 1,
 };
 
 struct Env {

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -20,7 +20,7 @@ use crate::{
     quic_p2p,
     rng::{self, MainRng},
     section::MIN_AGE,
-    section::{EldersInfo, SectionKeyInfo, SectionProofSlice},
+    section::{EldersInfo, SectionKeyInfo, SectionProofChain},
     utils, ELDER_SIZE,
 };
 use crossbeam_channel::Receiver;
@@ -521,22 +521,22 @@ fn send_genesis_update() {
     verify_proof_chain_does_not_contain(proof, orig_elders_version);
 }
 
-fn verify_proof_chain_contains(proof_chain: &SectionProofSlice, expected_version: u64) {
+fn verify_proof_chain_contains(proof_chain: &SectionProofChain, expected_version: u64) {
     assert!(
         proof_chain
-            .all_prefix_version()
-            .any(|(_, version)| version == expected_version),
+            .key_infos()
+            .any(|info| info.version() == expected_version),
         "{:?} doesn't contain expected version {}",
         proof_chain,
         expected_version,
     );
 }
 
-fn verify_proof_chain_does_not_contain(proof_chain: &SectionProofSlice, unexpected_version: u64) {
+fn verify_proof_chain_does_not_contain(proof_chain: &SectionProofChain, unexpected_version: u64) {
     assert!(
         proof_chain
-            .all_prefix_version()
-            .all(|(_, version)| version != unexpected_version),
+            .key_infos()
+            .all(|info| info.version() != unexpected_version),
         "{:?} contains unexpected version {}",
         proof_chain,
         unexpected_version,

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -55,7 +55,7 @@ impl Env {
         let network = Network::new();
 
         let (elders_info, full_ids) =
-            test_utils::create_elders_info(&mut rng, &network, sec_size, None);
+            test_utils::create_elders_info(&mut rng, &network, sec_size, 0);
         let secret_key_set = generate_bls_threshold_secret_key(&mut rng, full_ids.len());
         let genesis_prefix_info = test_utils::create_genesis_prefix_info(
             elders_info.clone(),
@@ -282,7 +282,7 @@ impl Env {
                 .map(|node| (*node.public_id().name(), node.clone()))
                 .collect(),
             *self.elders_info.prefix(),
-            Some(&self.elders_info),
+            self.elders_info.version() + 1,
         )
         .unwrap();
 
@@ -294,7 +294,7 @@ impl Env {
         let new_elder_info = EldersInfo::new(
             self.elders_info.elder_map().clone(),
             *old_info.new_elders_info.prefix(),
-            Some(&old_info.new_elders_info),
+            old_info.new_elders_info.version() + 1,
         )
         .unwrap();
         self.updated_other_ids(new_elder_info)
@@ -329,7 +329,7 @@ impl Env {
         let new_elders_info = EldersInfo::new(
             new_member_map,
             *self.elders_info.prefix(),
-            Some(&self.elders_info),
+            self.elders_info.version() + 1,
         )
         .unwrap();
         self.updated_other_ids(new_elders_info)

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -271,13 +271,14 @@ impl Env {
 
     fn new_elders_info_with_candidate(&mut self) -> DkgToSectionInfo {
         assert!(
-            self.elders_info.num_elders() < ELDER_SIZE,
+            self.elders_info.elders.len() < ELDER_SIZE,
             "There is already ELDER_SIZE elders - the candidate won't be promoted"
         );
 
         let new_elder_info = EldersInfo::new(
             self.elders_info
-                .elder_nodes()
+                .elders
+                .values()
                 .chain(iter::once(&self.candidate))
                 .map(|node| (*node.public_id().name(), node.clone()))
                 .collect(),
@@ -291,7 +292,7 @@ impl Env {
     fn new_elders_info_without_candidate(&mut self) -> DkgToSectionInfo {
         let old_info = self.new_elders_info_with_candidate();
         let new_elder_info = EldersInfo::new(
-            self.elders_info.elder_map().clone(),
+            self.elders_info.elders.clone(),
             old_info.new_elders_info.prefix,
             old_info.new_elders_info.version + 1,
         );
@@ -314,7 +315,7 @@ impl Env {
 
         let new_member_map = self
             .elders_info
-            .elder_map()
+            .elders
             .iter()
             .filter(|(_, node)| node.public_id() != dropped_elder_id)
             .map(|(name, node)| (*name, node.clone()))

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -283,8 +283,7 @@ impl Env {
                 .collect(),
             *self.elders_info.prefix(),
             self.elders_info.version() + 1,
-        )
-        .unwrap();
+        );
 
         self.updated_other_ids(new_elder_info)
     }
@@ -295,8 +294,7 @@ impl Env {
             self.elders_info.elder_map().clone(),
             *old_info.new_elders_info.prefix(),
             old_info.new_elders_info.version() + 1,
-        )
-        .unwrap();
+        );
         self.updated_other_ids(new_elder_info)
     }
 
@@ -330,8 +328,7 @@ impl Env {
             new_member_map,
             *self.elders_info.prefix(),
             self.elders_info.version() + 1,
-        )
-        .unwrap();
+        );
         self.updated_other_ids(new_elders_info)
     }
 

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -224,8 +224,9 @@ impl Env {
     }
 
     fn accumulate_section_info_if_vote(&mut self, new_info: &DkgToSectionInfo) {
-        let section_key_info = SectionKeyInfo::from_elders_info(
-            &new_info.new_elders_info,
+        let section_key_info = SectionKeyInfo::new(
+            new_info.new_elders_info.prefix,
+            new_info.new_elders_info.version,
             new_info.new_pk_set.public_key(),
         );
         let _ = self.n_vote_for_gossipped(
@@ -525,7 +526,7 @@ fn verify_proof_chain_contains(proof_chain: &SectionProofChain, expected_version
     assert!(
         proof_chain
             .key_infos()
-            .any(|info| info.version() == expected_version),
+            .any(|info| info.version == expected_version),
         "{:?} doesn't contain expected version {}",
         proof_chain,
         expected_version,
@@ -536,7 +537,7 @@ fn verify_proof_chain_does_not_contain(proof_chain: &SectionProofChain, unexpect
     assert!(
         proof_chain
             .key_infos()
-            .all(|info| info.version() != unexpected_version),
+            .all(|info| info.version != unexpected_version),
         "{:?} contains unexpected version {}",
         proof_chain,
         unexpected_version,

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -338,11 +338,11 @@ impl Env {
     }
 
     fn is_candidate_member(&self) -> bool {
-        self.subject.is_peer_our_member(self.candidate.public_id())
+        self.subject.is_peer_our_member(self.candidate.name())
     }
 
     fn is_candidate_elder(&self) -> bool {
-        self.subject.is_peer_our_elder(self.candidate.public_id())
+        self.subject.is_peer_our_elder(self.candidate.name())
     }
 
     fn gen_peer(&mut self) -> Peer {

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -259,9 +259,9 @@ impl Env {
     // Accumulate `AckMessage` for the latest version of our own section.
     fn accumulate_self_ack_message(&mut self) {
         let event = AccumulatingEvent::AckMessage(AckMessagePayload {
-            dst_name: self.elders_info.prefix().name(),
-            src_prefix: *self.elders_info.prefix(),
-            ack_version: self.elders_info.version(),
+            dst_name: self.elders_info.prefix.name(),
+            src_prefix: self.elders_info.prefix,
+            ack_version: self.elders_info.version,
         });
 
         // This event needs total consensus.
@@ -281,8 +281,8 @@ impl Env {
                 .chain(iter::once(&self.candidate))
                 .map(|node| (*node.public_id().name(), node.clone()))
                 .collect(),
-            *self.elders_info.prefix(),
-            self.elders_info.version() + 1,
+            self.elders_info.prefix,
+            self.elders_info.version + 1,
         );
 
         self.updated_other_ids(new_elder_info)
@@ -292,8 +292,8 @@ impl Env {
         let old_info = self.new_elders_info_with_candidate();
         let new_elder_info = EldersInfo::new(
             self.elders_info.elder_map().clone(),
-            *old_info.new_elders_info.prefix(),
-            old_info.new_elders_info.version() + 1,
+            old_info.new_elders_info.prefix,
+            old_info.new_elders_info.version + 1,
         );
         self.updated_other_ids(new_elder_info)
     }
@@ -326,8 +326,8 @@ impl Env {
 
         let new_elders_info = EldersInfo::new(
             new_member_map,
-            *self.elders_info.prefix(),
-            self.elders_info.version() + 1,
+            self.elders_info.prefix,
+            self.elders_info.version + 1,
         );
         self.updated_other_ids(new_elders_info)
     }
@@ -483,7 +483,7 @@ fn handle_bootstrap() {
 fn send_genesis_update() {
     let mut env = Env::new(ELDER_SIZE);
 
-    let orig_elders_version = env.elders_info.version();
+    let orig_elders_version = env.elders_info.version;
 
     let adult0 = env.gen_peer();
     let adult1 = env.gen_peer();
@@ -506,7 +506,7 @@ fn send_genesis_update() {
     // Receive MemberKnowledge from the adult
     let parsec_version = env.subject.parsec_last_version();
     let variant = Variant::MemberKnowledge(MemberKnowledge {
-        elders_version: env.elders_info.version(),
+        elders_version: env.elders_info.version,
         parsec_version,
     });
     let msg = Message::single_src(&adult1.full_id, DstLocation::Direct, variant).unwrap();
@@ -516,7 +516,7 @@ fn send_genesis_update() {
     // contain the previous version.
     let message = utils::exactly_one(env.subject.create_genesis_updates());
     let proof = &message.1.proof;
-    verify_proof_chain_contains(proof, env.elders_info.version());
+    verify_proof_chain_contains(proof, env.elders_info.version);
     verify_proof_chain_does_not_contain(proof, orig_elders_version);
 }
 

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -30,7 +30,7 @@ pub fn create_elders_info(
     rng: &mut MainRng,
     network: &Network,
     elder_size: usize,
-    prev: Option<&EldersInfo>,
+    version: u64,
 ) -> (EldersInfo, BTreeMap<XorName, FullId>) {
     let full_ids: BTreeMap<_, _> = (0..elder_size)
         .map(|_| {
@@ -48,7 +48,7 @@ pub fn create_elders_info(
         })
         .collect();
 
-    let elders_info = EldersInfo::new(members_map, Prefix::default(), prev).unwrap();
+    let elders_info = EldersInfo::new(members_map, Prefix::default(), version).unwrap();
     (elders_info, full_ids)
 }
 

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -16,7 +16,7 @@
 use crate::{
     consensus::GenesisPrefixInfo,
     error::Result,
-    id::{FullId, P2pNode, PublicId},
+    id::{FullId, P2pNode},
     messages::{Message, MessageWithBytes},
     node::Node,
     rng::MainRng,
@@ -57,7 +57,7 @@ pub fn create_genesis_prefix_info(
     public_keys: bls::PublicKeySet,
     parsec_version: u64,
 ) -> GenesisPrefixInfo {
-    let ages = elder_age_counters(elders_info.elder_ids());
+    let ages = elder_age_counters(elders_info.elders.keys());
 
     GenesisPrefixInfo {
         elders_info,
@@ -68,13 +68,13 @@ pub fn create_genesis_prefix_info(
     }
 }
 
-pub fn elder_age_counters<'a, I>(elders: I) -> BTreeMap<PublicId, AgeCounter>
+pub fn elder_age_counters<'a, I>(elders: I) -> BTreeMap<XorName, AgeCounter>
 where
-    I: IntoIterator<Item = &'a PublicId>,
+    I: IntoIterator<Item = &'a XorName>,
 {
     elders
         .into_iter()
-        .map(|id| (*id, MIN_AGE_COUNTER))
+        .map(|name| (*name, MIN_AGE_COUNTER))
         .collect()
 }
 

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -62,7 +62,6 @@ pub fn create_genesis_prefix_info(
     GenesisPrefixInfo {
         elders_info,
         public_keys,
-        state_serialized: Vec::new(),
         ages,
         parsec_version,
     }

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -48,7 +48,7 @@ pub fn create_elders_info(
         })
         .collect();
 
-    let elders_info = EldersInfo::new(members_map, Prefix::default(), version).unwrap();
+    let elders_info = EldersInfo::new(members_map, Prefix::default(), version);
     (elders_info, full_ids)
 }
 

--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -51,7 +51,7 @@ pub fn delivery_targets(
     our_members: &SectionMembers,
     sections: &SectionMap,
 ) -> Result<(Vec<P2pNode>, usize)> {
-    if !sections.is_elder(our_id) {
+    if !sections.is_elder(our_id.name()) {
         // We are not Elder - return all the elders of our section, so the message can be properly
         // relayed through them.
         let targets: Vec<_> = sections.our_elders().cloned().collect();

--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -72,7 +72,7 @@ pub fn delivery_targets(
         }
         DstLocation::Section(target_name) => {
             let (prefix, section) = sections.closest(target_name);
-            if prefix == sections.our().prefix() || prefix.is_neighbour(sections.our().prefix()) {
+            if *prefix == sections.our().prefix || prefix.is_neighbour(&sections.our().prefix) {
                 // Exclude our name since we don't need to send to ourself
 
                 // FIXME: only doing this for now to match RT.
@@ -89,13 +89,13 @@ pub fn delivery_targets(
             candidates(target_name, our_id, sections)?
         }
         DstLocation::Prefix(prefix) => {
-            if prefix.is_compatible(sections.our().prefix())
-                || prefix.is_neighbour(sections.our().prefix())
+            if prefix.is_compatible(&sections.our().prefix)
+                || prefix.is_neighbour(&sections.our().prefix)
             {
                 // only route the message when we have all the targets in our chain -
                 // this is to prevent spamming the network by sending messages with
                 // intentionally short prefixes
-                if prefix.is_compatible(sections.our().prefix())
+                if prefix.is_compatible(&sections.our().prefix)
                     && !prefix.is_covered_by(sections.prefixes())
                 {
                     return Err(RoutingError::CannotRoute);
@@ -146,7 +146,7 @@ fn candidates(
         nodes_to_send.extend(connected.cloned());
         dg_size = delivery_group_size(len);
 
-        if prefix == sections.our().prefix() {
+        if *prefix == sections.our().prefix {
             // Send to all connected targets so they can forward the message
             nodes_to_send.retain(|node| node.name() != our_id.name());
             dg_size = nodes_to_send.len();

--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{Result, RoutingError},
     id::{P2pNode, PublicId},
     location::DstLocation,
-    section::{EldersInfo, SectionMap, SectionMembers},
+    section::{SectionMap, SectionMembers},
     xor_space::{XorName, Xorable},
 };
 use itertools::Itertools;
@@ -78,7 +78,8 @@ pub fn delivery_targets(
                 // FIXME: only doing this for now to match RT.
                 // should confirm if needed esp after msg_relay changes.
                 let section: Vec<_> = section
-                    .elder_nodes()
+                    .elders
+                    .values()
                     .filter(|node| node.name() != our_id.name())
                     .cloned()
                     .collect();
@@ -113,7 +114,7 @@ pub fn delivery_targets(
                 let targets: Vec<_> = sections
                     .all()
                     .filter_map(is_compatible)
-                    .flat_map(EldersInfo::elder_nodes)
+                    .flat_map(|info| info.elders.values())
                     .filter(|node| node.name() != our_id.name())
                     .cloned()
                     .collect();
@@ -138,7 +139,7 @@ fn candidates(
     let filtered_sections = sections
         .sorted_by_distance_to(target_name)
         .into_iter()
-        .map(|(prefix, info)| (prefix, info.num_elders(), info.elder_nodes()));
+        .map(|(prefix, info)| (prefix, info.elders.len(), info.elders.values()));
 
     let mut dg_size = 0;
     let mut nodes_to_send = Vec::new();

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -27,9 +27,9 @@ pub struct EldersInfo {
     elders: BTreeMap<XorName, P2pNode>,
     /// The section version. This increases monotonically whenever the set of elders changes.
     /// Thus `EldersInfo`s with compatible prefixes always have different versions.
-    version: u64,
+    pub version: u64,
     /// The section prefix. It matches all the members' names.
-    prefix: Prefix<XorName>,
+    pub prefix: Prefix<XorName>,
 }
 
 impl EldersInfo {
@@ -66,14 +66,6 @@ impl EldersInfo {
         self.elders.len()
     }
 
-    pub(crate) fn version(&self) -> u64 {
-        self.version
-    }
-
-    pub(crate) fn prefix(&self) -> &Prefix<XorName> {
-        &self.prefix
-    }
-
     /// Returns `true` if the proofs are from a quorum of this section.
     pub(crate) fn is_quorum(&self, proofs: &ProofSet) -> bool {
         proofs.ids().filter(|id| self.contains_elder(id)).count() >= quorum_count(self.num_elders())
@@ -86,7 +78,7 @@ impl EldersInfo {
 
     /// Returns whether this `EldersInfo` is compatible and newer than the other.
     pub(crate) fn is_newer(&self, other: &Self) -> bool {
-        self.prefix().is_compatible(other.prefix()) && self.version() > other.version()
+        self.prefix.is_compatible(&other.prefix) && self.version > other.version
     }
 }
 

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -13,7 +13,6 @@ use crate::{
     id::{P2pNode, PublicId},
     Prefix, XorName, QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
 };
-use bincode::serialize;
 use itertools::Itertools;
 use serde::{de::Error as SerdeDeError, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -33,135 +32,90 @@ pub struct EldersInfo {
     version: u64,
     /// The section prefix. It matches all the members' names.
     prefix: Prefix<XorName>,
-    /// The hash of the predecessor section, except if this is the network's genesis section.
-    prev_hash: Option<Digest256>,
     /// The hash of the above fields. This is not serialized, and computed after deserialization.
     hash: Digest256,
 }
 
 impl Serialize for EldersInfo {
     fn serialize<S: Serializer>(&self, serialiser: S) -> Result<S::Ok, S::Error> {
-        (&self.elders, self.version, &self.prefix, &self.prev_hash).serialize(serialiser)
+        (&self.elders, &self.prefix, self.version).serialize(serialiser)
     }
 }
 
 impl<'de> Deserialize<'de> for EldersInfo {
     fn deserialize<D: Deserializer<'de>>(deserialiser: D) -> Result<Self, D::Error> {
-        let (members, version, prefix, prev_hash) = Deserialize::deserialize(deserialiser)?;
-        Self::new_with_fields(members, version, prefix, prev_hash)
+        let (members, prefix, version) = Deserialize::deserialize(deserialiser)?;
+        Self::new(members, prefix, version)
             .map_err(|err| D::Error::custom(format!("failed to construct elders info: {:?}", err)))
     }
 }
 
 impl EldersInfo {
-    /// Creates a `SectionInfo` with the given members, prefix and predecessors.
+    /// Creates a new `EldersInfo` with the given members, prefix and version.
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        members: BTreeMap<XorName, P2pNode>,
-        prefix: Prefix<XorName>,
-        prev: Option<&Self>,
-    ) -> Result<Self, RoutingError> {
-        let version = if let Some(prev) = prev {
-            prev.version() + 1
-        } else {
-            0
-        };
-
-        Self::new_with_fields(members, version, prefix, prev.map(Self::hash).copied())
-    }
-
-    pub fn elder_map(&self) -> &BTreeMap<XorName, P2pNode> {
-        &self.elders
-    }
-
-    pub fn contains_elder(&self, pub_id: &PublicId) -> bool {
-        self.elders.contains_key(pub_id.name())
-    }
-
-    pub fn elder_nodes(&self) -> impl Iterator<Item = &P2pNode> + ExactSizeIterator {
-        self.elders.values()
-    }
-
-    pub fn elder_ids(&self) -> impl Iterator<Item = &PublicId> {
-        self.elders.values().map(P2pNode::public_id)
-    }
-
-    pub fn elder_names(&self) -> impl Iterator<Item = &XorName> {
-        self.elders.values().map(P2pNode::name)
-    }
-
-    pub fn num_elders(&self) -> usize {
-        self.elders.len()
-    }
-
-    pub fn version(&self) -> u64 {
-        self.version
-    }
-
-    pub fn prefix(&self) -> &Prefix<XorName> {
-        &self.prefix
-    }
-
-    #[cfg(feature = "mock_base")]
-    pub fn prev_hash(&self) -> Option<&Digest256> {
-        self.prev_hash.as_ref()
-    }
-
-    pub fn hash(&self) -> &Digest256 {
-        &self.hash
-    }
-
-    /// Returns `true` if the proofs are from a quorum of this section.
-    pub fn is_quorum(&self, proofs: &ProofSet) -> bool {
-        proofs.ids().filter(|id| self.contains_elder(id)).count() >= quorum_count(self.num_elders())
-    }
-
-    /// Returns `true` if the proofs are from all members of this section.
-    pub fn is_total_consensus(&self, proofs: &ProofSet) -> bool {
-        proofs.ids().filter(|id| self.contains_elder(id)).count() == self.num_elders()
-    }
-
-    /// Returns `true` if `self` is a successor of `other_info`, according to its hash.
-    pub fn is_successor_of(&self, other_info: &Self) -> bool {
-        self.prev_hash.as_ref() == Some(&other_info.hash)
-    }
-
-    /// Returns whether this `EldersInfo` is compatible and newer than the other.
-    pub fn is_newer(&self, other: &Self) -> bool {
-        self.prefix().is_compatible(other.prefix()) && self.version() > other.version()
-    }
-
-    #[cfg(any(test, feature = "mock_base"))]
-    pub fn new_for_test(
-        members: BTreeMap<PublicId, P2pNode>,
-        prefix: Prefix<XorName>,
-        version: u64,
-    ) -> Result<Self, RoutingError> {
-        let members = members
-            .into_iter()
-            .map(|(pub_id, node)| (*pub_id.name(), node))
-            .collect();
-        Self::new_with_fields(members, version, prefix, None)
-    }
-
-    /// Creates a new instance with the given fields, and computes its hash.
-    fn new_with_fields(
         elders: BTreeMap<XorName, P2pNode>,
-        version: u64,
         prefix: Prefix<XorName>,
-        prev_hash: Option<Digest256>,
+        version: u64,
     ) -> Result<Self, RoutingError> {
         let hash = {
-            let fields = (&elders, version, &prefix, &prev_hash);
-            crypto::sha3_256(&serialize(&fields)?)
+            let fields = (&elders, &prefix, version);
+            crypto::sha3_256(&bincode::serialize(&fields)?)
         };
+
         Ok(Self {
             elders,
             version,
             prefix,
-            prev_hash,
             hash,
         })
+    }
+
+    pub(crate) fn elder_map(&self) -> &BTreeMap<XorName, P2pNode> {
+        &self.elders
+    }
+
+    pub(crate) fn contains_elder(&self, pub_id: &PublicId) -> bool {
+        self.elders.contains_key(pub_id.name())
+    }
+
+    pub(crate) fn elder_nodes(&self) -> impl Iterator<Item = &P2pNode> + ExactSizeIterator {
+        self.elders.values()
+    }
+
+    pub(crate) fn elder_ids(&self) -> impl Iterator<Item = &PublicId> {
+        self.elders.values().map(P2pNode::public_id)
+    }
+
+    pub(crate) fn elder_names(&self) -> impl Iterator<Item = &XorName> {
+        self.elders.values().map(P2pNode::name)
+    }
+
+    pub(crate) fn num_elders(&self) -> usize {
+        self.elders.len()
+    }
+
+    pub(crate) fn version(&self) -> u64 {
+        self.version
+    }
+
+    pub(crate) fn prefix(&self) -> &Prefix<XorName> {
+        &self.prefix
+    }
+
+    /// Returns `true` if the proofs are from a quorum of this section.
+    pub(crate) fn is_quorum(&self, proofs: &ProofSet) -> bool {
+        proofs.ids().filter(|id| self.contains_elder(id)).count() >= quorum_count(self.num_elders())
+    }
+
+    /// Returns `true` if the proofs are from all members of this section.
+    pub(crate) fn is_total_consensus(&self, proofs: &ProofSet) -> bool {
+        proofs.ids().filter(|id| self.contains_elder(id)).count() == self.num_elders()
+    }
+
+    /// Returns whether this `EldersInfo` is compatible and newer than the other.
+    pub(crate) fn is_newer(&self, other: &Self) -> bool {
+        self.prefix().is_compatible(other.prefix()) && self.version() > other.version()
     }
 }
 
@@ -182,14 +136,4 @@ impl Debug for EldersInfo {
 #[inline]
 pub const fn quorum_count(elder_size: usize) -> usize {
     1 + (elder_size * QUORUM_NUMERATOR) / QUORUM_DENOMINATOR
-}
-
-#[cfg(feature = "mock_base")]
-/// Test helper to create arbitrary elders nfo.
-pub fn elders_info_for_test(
-    members: BTreeMap<PublicId, P2pNode>,
-    prefix: Prefix<XorName>,
-    version: u64,
-) -> Result<EldersInfo, RoutingError> {
-    EldersInfo::new_for_test(members, prefix, version)
 }

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -22,14 +22,9 @@ pub use self::{
     section_keys::{SectionKeyShare, SectionKeys, SectionKeysProvider},
     section_map::SectionMap,
     section_members::SectionMembers,
-    section_proof_chain::{
-        SectionKeyInfo, SectionProofBlock, SectionProofChain, SectionProofSlice, TrustStatus,
-    },
+    section_proof_chain::{SectionKeyInfo, SectionProofBlock, SectionProofChain, TrustStatus},
     shared_state::SharedState,
 };
-
-#[cfg(feature = "mock_base")]
-pub use self::section_proof_chain::section_proof_slice_for_test;
 
 use crate::consensus::AccumulatingProof;
 

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -29,9 +29,7 @@ pub use self::{
 };
 
 #[cfg(feature = "mock_base")]
-pub use self::{
-    elders_info::elders_info_for_test, section_proof_chain::section_proof_slice_for_test,
-};
+pub use self::section_proof_chain::section_proof_slice_for_test;
 
 use crate::consensus::AccumulatingProof;
 

--- a/src/section/section_keys.rs
+++ b/src/section/section_keys.rs
@@ -126,7 +126,8 @@ impl SectionKeysProvider {
 
     pub fn finalise_dkg(&mut self, our_id: &PublicId, elders_info: &EldersInfo) -> Result<()> {
         let first_name = elders_info
-            .elder_names()
+            .elders
+            .keys()
             .next()
             .ok_or(RoutingError::InvalidElderDkgResult)?;
         let dkg_result = self

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -10,7 +10,7 @@ use super::{
     elders_info::EldersInfo, network_stats::NetworkStats, section_proof_chain::SectionKeyInfo,
 };
 use crate::{
-    id::{P2pNode, PublicId},
+    id::P2pNode,
     location::DstLocation,
     xor_space::{Prefix, XorName},
 };
@@ -79,10 +79,10 @@ impl SectionMap {
     }
 
     /// Find other section containing the given elder.
-    pub fn find_other_by_elder(&self, pub_id: &PublicId) -> Option<&EldersInfo> {
+    pub fn find_other_by_elder(&self, elder_name: &XorName) -> Option<&EldersInfo> {
         self.other
             .iter()
-            .find(|(_, info)| info.elders.contains_key(pub_id.name()))
+            .find(|(_, info)| info.elders.contains_key(elder_name))
             .map(|(_, info)| info)
     }
 
@@ -163,8 +163,8 @@ impl SectionMap {
     }
 
     /// Returns whether the given peer is elder in a known sections.
-    pub fn is_elder(&self, pub_id: &PublicId) -> bool {
-        self.get_elder(pub_id.name()).is_some()
+    pub fn is_elder(&self, name: &XorName) -> bool {
+        self.get_elder(name).is_some()
     }
 
     /// Set the new version of our section.

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -28,7 +28,7 @@ const MAX_RECENT_KEYS: usize = 20;
 /// Container for storing information about sections in the network.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SectionMap {
-    // Our section including its whole history.
+    // Our section.
     our: EldersInfo,
     // Other sections: maps section prefixes to their latest signed elders infos.
     // Note that after a split, the section's latest section info could be the one from the

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -51,7 +51,7 @@ impl SectionMap {
             our: our_info,
             other: Default::default(),
             other_queued: Default::default(),
-            keys: iter::once((*our_key.prefix(), our_key)).collect(),
+            keys: iter::once((our_key.prefix, our_key)).collect(),
             recent_keys: Default::default(),
             knowledge: Default::default(),
         }
@@ -291,7 +291,7 @@ impl SectionMap {
         self.keys()
             .filter(|(prefix, _)| prefix.matches(name))
             .map(|(_, info)| info)
-            .max_by_key(|info| info.version())
+            .max_by_key(|info| info.version)
     }
 
     /// Updates the entry in `keys` for `prefix` to the latest known key; if a split
@@ -303,10 +303,10 @@ impl SectionMap {
         if let Some((&old_prefix, old_version)) = self
             .keys
             .iter()
-            .find(|(prefix, _)| prefix.is_compatible(key_info.prefix()))
-            .map(|(prefix, info)| (prefix, info.version()))
+            .find(|(prefix, _)| prefix.is_compatible(&key_info.prefix))
+            .map(|(prefix, info)| (prefix, info.version))
         {
-            if old_version >= key_info.version() || old_prefix.is_extension_of(key_info.prefix()) {
+            if old_version >= key_info.version || old_prefix.is_extension_of(&key_info.prefix) {
                 // Do not overwrite newer version or prefix extensions
                 return;
             }
@@ -325,13 +325,13 @@ impl SectionMap {
             trace!("    from {:?} to {:?}", old_key_info, key_info);
 
             let old_prefix_sibling = old_prefix.sibling();
-            let mut current_prefix = key_info.prefix().sibling();
+            let mut current_prefix = key_info.prefix.sibling();
             while !self.keys.contains_key(&current_prefix) && current_prefix != old_prefix_sibling {
                 let _ = self.keys.insert(current_prefix, old_key_info.clone());
                 current_prefix = current_prefix.popped().sibling();
             }
         }
-        let _ = self.keys.insert(*key_info.prefix(), key_info.clone());
+        let _ = self.keys.insert(key_info.prefix, key_info.clone());
     }
 
     pub fn get_knowledge(&self, prefix: &Prefix<XorName>) -> Option<u64> {

--- a/src/section/section_members.rs
+++ b/src/section/section_members.rs
@@ -40,7 +40,8 @@ impl SectionMembers {
     /// Constructs the container initially with the section elders.
     pub fn new(elders_info: &EldersInfo, ages: &BTreeMap<PublicId, AgeCounter>) -> Self {
         let members = elders_info
-            .elder_nodes()
+            .elders
+            .values()
             .map(|p2p_node| {
                 let info = MemberInfo {
                     age_counter: *ages.get(p2p_node.public_id()).unwrap_or(&MIN_AGE_COUNTER),

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -114,13 +114,7 @@ impl SectionProofChain {
 
         let head_index = std::cmp::min(first_index, self.tail.len()) - 1;
         let head = self.tail[head_index].key_info().clone();
-
-        let tail_first_index = head_index + 1;
-        let tail = if tail_first_index >= self.tail.len() {
-            vec![]
-        } else {
-            self.tail[tail_first_index..].to_vec()
-        };
+        let tail = self.tail[head_index + 1..].to_vec();
 
         Self { head, tail }
     }

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -234,6 +234,10 @@ impl SectionProofChain {
             blocks,
         }
     }
+
+    pub fn len(&self) -> usize {
+        1 + self.blocks.len()
+    }
 }
 
 fn validate_next_block(last: &SectionKeyInfo, next: &SectionProofBlock) -> bool {

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -279,7 +279,7 @@ impl SectionKeyInfo {
     }
 
     pub fn from_elders_info(elders_info: &EldersInfo, key: bls::PublicKey) -> Self {
-        Self::new(elders_info.version(), *elders_info.prefix(), key)
+        Self::new(elders_info.version, elders_info.prefix, key)
     }
 
     pub fn key(&self) -> &bls::PublicKey {

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -48,7 +48,7 @@ impl SharedState {
         section_pk: bls::PublicKey,
         ages: BTreeMap<XorName, AgeCounter>,
     ) -> Self {
-        let pk_info = SectionKeyInfo::from_elders_info(&elders_info, section_pk);
+        let pk_info = SectionKeyInfo::new(elders_info.prefix, elders_info.version, section_pk);
         let our_history = SectionProofChain::new(pk_info);
         let our_key_info = our_history.last_key_info().clone();
         let our_members = SectionMembers::new(&elders_info, &ages);
@@ -521,8 +521,11 @@ mod test {
                 let prefix = Prefix::<XorName>::from_str(prefix_str).unwrap();
                 let elders_info = gen_elders_info(rng, prefix, version as u64);
                 let bls_keys = generate_bls_threshold_secret_key(rng, 1).public_keys();
-                let key_info =
-                    SectionKeyInfo::from_elders_info(&elders_info, bls_keys.public_key());
+                let key_info = SectionKeyInfo::new(
+                    elders_info.prefix,
+                    elders_info.version,
+                    bls_keys.public_key(),
+                );
                 (key_info, elders_info, bls_keys)
             })
             .collect::<Vec<_>>();

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -73,7 +73,7 @@ impl SharedState {
         }
 
         if let Some(new) = new {
-            if self.sections.has_our_history() && *self != new {
+            if self.our_history.len() > 1 && *self != new {
                 log_or_panic!(
                     log::Level::Error,
                     "shared state update - mismatch: old: {:?} --- new: {:?}",
@@ -237,11 +237,11 @@ impl SharedState {
         }
     }
 
-    pub fn push_our_new_info(&mut self, elders_info: EldersInfo, proof_block: SectionProofBlock) {
+    pub fn update_our_section(&mut self, elders_info: EldersInfo, proof_block: SectionProofBlock) {
         self.our_members
             .remove_not_matching_our_prefix(elders_info.prefix());
         self.our_history.push(proof_block);
-        self.sections.push_our(elders_info);
+        self.sections.set_our(elders_info);
         self.sections.update_keys(self.our_history.last_key_info());
     }
 

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -46,10 +46,10 @@ pub struct SharedState {
 impl SharedState {
     pub fn new(
         elders_info: EldersInfo,
-        bls_keys: bls::PublicKeySet,
+        section_pk: bls::PublicKey,
         ages: BTreeMap<PublicId, AgeCounter>,
     ) -> Self {
-        let pk_info = SectionKeyInfo::from_elders_info(&elders_info, bls_keys.public_key());
+        let pk_info = SectionKeyInfo::from_elders_info(&elders_info, section_pk);
         let our_history = SectionProofChain::from_genesis(pk_info);
         let our_key_info = our_history.last_key_info().clone();
         let our_members = SectionMembers::new(&elders_info, &ages);
@@ -536,8 +536,8 @@ mod test {
         let mut state = {
             let start_section = keys_to_update.first().expect("`updates` can't be empty");
             let info = start_section.1.clone();
-            let keys = start_section.2.clone();
-            SharedState::new(info, keys, Default::default())
+            let public_key = start_section.2.public_key();
+            SharedState::new(info, public_key, Default::default())
         };
 
         // Act
@@ -644,7 +644,9 @@ mod test {
     ) {
         let mut state = SharedState::new(
             gen_elders_info(rng, Default::default(), 0),
-            generate_bls_threshold_secret_key(rng, 1).public_keys(),
+            generate_bls_threshold_secret_key(rng, 1)
+                .public_keys()
+                .public_key(),
             Default::default(),
         );
 
@@ -778,9 +780,9 @@ mod test {
 
         let participants = elders_info.num_elders();
         let secret_key_set = generate_bls_threshold_secret_key(rng, participants);
-        let public_key_set = secret_key_set.public_keys();
+        let public_key = secret_key_set.public_keys().public_key();
 
-        let mut state = SharedState::new(elders_info, public_key_set, ages);
+        let mut state = SharedState::new(elders_info, public_key, ages);
 
         for neighbour_info in sections_iter {
             add_neighbour_elders_info(&mut state, &our_pub_id, neighbour_info);

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -8,7 +8,7 @@
 
 use super::{
     AgeCounter, EldersInfo, MemberState, SectionKeyInfo, SectionMap, SectionMembers,
-    SectionProofBlock, SectionProofChain, SectionProofSlice,
+    SectionProofBlock, SectionProofChain,
 };
 use crate::{
     consensus::AccumulatingEvent,
@@ -49,7 +49,7 @@ impl SharedState {
         ages: BTreeMap<XorName, AgeCounter>,
     ) -> Self {
         let pk_info = SectionKeyInfo::from_elders_info(&elders_info, section_pk);
-        let our_history = SectionProofChain::from_genesis(pk_info);
+        let our_history = SectionProofChain::new(pk_info);
         let our_key_info = our_history.last_key_info().clone();
         let our_members = SectionMembers::new(&elders_info, &ages);
 
@@ -280,7 +280,7 @@ impl SharedState {
         Some(details)
     }
 
-    /// Provide a SectionProofSlice that proves the given signature to the given destination
+    /// Provide a SectionProofChain that proves the given signature to the given destination
     /// location.
     /// If `node_knowledge_override` is `Some`, it is used when calculating proof for
     /// `DstLocation::Node` instead of the stored knowledge. Has no effect for other location types.
@@ -288,7 +288,7 @@ impl SharedState {
         &self,
         target: &DstLocation,
         node_knowledge_override: Option<u64>,
-    ) -> SectionProofSlice {
+    ) -> SectionProofChain {
         let version = match (target, node_knowledge_override) {
             (DstLocation::Node(_), Some(knowledge)) => knowledge,
             _ => self.sections.trusted_key_version(target),

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -108,7 +108,7 @@ mod tests {
             let other_ids = secret_ids.values().zip(secret_bls_ids.values()).skip(1);
 
             let prefix = Prefix::new(0, *unwrap!(all_nodes.keys().next()));
-            let elders_info = unwrap!(EldersInfo::new(all_nodes.clone(), prefix, None));
+            let elders_info = unwrap!(EldersInfo::new(all_nodes.clone(), prefix, 0));
             let key_info = SectionKeyInfo::from_elders_info(&elders_info, pk_set.public_key());
             let proof = SectionProofSlice::from_genesis(key_info);
 

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -109,7 +109,8 @@ mod tests {
 
             let prefix = Prefix::new(0, *unwrap!(all_nodes.keys().next()));
             let elders_info = EldersInfo::new(all_nodes.clone(), prefix, 0);
-            let key_info = SectionKeyInfo::from_elders_info(&elders_info, pk_set.public_key());
+            let key_info =
+                SectionKeyInfo::new(elders_info.prefix, elders_info.version, pk_set.public_key());
             let proof = SectionProofChain::new(key_info);
 
             let signed_msg = unwrap!(AccumulatingMessage::new(

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -79,7 +79,7 @@ mod tests {
         location::{DstLocation, SrcLocation},
         messages::{Message, PlainMessage, Variant},
         rng,
-        section::{EldersInfo, SectionKeyInfo, SectionKeyShare, SectionProofSlice},
+        section::{EldersInfo, SectionKeyInfo, SectionKeyShare, SectionProofChain},
         unwrap, Prefix, XorName,
     };
     use itertools::Itertools;
@@ -110,7 +110,7 @@ mod tests {
             let prefix = Prefix::new(0, *unwrap!(all_nodes.keys().next()));
             let elders_info = EldersInfo::new(all_nodes.clone(), prefix, 0);
             let key_info = SectionKeyInfo::from_elders_info(&elders_info, pk_set.public_key());
-            let proof = SectionProofSlice::from_genesis(key_info);
+            let proof = SectionProofChain::new(key_info);
 
             let signed_msg = unwrap!(AccumulatingMessage::new(
                 content.clone(),

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -108,7 +108,7 @@ mod tests {
             let other_ids = secret_ids.values().zip(secret_bls_ids.values()).skip(1);
 
             let prefix = Prefix::new(0, *unwrap!(all_nodes.keys().next()));
-            let elders_info = unwrap!(EldersInfo::new(all_nodes.clone(), prefix, 0));
+            let elders_info = EldersInfo::new(all_nodes.clone(), prefix, 0);
             let key_info = SectionKeyInfo::from_elders_info(&elders_info, pk_set.public_key());
             let proof = SectionProofSlice::from_genesis(key_info);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,53 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use itertools::Itertools;
-use std::{
-    fmt::{self, Debug, Formatter},
-    iter, mem,
-};
-
-/// Vec-like container that is guaranteed to contain at least one element.
-#[derive(PartialEq, Eq, Serialize, Deserialize)]
-pub struct NonEmptyList<T> {
-    head: Vec<T>,
-    tail: T,
-}
-
-impl<T> NonEmptyList<T> {
-    pub fn new(first: T) -> Self {
-        Self {
-            head: Vec::new(),
-            tail: first,
-        }
-    }
-
-    pub fn push(&mut self, item: T) {
-        self.head.push(mem::replace(&mut self.tail, item))
-    }
-
-    pub fn len(&self) -> usize {
-        self.head.len() + 1
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator {
-        self.head.iter().chain(iter::once(&self.tail))
-    }
-
-    pub fn last(&self) -> &T {
-        &self.tail
-    }
-}
-
-impl<T> Debug for NonEmptyList<T>
-where
-    T: Debug,
-{
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "[{:?}]", self.iter().format(", "))
-    }
-}
-
 // Test utils
 
 /// If the iterator yields exactly one element, returns it. Otherwise panics.

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -18,7 +18,7 @@ fn messages_accumulate_with_quorum() {
     let elder_size = 8;
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size: elder_size,
+        recommended_section_size: elder_size,
     });
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes(&env, section_size);

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -67,13 +67,13 @@ fn messages_during_churn() {
 #[ignore]
 fn remove_unresponsive_node() {
     let elder_size = 8;
-    let safe_section_size = 8;
+    let recommended_section_size = 8;
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size,
+        recommended_section_size,
     });
 
-    let mut nodes = create_connected_nodes(&env, safe_section_size);
+    let mut nodes = create_connected_nodes(&env, recommended_section_size);
     // Pause a node to act as non-responsive.
     let mut rng = env.new_rng();
     let non_responsive_index = gen_elder_index(&mut rng, &nodes);
@@ -169,7 +169,7 @@ impl Default for Params {
         Self {
             network: NetworkParams {
                 elder_size: 4,
-                safe_section_size: 5,
+                recommended_section_size: 5,
             },
             initial_prefix_lens: vec![],
             message_schedule: MessageSchedule::AfterChurn,
@@ -327,13 +327,13 @@ fn drop_random_nodes<R: Rng>(
         }
 
         let elder_size = node.inner.elder_size();
-        let safe_section_size = node.inner.safe_section_size();
+        let recommended_section_size = node.inner.recommended_section_size();
 
         let section = sections.get_mut(node.our_prefix()).unwrap();
 
         // Drop at most as many nodes as is the minimal number of non-elders in the section.
         // This guarantees we never drop below `elder_size` even in case of split.
-        if section.dropped_count >= safe_section_size - elder_size {
+        if section.dropped_count >= recommended_section_size - elder_size {
             continue;
         }
 

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -16,7 +16,7 @@ use routing::{mock::Environment, NetworkParams};
 fn node_drops() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE + 1,
+        recommended_section_size: LOWERED_ELDER_SIZE + 1,
     });
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes(&env, LOWERED_ELDER_SIZE + 2);

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -22,8 +22,8 @@ fn node_drops() {
     let mut nodes = create_connected_nodes(&env, LOWERED_ELDER_SIZE + 2);
 
     let index = rng.gen_range(0, nodes.len());
-    let dropped_id = *nodes.remove(index).id();
+    let dropped_name = *nodes.remove(index).name();
 
-    poll_until(&env, &mut nodes, |nodes| node_left(nodes, &dropped_id));
+    poll_until(&env, &mut nodes, |nodes| node_left(nodes, &dropped_name));
     verify_invariants_for_nodes(&env, &nodes);
 }

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -16,11 +16,11 @@ use std::collections::HashMap;
 #[test]
 fn send() {
     let elder_size = 8;
-    let safe_section_size = 8;
+    let recommended_section_size = 8;
     let quorum = quorum_count(elder_size);
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size,
+        recommended_section_size,
     });
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes(&env, elder_size + 1);
@@ -54,11 +54,11 @@ fn send() {
 #[test]
 fn send_and_receive() {
     let elder_size = 8;
-    let safe_section_size = 8;
+    let recommended_section_size = 8;
     let quorum = quorum_count(elder_size);
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size,
+        recommended_section_size,
     });
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes(&env, elder_size + 1);

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -34,7 +34,7 @@ fn test_nodes(percentage_size: usize) {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
         // Require at least one non-elder to make things more interesting.
-        safe_section_size: LOWERED_ELDER_SIZE + 1,
+        recommended_section_size: LOWERED_ELDER_SIZE + 1,
     });
     let nodes = create_connected_nodes(&env, size);
     verify_invariants_for_nodes(&env, &nodes);
@@ -51,7 +51,7 @@ fn create_node_with_contact(env: &Environment, contact: &mut TestNode) -> TestNo
 fn disconnect_on_rebootstrap() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
     let mut nodes = create_connected_nodes(&env, 2);
 
@@ -71,7 +71,7 @@ fn single_section() {
     let sec_size = 10;
     let env = Environment::new(NetworkParams {
         elder_size: sec_size,
-        safe_section_size: sec_size,
+        recommended_section_size: sec_size,
     });
     let nodes = create_connected_nodes(&env, sec_size);
     verify_invariants_for_nodes(&env, &nodes);
@@ -96,7 +96,7 @@ fn more_than_section_size_nodes() {
 fn node_joins_in_front() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
     let mut nodes = create_connected_nodes(&env, 2 * LOWERED_ELDER_SIZE);
     let transport_config = TransportConfig::node().with_hard_coded_contact(nodes[0].endpoint());
@@ -115,7 +115,7 @@ fn node_joins_in_front() {
 fn multiple_joining_nodes() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
 
     let iterations = 10;
@@ -150,10 +150,10 @@ fn multiple_joining_nodes() {
 fn single_split() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        // The smallest `safe_section_size` where when a split happens, the set of elders
+        // The smallest `recommended_section_size` where when a split happens, the set of elders
         // post-split in at least one of the sub-sections might be completely different from the
         // set of elders pre-split. This setup exposed a bug before and we want to have it covered.
-        safe_section_size: LOWERED_ELDER_SIZE + 3,
+        recommended_section_size: LOWERED_ELDER_SIZE + 3,
     });
     let mut nodes = vec![];
     trigger_split(&env, &mut nodes, &Prefix::default());
@@ -163,7 +163,7 @@ fn single_split() {
 fn multi_split() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE + 1,
+        recommended_section_size: LOWERED_ELDER_SIZE + 1,
     });
     let nodes = create_connected_nodes_until_split(&env, &[2, 2, 2, 2]);
     verify_invariants_for_nodes(&env, &nodes);
@@ -263,7 +263,7 @@ fn simultaneous_joining_nodes_two_sections() {
     // Create a network with two sections:
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
     let nodes = create_connected_nodes_until_split(&env, &[1, 1]);
 
@@ -291,7 +291,7 @@ fn simultaneous_joining_nodes_two_sections_switch_section() {
     // Create a network with two sections:
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
     let nodes = create_connected_nodes_until_split(&env, &[1, 1]);
 
@@ -319,12 +319,12 @@ fn simultaneous_joining_nodes_three_section_with_one_ready_to_split() {
     // TODO: Use same section size once we have a reliable message relay that handle split.
     // Allow for more routes otherwise NodeApproval get losts during soak test.
     let elder_size = LOWERED_ELDER_SIZE + 1;
-    let safe_section_size = LOWERED_ELDER_SIZE + 1;
+    let recommended_section_size = LOWERED_ELDER_SIZE + 1;
 
     // Create a network with three sections:
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size,
+        recommended_section_size,
     });
     let mut nodes = create_connected_nodes_until_split(&env, &[1, 2, 2]);
 
@@ -364,7 +364,7 @@ fn simultaneous_joining_nodes_three_section_with_one_ready_to_split() {
 fn check_close_names_for_elder_size_nodes() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
     let mut nodes = create_connected_nodes(&env, LOWERED_ELDER_SIZE);
 
@@ -378,10 +378,10 @@ fn check_close_names_for_elder_size_nodes() {
 #[test]
 fn check_section_info_ack() {
     let elder_size = 8;
-    let safe_section_size = 8;
+    let recommended_section_size = 8;
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size,
+        recommended_section_size,
     });
 
     let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);
@@ -411,10 +411,10 @@ fn check_section_info_ack() {
 fn carry_out_parsec_pruning() {
     let init_network_size = 7;
     let elder_size = 8;
-    let safe_section_size = 8;
+    let recommended_section_size = 8;
     let env = Environment::new(NetworkParams {
         elder_size,
-        safe_section_size,
+        recommended_section_size,
     });
     let mut rng = env.new_rng();
     let mut nodes = create_connected_nodes(&env, init_network_size);
@@ -472,10 +472,10 @@ fn carry_out_parsec_pruning() {
 fn node_pause_and_resume_simple() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE + 1,
+        recommended_section_size: LOWERED_ELDER_SIZE + 1,
     });
 
-    let mut nodes = create_connected_nodes(&env, env.safe_section_size());
+    let mut nodes = create_connected_nodes(&env, env.recommended_section_size());
     let paused_state = pause_node_and_poll(&env, &mut nodes);
 
     add_node_to_section(&env, &mut nodes, &Prefix::default());
@@ -504,7 +504,7 @@ fn node_pause_and_resume_simple() {
 fn node_pause_and_resume_during_split() {
     let env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE + 1,
+        recommended_section_size: LOWERED_ELDER_SIZE + 1,
     });
 
     let mut nodes = vec![];
@@ -512,8 +512,8 @@ fn node_pause_and_resume_during_split() {
         &env,
         &mut nodes,
         &Prefix::default(),
-        env.safe_section_size(),
-        env.safe_section_size(),
+        env.recommended_section_size(),
+        env.recommended_section_size(),
     );
 
     let paused_state = pause_node_and_poll(&env, &mut nodes);

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -489,7 +489,11 @@ fn node_pause_and_resume_simple() {
     // If the paused node is elder, verify it caught up to the new node joining.
     if nodes.last().unwrap().inner.is_elder() {
         poll_until(&env, &mut nodes, |nodes| {
-            nodes.last().unwrap().inner.is_peer_our_member(&new_id)
+            nodes
+                .last()
+                .unwrap()
+                .inner
+                .is_peer_our_member(new_id.name())
         })
     }
 
@@ -525,7 +529,7 @@ fn node_pause_and_resume_during_split() {
 // Pauses a random node and poll the network for a while. Returns the paused state.
 fn pause_node_and_poll(env: &Environment, nodes: &mut Vec<TestNode>) -> PausedState {
     let index = env.new_rng().gen_range(0, nodes.len());
-    let id = *nodes[index].id();
+    let name = *nodes[index].name();
     let state = nodes.remove(index).inner.pause().unwrap();
 
     // Poll the network for a while and verify the other nodes do not see the node as going offline.
@@ -538,8 +542,8 @@ fn pause_node_and_poll(env: &Environment, nodes: &mut Vec<TestNode>) -> PausedSt
 
     assert!(nodes
         .iter()
-        .filter(|node| node.our_prefix().matches(id.name()) && node.inner.is_elder())
-        .all(|node| node.inner.is_peer_our_member(&id)));
+        .filter(|node| node.our_prefix().matches(&name) && node.inner.is_elder())
+        .all(|node| node.inner.is_peer_our_member(&name)));
 
     state
 }

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -26,7 +26,7 @@ use std::iter;
 // allows churn to happen which doesn't trigger split or allow churn to not increase age.
 const NETWORK_PARAMS: NetworkParams = NetworkParams {
     elder_size: LOWERED_ELDER_SIZE,
-    safe_section_size: LOWERED_ELDER_SIZE + 4,
+    recommended_section_size: LOWERED_ELDER_SIZE + 4,
 };
 
 #[test]
@@ -156,8 +156,8 @@ fn startup_phase() {
     let env = Environment::new(NETWORK_PARAMS);
     let mut nodes = vec![];
 
-    // Only the first `safe_section_size - 1` adds cause age increments, the rest does not.
-    for i in 0..(env.safe_section_size() + 1) {
+    // Only the first `recommended_section_size - 1` adds cause age increments, the rest does not.
+    for i in 0..(env.recommended_section_size() + 1) {
         trace!("add node {}", i);
         add_node_to_section(&env, &mut nodes, &Prefix::default());
 
@@ -175,10 +175,10 @@ fn startup_phase() {
 // were only adding nodes, not removing.
 fn check_root_section_age_counters_after_only_adds(env: &Environment, nodes: &[TestNode]) -> bool {
     // Maximum number of churn events a node can experience during the startup phase:
-    // The startup phase last only while the section has less than safe_section_size nodes which
-    // means it has been through at most safe_section_size - 1 adds. We need to subtract one to
+    // The startup phase last only while the section has less than recommended_section_size nodes which
+    // means it has been through at most recommended_section_size - 1 adds. We need to subtract one to
     // discount the node itself because its age is not affected by its own churn.
-    let max_startup_churn_events = nodes.len().min(env.safe_section_size() - 1) - 1;
+    let max_startup_churn_events = nodes.len().min(env.recommended_section_size() - 1) - 1;
 
     for i in 0..nodes.len() {
         assert!(
@@ -263,7 +263,7 @@ fn churn_until_age_counter(
     let min_section_size = (NETWORK_PARAMS.elder_size + 1) + 1;
 
     // Ensure we are increasing age at each churn event.
-    let max_section_size = NETWORK_PARAMS.safe_section_size - 1;
+    let max_section_size = NETWORK_PARAMS.recommended_section_size - 1;
     assert!(min_section_size < max_section_size);
 
     // Store the name here in case it changes due to relocation.

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -48,7 +48,7 @@ fn message_with_invalid_security(fail_type: FailType) {
     //
     let mut env = Environment::new(NetworkParams {
         elder_size: LOWERED_ELDER_SIZE,
-        safe_section_size: LOWERED_ELDER_SIZE,
+        recommended_section_size: LOWERED_ELDER_SIZE,
     });
     env.expect_panic();
     let mut rng = env.new_rng();

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -88,8 +88,8 @@ fn message_with_invalid_security(fail_type: FailType) {
             FailType::UntrustedProofValidSig => {
                 let invalid_prefix = our_prefix;
                 SectionProofChain::new(SectionKeyInfo::new(
-                    0,
                     invalid_prefix,
+                    0,
                     bls_keys.public_keys().public_key(),
                 ))
             }

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -71,7 +71,7 @@ fn message_with_invalid_security(fail_type: FailType) {
         P2pNode::new(*fake_full.public_id(), socket_addr),
     ))
     .collect();
-    let new_info = EldersInfo::new(members, our_prefix, 10001).unwrap();
+    let new_info = EldersInfo::new(members, our_prefix, 10001);
 
     let content = PlainMessage {
         src: our_prefix,

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -8,9 +8,9 @@
 
 use super::{create_connected_nodes_until_split, poll_all, TestNode, LOWERED_ELDER_SIZE};
 use routing::{
-    generate_bls_threshold_secret_key, mock::Environment, section_proof_slice_for_test,
-    AccumulatingMessage, DstLocation, EldersInfo, FullId, Message, NetworkParams, P2pNode,
-    PlainMessage, Prefix, SectionKeyShare, Variant, XorName,
+    generate_bls_threshold_secret_key, mock::Environment, AccumulatingMessage, DstLocation,
+    EldersInfo, FullId, Message, NetworkParams, P2pNode, PlainMessage, Prefix, SectionKeyInfo,
+    SectionKeyShare, SectionProofChain, Variant, XorName,
 };
 use std::{collections::BTreeMap, iter, net::SocketAddr};
 
@@ -87,7 +87,11 @@ fn message_with_invalid_security(fail_type: FailType) {
                 .unwrap(),
             FailType::UntrustedProofValidSig => {
                 let invalid_prefix = our_prefix;
-                section_proof_slice_for_test(0, invalid_prefix, bls_keys.public_keys().public_key())
+                SectionProofChain::new(SectionKeyInfo::new(
+                    0,
+                    invalid_prefix,
+                    bls_keys.public_keys().public_key(),
+                ))
             }
         };
         let pk_set = bls_keys.public_keys();

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -8,9 +8,9 @@
 
 use super::{create_connected_nodes_until_split, poll_all, TestNode, LOWERED_ELDER_SIZE};
 use routing::{
-    elders_info_for_test, generate_bls_threshold_secret_key, mock::Environment,
-    section_proof_slice_for_test, AccumulatingMessage, DstLocation, FullId, Message, NetworkParams,
-    P2pNode, PlainMessage, Prefix, SectionKeyShare, Variant, XorName,
+    generate_bls_threshold_secret_key, mock::Environment, section_proof_slice_for_test,
+    AccumulatingMessage, DstLocation, EldersInfo, FullId, Message, NetworkParams, P2pNode,
+    PlainMessage, Prefix, SectionKeyShare, Variant, XorName,
 };
 use std::{collections::BTreeMap, iter, net::SocketAddr};
 
@@ -67,11 +67,11 @@ fn message_with_invalid_security(fail_type: FailType) {
 
     let socket_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
     let members: BTreeMap<_, _> = iter::once((
-        *fake_full.public_id(),
+        *fake_full.public_id().name(),
         P2pNode::new(*fake_full.public_id(), socket_addr),
     ))
     .collect();
-    let new_info = elders_info_for_test(members, our_prefix, 10001).unwrap();
+    let new_info = EldersInfo::new(members, our_prefix, 10001).unwrap();
 
     let content = PlainMessage {
         src: our_prefix,

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -217,7 +217,7 @@ pub fn node_joined(nodes: &[TestNode], index: usize) -> bool {
         return false;
     }
 
-    let id = nodes[index].id();
+    let name = nodes[index].name();
 
     nodes
         .iter()
@@ -225,16 +225,16 @@ pub fn node_joined(nodes: &[TestNode], index: usize) -> bool {
         .filter(|node| {
             node.inner
                 .our_prefix()
-                .map(|prefix| prefix.matches(id.name()))
+                .map(|prefix| prefix.matches(&name))
                 .unwrap_or(false)
         })
         .all(|node| {
-            if node.inner.is_peer_our_member(&id) {
+            if node.inner.is_peer_our_member(&name) {
                 true
             } else {
                 trace!(
                     "Node {} is not yet member according to {}",
-                    id.name(),
+                    name,
                     node.name()
                 );
                 false
@@ -247,20 +247,20 @@ pub fn all_nodes_joined(nodes: &[TestNode], indices: impl IntoIterator<Item = us
 }
 
 // Returns whether all nodes recognize the node with the given id as left.
-pub fn node_left(nodes: &[TestNode], id: &PublicId) -> bool {
+pub fn node_left(nodes: &[TestNode], name: &XorName) -> bool {
     nodes
         .iter()
         .filter(|node| node.inner.is_elder())
         .all(|node| {
             // Note: need both checks because even if a node has been consensused as offline, it
             // can still be considered as elder until the new `SectionInfo`.
-            if node.inner.is_peer_our_member(id) {
-                trace!("Node {} is still member according to {}", id, node.name());
+            if node.inner.is_peer_our_member(name) {
+                trace!("Node {} is still member according to {}", name, node.name());
                 return false;
             }
 
-            if node.inner.is_peer_elder(id) {
-                trace!("Node {} is still elder according to {}", id, node.name());
+            if node.inner.is_peer_elder(name) {
+                trace!("Node {} is still elder according to {}", name, node.name());
                 return false;
             }
 
@@ -768,19 +768,19 @@ pub fn add_node_to_section(env: &Environment, nodes: &mut Vec<TestNode>, prefix:
 }
 
 // Removes one elder node from the given prefix but only from nodes in the given index range.
-// Returns the id of the removed node.
+// Returns the name of the removed node.
 fn remove_elder_from_section_in_range(
     nodes: &mut Vec<TestNode>,
     prefix: &Prefix<XorName>,
     index_range: Range<usize>,
-) -> PublicId {
+) -> XorName {
     let index = indexed_nodes_with_prefix(&nodes[index_range], prefix)
         .find(|(_, node)| node.inner.is_elder())
         .map(|(index, _)| index)
         .unwrap();
 
     info!("Remove node {} from {:?}", nodes[index].name(), prefix);
-    *nodes.remove(index).id()
+    *nodes.remove(index).name()
 }
 
 // Generate random prefixes with the given lengths.

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -405,9 +405,15 @@ pub fn add_connected_nodes_until_one_away_from_split(
     let sub_prefix_last_bit = env.new_rng().gen();
     let sub_prefix = prefix_to_nearly_split.pushed(sub_prefix_last_bit);
     let (count0, count1) = if sub_prefix_last_bit {
-        (env.safe_section_size(), env.safe_section_size() - 1)
+        (
+            env.recommended_section_size(),
+            env.recommended_section_size() - 1,
+        )
     } else {
-        (env.safe_section_size() - 1, env.safe_section_size())
+        (
+            env.recommended_section_size() - 1,
+            env.recommended_section_size(),
+        )
     };
 
     add_mature_nodes(env, nodes, prefix_to_nearly_split, count0, count1);
@@ -417,14 +423,14 @@ pub fn add_connected_nodes_until_one_away_from_split(
 
 /// Split the section by adding and/or removing nodes to/from it.
 pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Prefix<XorName>) {
-    // To trigger split, we need the section to contain at least `safe_section_size` *mature* nodes
+    // To trigger split, we need the section to contain at least `recommended_section_size` *mature* nodes
     // from each sub-prefix.
     add_mature_nodes(
         env,
         nodes,
         prefix,
-        env.safe_section_size(),
-        env.safe_section_size(),
+        env.recommended_section_size(),
+        env.recommended_section_size(),
     );
 
     // Verify the split actually happened.
@@ -434,7 +440,7 @@ pub fn trigger_split(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Pref
 
 /// Add/remove nodes to the given section until it has exactly `count0` mature nodes from the
 /// 0-ending subprefix and `count1` mature nodes from the 1-ending subprefix.
-/// Note: if `count0` and `count1` are both at least `safe_section_size`, this causes the section
+/// Note: if `count0` and `count1` are both at least `recommended_section_size`, this causes the section
 /// to split.
 pub fn add_mature_nodes(
     env: &Environment,


### PR DESCRIPTION
- remove elders history of our section
- simplify `EldersInfo`
- simplify `GenesisPrefixInfo`
- simplify `SectionProofChain`
- use `XorName`, not `PublicId` to lookup peers