### PR TITLE
Update transport module and use latest quic-p2p

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.4"
 bls = { package = "threshold_crypto", version = "~0.3.2" }
-bytes = "~0.4.12"
-crossbeam-channel = "~0.3.9"
+bytes = "~0.5.4"
+crossbeam-channel = "~0.4.2"
 ctrlc = { version = "~3", optional = true, features = ["termination"] }
 derive_more = "0.99.2"
 ed25519_dalek = { package = "tmp-ed25519", version = "1.0.0-pre.3", features = ["serde"] }
@@ -28,10 +28,10 @@ itertools = "~0.6.1"
 lazy_static = { version = "~1", optional = true }
 log = "~0.4.8"
 lru_time_cache = "~0.8.1"
-mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", tag = "0.5.0", optional = true }
+mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", optional = true }
 num-bigint = "~0.1.40"
-parsec = "0.6.0"
-quic-p2p = "~0.5.0"
+parsec = "0.7.0"
+quic-p2p = { version = "0.6.0", features = ["upnp"] }
 # rand in the versions used for compatibility
 rand = "0.7.2"
 rand_crypto = { package = "rand", version = "~0.6.5" }

--- a/src/core.rs
+++ b/src/core.rs
@@ -19,7 +19,7 @@ use crate::{
     rng::{self, MainRng},
     time::Duration,
     timer::Timer,
-    transport::{PeerStatus, Transport, TransportBuilder},
+    transport::{PeerStatus, Transport},
     xor_space::XorName,
 };
 use bytes::Bytes;
@@ -49,10 +49,7 @@ impl Core {
         let full_id = config.full_id.unwrap_or_else(|| FullId::gen(&mut rng));
 
         config.transport_config.our_type = OurType::Node;
-        let transport = match TransportBuilder::new(transport_event_tx)
-            .with_config(config.transport_config)
-            .build()
-        {
+        let transport = match Transport::new(transport_event_tx, config.transport_config) {
             Ok(transport) => transport,
             Err(err) => panic!("Unable to start network transport: {:?}", err),
         };

--- a/src/messages/with_bytes.rs
+++ b/src/messages/with_bytes.rs
@@ -114,7 +114,7 @@ mod tests {
 
         let full_msg = unwrap!(Message::from_bytes(bytes));
         let partial_msg = unwrap!(PartialMessage::from_bytes(bytes));
-        let partial_msg_head = unwrap!(PartialMessage::from_bytes(&bytes.slice(0, 40)));
+        let partial_msg_head = unwrap!(PartialMessage::from_bytes(&bytes.slice(0..40)));
 
         let expected_partial = PartialMessage { dst: msg.dst };
 

--- a/src/node/tests/bootstrapping.rs
+++ b/src/node/tests/bootstrapping.rs
@@ -11,7 +11,8 @@ use crate::{
     messages::{Message, Variant},
     mock::Environment,
     node::{Node, NodeConfig, BOOTSTRAP_TIMEOUT},
-    quic_p2p::{Builder, EventSenders, Peer},
+    quic_p2p::{EventSenders, Peer},
+    transport::Transport,
     TransportConfig, TransportEvent,
 };
 use crossbeam_channel::{self as mpmc, TryRecvError};
@@ -31,10 +32,7 @@ fn lose_proxy_connection() {
     };
     let node_a_endpoint = env.gen_addr();
     let node_a_config = TransportConfig::node().with_endpoint(node_a_endpoint);
-    let node_a_network_service = Builder::new(node_a_event_tx)
-        .with_config(node_a_config)
-        .build()
-        .unwrap();
+    let node_a_network_service = Transport::new(node_a_event_tx, node_a_config).unwrap();
 
     // Construct a node "B" which will start in the bootstrapping stage and bootstrap off the
     // network service above.

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -535,7 +535,7 @@ impl JoiningPeer {
             let (client_tx, _) = crossbeam_channel::unbounded();
             (quic_p2p::EventSenders { node_tx, client_tx }, node_rx)
         };
-        let network_service = quic_p2p::Builder::new(network_event_tx).build().unwrap();
+        let network_service = quic_p2p::QuicP2p::new(network_event_tx).unwrap();
 
         Self {
             network_service,


### PR DESCRIPTION
This PR also updates the versions of bytes, crossbeam-channel and
parsec