### PR TITLE
Pull model

### DIFF
--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -190,7 +190,7 @@ impl ConsensusEngine {
             AccumulatingEvent::SectionInfo(..)
             | AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
-            | AccumulatingEvent::NeighbourInfo(_)
+            | AccumulatingEvent::NeighbourInfo { .. }
             | AccumulatingEvent::SendNeighbourInfo(_)
             | AccumulatingEvent::TheirKeyInfo { .. }
             | AccumulatingEvent::TheirKnowledge { .. }

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -191,7 +191,7 @@ impl ConsensusEngine {
             | AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::NeighbourInfo { .. }
-            | AccumulatingEvent::SendNeighbourInfo(_)
+            | AccumulatingEvent::SendNeighbourInfo { .. }
             | AccumulatingEvent::TheirKeyInfo { .. }
             | AccumulatingEvent::TheirKnowledge { .. }
             | AccumulatingEvent::ParsecPrune

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -16,8 +16,8 @@ pub use self::{
     event_accumulator::{AccumulatingProof, InsertError},
     genesis_prefix_info::GenesisPrefixInfo,
     network_event::{
-        AccumulatingEvent, AckMessagePayload, EventSigPayload, IntoAccumulatingEvent,
-        NeighbourEldersRemoved, NetworkEvent, OnlinePayload, SendAckMessagePayload,
+        AccumulatingEvent, EventSigPayload, IntoAccumulatingEvent, NeighbourEldersRemoved,
+        NetworkEvent, OnlinePayload,
     },
     parsec::{
         generate_bls_threshold_secret_key, generate_first_dkg_result, Block, CreateGossipError,
@@ -193,17 +193,10 @@ impl ConsensusEngine {
             | AccumulatingEvent::NeighbourInfo(_)
             | AccumulatingEvent::TheirKeyInfo { .. }
             | AccumulatingEvent::TheirKnowledge { .. }
-            | AccumulatingEvent::AckMessage(_)
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::Relocate(_)
             | AccumulatingEvent::RelocatePrepare(_, _)
             | AccumulatingEvent::User(_) => our_elders.is_quorum(proofs),
-
-            AccumulatingEvent::SendAckMessage(_) => {
-                // We may not reach consensus if malicious peer, but when we do we know all our
-                // nodes have updated `their_keys`.
-                our_elders.is_total_consensus(proofs)
-            }
 
             AccumulatingEvent::Genesis { .. }
             | AccumulatingEvent::StartDkg(_)

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -191,6 +191,7 @@ impl ConsensusEngine {
             | AccumulatingEvent::Online(_)
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::NeighbourInfo(_)
+            | AccumulatingEvent::SendNeighbourInfo(_)
             | AccumulatingEvent::TheirKeyInfo { .. }
             | AccumulatingEvent::TheirKnowledge { .. }
             | AccumulatingEvent::ParsecPrune

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -192,6 +192,7 @@ impl ConsensusEngine {
             | AccumulatingEvent::Offline(_)
             | AccumulatingEvent::NeighbourInfo(_)
             | AccumulatingEvent::TheirKeyInfo { .. }
+            | AccumulatingEvent::TheirKnowledge { .. }
             | AccumulatingEvent::AckMessage(_)
             | AccumulatingEvent::ParsecPrune
             | AccumulatingEvent::Relocate(_)

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -150,7 +150,9 @@ impl Debug for AccumulatingEvent {
             Self::Online(payload) => write!(formatter, "Online({:?})", payload),
             Self::Offline(id) => write!(formatter, "Offline({})", id),
             Self::SectionInfo(info, _) => write!(formatter, "SectionInfo({:?})", info),
-            Self::NeighbourInfo(info) => write!(formatter, "NeighbourInfo({:?})", info),
+            Self::NeighbourInfo(elders_info) => {
+                write!(formatter, "NeighbourInfo({:?})", elders_info)
+            }
             Self::SendNeighbourInfo(prefix) => write!(formatter, "SendNeighbourInfo({:?})", prefix),
             Self::TheirKeyInfo { prefix, key } => write!(
                 formatter,

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -107,6 +107,12 @@ pub enum AccumulatingEvent {
         key: bls::PublicKey,
     },
 
+    // Voted to update their knowledge of our section.
+    TheirKnowledge {
+        prefix: Prefix<XorName>,
+        knowledge: u64,
+    },
+
     // Voted for received AckMessage to update their_knowledge
     AckMessage(AckMessagePayload),
 
@@ -172,6 +178,11 @@ impl Debug for AccumulatingEvent {
                 formatter,
                 "TheirKeyInfo {{ prefix: {:?}, key: {:?} }}",
                 prefix, key
+            ),
+            Self::TheirKnowledge { prefix, knowledge } => write!(
+                formatter,
+                "TheirKnowledge {{ prefix: {:?}, knowledge: {} }}",
+                prefix, knowledge
             ),
             Self::AckMessage(payload) => write!(formatter, "AckMessage({:?})", payload),
             Self::SendAckMessage(payload) => write!(formatter, "SendAckMessage({:?})", payload),

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -21,26 +21,6 @@ use std::{
 };
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub struct AckMessagePayload {
-    /// The name of the section that message was for. This is important as we may get a message
-    /// when we are still pre-split, think it is for us, but it was not.
-    /// (i.e sent to 00, and we are 01, but lagging at 0 we are valid destination).
-    pub dst_name: XorName,
-    /// The prefix of our section when we acknowledge their SectionInfo of version ack_version.
-    pub src_prefix: Prefix<XorName>,
-    /// The key acknowledged.
-    pub ack_key: bls::PublicKey,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub struct SendAckMessagePayload {
-    /// The prefix acknowledged.
-    pub ack_prefix: Prefix<XorName>,
-    /// The key acknowledged.
-    pub ack_key: bls::PublicKey,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct EventSigPayload {
     /// The public key share for that signature share
     pub pub_key_share: bls::PublicKeyShare,
@@ -113,12 +93,6 @@ pub enum AccumulatingEvent {
         knowledge: u64,
     },
 
-    // Voted for received AckMessage to update their_knowledge
-    AckMessage(AckMessagePayload),
-
-    // Voted for sending AckMessage (Require 100% consensus)
-    SendAckMessage(SendAckMessagePayload),
-
     // Prune the gossip graph.
     ParsecPrune,
 
@@ -184,8 +158,6 @@ impl Debug for AccumulatingEvent {
                 "TheirKnowledge {{ prefix: {:?}, knowledge: {} }}",
                 prefix, knowledge
             ),
-            Self::AckMessage(payload) => write!(formatter, "AckMessage({:?})", payload),
-            Self::SendAckMessage(payload) => write!(formatter, "SendAckMessage({:?})", payload),
             Self::ParsecPrune => write!(formatter, "ParsecPrune"),
             Self::Relocate(payload) => write!(formatter, "Relocate({:?})", payload),
             Self::RelocatePrepare(payload, count_down) => {

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -78,8 +78,11 @@ pub enum AccumulatingEvent {
 
     SectionInfo(EldersInfo, bls::PublicKey),
 
-    // Voted for received message with info to update neighbour_info.
+    // Voted for received message with info about a neighbour section.
     NeighbourInfo(EldersInfo),
+
+    // Voted to send info about our section to a neighbour section.
+    SendNeighbourInfo(Prefix<XorName>),
 
     // Voted for received message with keys to update their_keys
     TheirKeyInfo {
@@ -148,6 +151,7 @@ impl Debug for AccumulatingEvent {
             Self::Offline(id) => write!(formatter, "Offline({})", id),
             Self::SectionInfo(info, _) => write!(formatter, "SectionInfo({:?})", info),
             Self::NeighbourInfo(info) => write!(formatter, "NeighbourInfo({:?})", info),
+            Self::SendNeighbourInfo(prefix) => write!(formatter, "SendNeighbourInfo({:?})", prefix),
             Self::TheirKeyInfo { prefix, key } => write!(
                 formatter,
                 "TheirKeyInfo {{ prefix: {:?}, key: {:?} }}",

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -9,6 +9,7 @@
 use crate::{
     consensus::{DkgResultWrapper, Observation, ParsecNetworkEvent},
     id::{P2pNode, PublicId},
+    messages::MessageHash,
     relocation::RelocateDetails,
     section::{EldersInfo, SectionMap},
     Prefix, XorName,
@@ -84,8 +85,9 @@ pub enum AccumulatingEvent {
     // Voted to send info about our section to a neighbour section.
     SendNeighbourInfo {
         dst: Prefix<XorName>,
-        dst_key: bls::PublicKey,
-        our_key_index: u64,
+        // Hash of the incoming message that triggered this vote. It's purpose is to make the votes
+        // triggered by different message unique.
+        nonce: MessageHash,
     },
 
     // Voted for received message with keys to update their_keys
@@ -157,14 +159,10 @@ impl Debug for AccumulatingEvent {
             Self::NeighbourInfo(elders_info, _) => {
                 write!(formatter, "NeighbourInfo({:?}, ..)", elders_info)
             }
-            Self::SendNeighbourInfo {
-                dst,
-                dst_key,
-                our_key_index,
-            } => write!(
+            Self::SendNeighbourInfo { dst, nonce } => write!(
                 formatter,
-                "SendNeighbourInfo {{ dst: {:?}, dst_key: {:?}, our_key_index: {:?} }}",
-                dst, dst_key, our_key_index
+                "SendNeighbourInfo {{ dst: {:?}, nonce: {:?} }}",
+                dst, nonce
             ),
             Self::TheirKeyInfo { prefix, key } => write!(
                 formatter,

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -84,7 +84,7 @@ pub enum AccumulatingEvent {
 
     // Voted to send info about our section to a neighbour section.
     SendNeighbourInfo {
-        dst: Prefix<XorName>,
+        dst: XorName,
         // Hash of the incoming message that triggered this vote. It's purpose is to make the votes
         // triggered by different message unique.
         nonce: MessageHash,

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -226,7 +226,7 @@ pub struct NeighbourEldersRemoved(pub BTreeSet<P2pNode>);
 
 impl NeighbourEldersRemoved {
     pub fn builder(sections: &SectionMap) -> NeighbourEldersRemovedBuilder {
-        NeighbourEldersRemovedBuilder(sections.other_elders().cloned().collect())
+        NeighbourEldersRemovedBuilder(sections.neighbour_elders().cloned().collect())
     }
 }
 
@@ -234,7 +234,7 @@ pub struct NeighbourEldersRemovedBuilder(BTreeSet<P2pNode>);
 
 impl NeighbourEldersRemovedBuilder {
     pub fn build(mut self, sections: &SectionMap) -> NeighbourEldersRemoved {
-        for p2p_node in sections.other_elders() {
+        for p2p_node in sections.neighbour_elders() {
             let _ = self.0.remove(p2p_node);
         }
 

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -79,10 +79,14 @@ pub enum AccumulatingEvent {
     SectionInfo(EldersInfo, bls::PublicKey),
 
     // Voted for received message with info about a neighbour section.
-    NeighbourInfo(EldersInfo),
+    NeighbourInfo(EldersInfo, bls::PublicKey),
 
     // Voted to send info about our section to a neighbour section.
-    SendNeighbourInfo(Prefix<XorName>),
+    SendNeighbourInfo {
+        dst: Prefix<XorName>,
+        dst_key: bls::PublicKey,
+        our_key_index: u64,
+    },
 
     // Voted for received message with keys to update their_keys
     TheirKeyInfo {
@@ -149,11 +153,19 @@ impl Debug for AccumulatingEvent {
             ),
             Self::Online(payload) => write!(formatter, "Online({:?})", payload),
             Self::Offline(id) => write!(formatter, "Offline({})", id),
-            Self::SectionInfo(info, _) => write!(formatter, "SectionInfo({:?})", info),
-            Self::NeighbourInfo(elders_info) => {
-                write!(formatter, "NeighbourInfo({:?})", elders_info)
+            Self::SectionInfo(info, _) => write!(formatter, "SectionInfo({:?}, ..)", info),
+            Self::NeighbourInfo(elders_info, _) => {
+                write!(formatter, "NeighbourInfo({:?}, ..)", elders_info)
             }
-            Self::SendNeighbourInfo(prefix) => write!(formatter, "SendNeighbourInfo({:?})", prefix),
+            Self::SendNeighbourInfo {
+                dst,
+                dst_key,
+                our_key_index,
+            } => write!(
+                formatter,
+                "SendNeighbourInfo {{ dst: {:?}, dst_key: {:?}, our_key_index: {:?} }}",
+                dst, dst_key, our_key_index
+            ),
             Self::TheirKeyInfo { prefix, key } => write!(
                 formatter,
                 "TheirKeyInfo {{ prefix: {:?}, key: {:?} }}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub mod rng;
 #[cfg(feature = "mock_base")]
 pub use self::{
     consensus::generate_bls_threshold_secret_key,
-    messages::{AccumulatingMessage, Message, PlainMessage, Variant},
+    messages::{AccumulatingMessage, Message, MessageHash, PlainMessage, Variant},
     network_params::NetworkParams,
     relocation::Overrides as RelocationOverrides,
     routing_table::delivery_group_size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use self::{
     network_params::NetworkParams,
     relocation::Overrides as RelocationOverrides,
     routing_table::delivery_group_size,
-    section::{quorum_count, EldersInfo, SectionKeyShare, SectionProofChain, MIN_AGE},
+    section::{quorum_count, EldersInfo, IndexedSecretKeyShare, SectionProofChain, MIN_AGE},
     xor_space::Xorable,
 };
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -51,8 +51,6 @@ pub enum DstLocation {
     Node(XorName),
     /// Destination are the nodes of the section whose prefix matches the given name.
     Section(XorName),
-    /// Destination are the nodes whose name is matched by the given prefix.
-    Prefix(Prefix<XorName>),
     /// Destination is the node at the `ConnectionInfo` the message is directly sent to.
     Direct,
 }
@@ -62,7 +60,7 @@ impl DstLocation {
     pub fn is_single(&self) -> bool {
         match self {
             Self::Node(_) | Self::Direct => true,
-            Self::Section(_) | Self::Prefix(_) => false,
+            Self::Section(_) => false,
         }
     }
 
@@ -75,7 +73,6 @@ impl DstLocation {
     pub fn is_compatible(&self, other_prefix: &Prefix<XorName>) -> bool {
         match self {
             Self::Section(name) | Self::Node(name) => other_prefix.matches(name),
-            Self::Prefix(prefix) => other_prefix.is_compatible(prefix),
             Self::Direct => false,
         }
     }
@@ -84,7 +81,7 @@ impl DstLocation {
     pub fn as_node(&self) -> Result<&XorName> {
         match self {
             Self::Node(name) => Ok(name),
-            Self::Section(_) | Self::Prefix(_) | Self::Direct => Err(RoutingError::BadLocation),
+            Self::Section(_) | Self::Direct => Err(RoutingError::BadLocation),
         }
     }
 
@@ -92,15 +89,7 @@ impl DstLocation {
     pub fn as_section(&self) -> Result<&XorName> {
         match self {
             Self::Section(name) => Ok(name),
-            Self::Node(_) | Self::Prefix(_) | Self::Direct => Err(RoutingError::BadLocation),
-        }
-    }
-
-    /// If this location is `Prefix`, returns it, otherwise error.
-    pub fn as_prefix(&self) -> Result<&Prefix<XorName>> {
-        match self {
-            Self::Prefix(prefix) => Ok(prefix),
-            Self::Node(_) | Self::Section(_) | Self::Direct => Err(RoutingError::BadLocation),
+            Self::Node(_) | Self::Direct => Err(RoutingError::BadLocation),
         }
     }
 
@@ -115,7 +104,6 @@ impl DstLocation {
         match self {
             DstLocation::Node(self_name) => name == self_name,
             DstLocation::Section(self_name) => prefix.matches(self_name),
-            DstLocation::Prefix(self_prefix) => prefix.is_compatible(self_prefix),
             DstLocation::Direct => true,
         }
     }

--- a/src/messages/accumulating_message.rs
+++ b/src/messages/accumulating_message.rs
@@ -9,7 +9,7 @@
 use super::{DstLocation, Message, MessageHash, SrcAuthority, Variant};
 use crate::{
     error::Result,
-    section::{SectionKeyShare, SectionProofChain},
+    section::{IndexedSecretKeyShare, SectionProofChain},
     xor_space::{Prefix, XorName},
 };
 use bincode::serialize;
@@ -31,14 +31,14 @@ impl AccumulatingMessage {
     /// Create new `AccumulatingMessage`
     pub fn new(
         content: PlainMessage,
-        section_share: &SectionKeyShare,
+        secret_key_share: &IndexedSecretKeyShare,
         public_key_set: bls::PublicKeySet,
         proof: SectionProofChain,
     ) -> Result<Self> {
         let bytes = content.serialize_for_signing()?;
         let mut signature_shares = BTreeSet::new();
-        let sig_share = section_share.key.sign(&bytes);
-        let _ = signature_shares.insert((section_share.index, sig_share));
+        let sig_share = secret_key_share.key.sign(&bytes);
+        let _ = signature_shares.insert((secret_key_share.index, sig_share));
 
         Ok(Self {
             content,
@@ -180,8 +180,8 @@ mod tests {
         let pk_set = sk_set.public_keys();
         let pk = pk_set.public_key();
 
-        let sk_share_0 = SectionKeyShare::new_with_position(0, sk_set.secret_key_share(0));
-        let sk_share_1 = SectionKeyShare::new_with_position(1, sk_set.secret_key_share(1));
+        let sk_share_0 = IndexedSecretKeyShare::from_set(&sk_set, 0);
+        let sk_share_1 = IndexedSecretKeyShare::from_set(&sk_set, 1);
 
         let content = gen_message(&mut rng);
         let proof = make_proof_chain(&pk_set);
@@ -217,9 +217,9 @@ mod tests {
         let pk_set = sk_set.public_keys();
         let pk = pk_set.public_key();
 
-        let sk_share_0 = SectionKeyShare::new_with_position(0, sk_set.secret_key_share(0));
-        let sk_share_1 = SectionKeyShare::new_with_position(1, sk_set.secret_key_share(1));
-        let sk_share_2 = SectionKeyShare::new_with_position(2, sk_set.secret_key_share(2));
+        let sk_share_0 = IndexedSecretKeyShare::from_set(&sk_set, 0);
+        let sk_share_1 = IndexedSecretKeyShare::from_set(&sk_set, 1);
+        let sk_share_2 = IndexedSecretKeyShare::from_set(&sk_set, 2);
 
         let content = gen_message(&mut rng);
         let proof = make_proof_chain(&pk_set);

--- a/src/messages/accumulating_message.rs
+++ b/src/messages/accumulating_message.rs
@@ -115,6 +115,7 @@ impl AccumulatingMessage {
             },
             dst: self.content.dst,
             variant: self.content.variant,
+            dst_key: Some(self.dst_key),
         })
     }
 

--- a/src/messages/accumulating_message.rs
+++ b/src/messages/accumulating_message.rs
@@ -25,6 +25,8 @@ pub struct AccumulatingMessage {
     pub proof: SectionProofChain,
     pub public_key_set: bls::PublicKeySet,
     pub signature_shares: BTreeSet<(usize, bls::SignatureShare)>,
+    // The latest key of the destination section according to our knowledge.
+    pub dst_key: bls::PublicKey,
 }
 
 impl AccumulatingMessage {
@@ -34,6 +36,7 @@ impl AccumulatingMessage {
         secret_key_share: &IndexedSecretKeyShare,
         public_key_set: bls::PublicKeySet,
         proof: SectionProofChain,
+        dst_key: bls::PublicKey,
     ) -> Result<Self> {
         let bytes = content.serialize_for_signing()?;
         let mut signature_shares = BTreeSet::new();
@@ -45,6 +48,7 @@ impl AccumulatingMessage {
             proof,
             public_key_set,
             signature_shares,
+            dst_key,
         })
     }
 
@@ -168,7 +172,8 @@ mod tests {
         consensus::generate_bls_threshold_secret_key,
         messages::VerifyStatus,
         rng::{self, MainRng},
-        unwrap, Prefix,
+        section::gen_secret_key,
+        Prefix,
     };
     use rand::{self, Rng};
     use std::iter;
@@ -184,28 +189,28 @@ mod tests {
         let sk_share_1 = IndexedSecretKeyShare::from_set(&sk_set, 1);
 
         let content = gen_message(&mut rng);
+        let dst_key = gen_secret_key(&mut rng).public_key();
         let proof = make_proof_chain(&pk_set);
 
-        let mut msg_0 = unwrap!(AccumulatingMessage::new(
+        let mut msg_0 = AccumulatingMessage::new(
             content.clone(),
             &sk_share_0,
             pk_set.clone(),
             proof.clone(),
-        ));
+            dst_key,
+        )
+        .unwrap();
         assert!(!msg_0.check_fully_signed());
 
-        let msg_1 = unwrap!(AccumulatingMessage::new(
-            content,
-            &sk_share_1,
-            pk_set,
-            proof
-        ));
+        let msg_1 = AccumulatingMessage::new(content, &sk_share_1, pk_set, proof, dst_key).unwrap();
         msg_0.add_signature_shares(msg_1);
         assert!(msg_0.check_fully_signed());
 
-        let msg = unwrap!(msg_0.combine_signatures());
+        let msg = msg_0
+            .combine_signatures()
+            .expect("failed to combine signatures");
         assert_eq!(
-            unwrap!(msg.verify(iter::once((&Prefix::default(), &pk)))),
+            msg.verify(iter::once((&Prefix::default(), &pk))).unwrap(),
             VerifyStatus::Full
         );
     }
@@ -222,15 +227,18 @@ mod tests {
         let sk_share_2 = IndexedSecretKeyShare::from_set(&sk_set, 2);
 
         let content = gen_message(&mut rng);
+        let dst_key = gen_secret_key(&mut rng).public_key();
         let proof = make_proof_chain(&pk_set);
 
         // Message with valid signature
-        let mut msg_0 = unwrap!(AccumulatingMessage::new(
+        let mut msg_0 = AccumulatingMessage::new(
             content.clone(),
             &sk_share_0,
             pk_set.clone(),
-            proof.clone()
-        ));
+            proof.clone(),
+            dst_key,
+        )
+        .unwrap();
 
         // Message with invalid signature
         let invalid_signature_share = sk_share_1.key.sign(b"bad message");
@@ -239,6 +247,7 @@ mod tests {
             proof: proof.clone(),
             public_key_set: pk_set.clone(),
             signature_shares: iter::once((1, invalid_signature_share)).collect(),
+            dst_key,
         };
 
         msg_0.add_signature_shares(msg_1);
@@ -248,20 +257,17 @@ mod tests {
         assert!(!msg_0.check_fully_signed());
 
         // Another valid signature
-        let msg_2 = unwrap!(AccumulatingMessage::new(
-            content,
-            &sk_share_2,
-            pk_set,
-            proof
-        ));
+        let msg_2 = AccumulatingMessage::new(content, &sk_share_2, pk_set, proof, dst_key).unwrap();
         msg_0.add_signature_shares(msg_2);
 
         // There are now two valid signatures which is enough.
         assert!(msg_0.check_fully_signed());
 
-        let msg = unwrap!(msg_0.combine_signatures());
+        let msg = msg_0
+            .combine_signatures()
+            .expect("failed to combine signatures");
         assert_eq!(
-            unwrap!(msg.verify(iter::once((&Prefix::default(), &pk)))),
+            msg.verify(iter::once((&Prefix::default(), &pk))).unwrap(),
             VerifyStatus::Full
         );
     }

--- a/src/messages/hash.rs
+++ b/src/messages/hash.rs
@@ -11,10 +11,11 @@ use hex_fmt::HexFmt;
 use std::fmt::{self, Debug, Formatter};
 
 /// Cryptographic hash of Message
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct MessageHash(Digest256);
 
 impl MessageHash {
+    /// Compute hash of the given message.
     pub fn from_bytes(bytes: &[u8]) -> Self {
         Self(crypto::sha3_256(bytes))
     }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -158,6 +158,16 @@ where
     )
 }
 
+/// What to do with an incomming message.
+pub enum MessageAction {
+    /// Message will be handled
+    Handle,
+    /// Message will be bounced back to the sender
+    Bounce,
+    /// Message will be discarded
+    Discard,
+}
+
 fn serialize_for_section_signing(
     dst: &DstLocation,
     dst_key: Option<&bls::PublicKey>,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -96,15 +96,6 @@ impl Message {
         self.src.verify(&self.dst, &self.variant, their_keys)
     }
 
-    /// If this message is from a section, returns its prefix and the latest section key from the
-    /// message proof. Otherwise `None`.
-    pub fn source_section_key_info(&self) -> Option<(&Prefix<XorName>, &bls::PublicKey)> {
-        match &self.src {
-            SrcAuthority::Node { .. } => None,
-            SrcAuthority::Section { prefix, proof, .. } => Some((prefix, proof.last_key())),
-        }
-    }
-
     pub(crate) fn into_queued(self, sender: Option<SocketAddr>) -> QueuedMessage {
         QueuedMessage {
             message: self,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -41,6 +41,10 @@ pub struct Message {
     pub src: SrcAuthority,
     /// The body of the message.
     pub variant: Variant,
+    /// Source's knowledge of the destination section key. If present, the destination can use it
+    /// to determine the length of the proof of messages sent to the source so the source would
+    /// trust it (the proof needs to start at this key).
+    pub dst_key: Option<bls::PublicKey>,
 }
 
 /// Partially deserialized message.
@@ -80,6 +84,7 @@ impl Message {
                 signature,
             },
             variant,
+            dst_key: None,
         })
     }
 

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -38,17 +38,17 @@ impl SrcAuthority {
         }
     }
 
+    pub fn check_is_section(&self) -> Result<()> {
+        match self {
+            Self::Section { .. } => Ok(()),
+            Self::Node { .. } => Err(RoutingError::BadLocation),
+        }
+    }
+
     pub fn as_node(&self) -> Result<&PublicId> {
         match self {
             Self::Node { public_id, .. } => Ok(public_id),
             Self::Section { .. } => Err(RoutingError::BadLocation),
-        }
-    }
-
-    pub fn as_section(&self) -> Result<&Prefix<XorName>> {
-        match self {
-            Self::Section { prefix, .. } => Ok(prefix),
-            Self::Node { .. } => Err(RoutingError::BadLocation),
         }
     }
 

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -61,6 +61,7 @@ impl SrcAuthority {
     pub fn verify<'a, I>(
         &'a self,
         dst: &DstLocation,
+        dst_key: Option<&bls::PublicKey>,
         variant: &Variant,
         trusted_key_infos: I,
     ) -> Result<VerifyStatus>
@@ -72,7 +73,7 @@ impl SrcAuthority {
                 public_id,
                 signature,
             } => {
-                let bytes = super::serialize_for_node_signing(public_id, dst, variant)?;
+                let bytes = super::serialize_for_node_signing(public_id, dst, dst_key, variant)?;
                 if !public_id.verify(&bytes, signature) {
                     return Err(RoutingError::FailedSignature);
                 }
@@ -93,7 +94,7 @@ impl SrcAuthority {
                     TrustStatus::Invalid => return Err(RoutingError::UntrustedMessage),
                 };
 
-                let bytes = super::serialize_for_section_signing(dst, variant)?;
+                let bytes = super::serialize_for_section_signing(dst, dst_key, variant)?;
                 if !proof.last_key().verify(signature, &bytes) {
                     return Err(RoutingError::FailedSignature);
                 }

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -103,4 +103,12 @@ impl SrcAuthority {
 
         Ok(VerifyStatus::Full)
     }
+
+    // If this is `Section`, returns the prefix and the latest key, otherwise `None`.
+    pub(crate) fn section_prefix_and_key(&self) -> Option<(&Prefix<XorName>, &bls::PublicKey)> {
+        match self {
+            SrcAuthority::Section { prefix, proof, .. } => Some((prefix, proof.last_key())),
+            SrcAuthority::Node { .. } => None,
+        }
+    }
 }

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -11,7 +11,7 @@ use crate::{
     consensus::{GenesisPrefixInfo, ParsecRequest, ParsecResponse},
     relocation::{RelocateDetails, RelocatePayload},
     section::EldersInfo,
-    xor_space::{Prefix, XorName},
+    xor_space::XorName,
 };
 use bytes::Bytes;
 use hex_fmt::HexFmt;
@@ -31,15 +31,6 @@ pub enum Variant {
     /// Approves the joining node as a routing node.
     /// Section X -> Node joining X
     NodeApproval(Box<GenesisPrefixInfo>),
-    /// Acknowledgement that the src section knows that the dst section has the specified
-    /// key.
-    /// Section X -> Section Y
-    AckMessage {
-        /// The prefix of our section when we acknowledge their version.
-        src_prefix: Prefix<XorName>,
-        /// The key acknowledged.
-        ack_key: bls::PublicKey,
-    },
     /// Update sent to Adults and Infants by Elders
     GenesisUpdate(Box<GenesisPrefixInfo>),
     /// Send from a section to the node being relocated.
@@ -83,14 +74,6 @@ impl Debug for Variant {
             Self::NeighbourInfo(payload) => write!(f, "NeighbourInfo({:?})", payload),
             Self::UserMessage(payload) => write!(f, "UserMessage({})", HexFmt(payload)),
             Self::NodeApproval(payload) => write!(f, "NodeApproval({:?})", payload),
-            Self::AckMessage {
-                src_prefix,
-                ack_key,
-            } => f
-                .debug_struct("AckMessage")
-                .field("src_prefix", src_prefix)
-                .field("ack_key", ack_key)
-                .finish(),
             Self::GenesisUpdate(payload) => write!(f, "GenesisUpdate({:?})", payload),
             Self::Relocate(payload) => write!(f, "Relocate({:?})", payload),
             Self::MessageSignature(payload) => write!(f, "MessageSignature({:?})", payload.content),

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -25,7 +25,14 @@ use std::{
 /// Message variant
 pub enum Variant {
     /// Inform neighbours about our new section.
-    NeighbourInfo(EldersInfo),
+    NeighbourInfo {
+        /// `EldersInfo` of the neighbour section.
+        elders_info: EldersInfo,
+        /// Nonce that is derived from the incoming message that triggered sending this
+        /// `NeighbourInfo`. It's purpose is to make sure that `NeighbourInfo`s that are otherwise
+        /// identical but triggered by different messages are not filtered out.
+        nonce: MessageHash,
+    },
     /// User-facing message
     UserMessage(Vec<u8>),
     /// Approves the joining node as a routing node.
@@ -71,7 +78,11 @@ pub enum Variant {
 impl Debug for Variant {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::NeighbourInfo(payload) => write!(f, "NeighbourInfo({:?})", payload),
+            Self::NeighbourInfo { elders_info, nonce } => f
+                .debug_struct("NeighbourInfo")
+                .field("elders_info", elders_info)
+                .field("nonce", nonce)
+                .finish(),
             Self::UserMessage(payload) => write!(f, "UserMessage({})", HexFmt(payload)),
             Self::NodeApproval(payload) => write!(f, "NodeApproval({:?})", payload),
             Self::GenesisUpdate(payload) => write!(f, "GenesisUpdate({:?})", payload),

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -29,8 +29,8 @@ pub enum Variant {
         /// `EldersInfo` of the neighbour section.
         elders_info: EldersInfo,
         /// Nonce that is derived from the incoming message that triggered sending this
-        /// `NeighbourInfo`. It's purpose is to make sure that `NeighbourInfo`s that are otherwise
-        /// identical but triggered by different messages are not filtered out.
+        /// `NeighbourInfo`. It's purpose is to make sure that `NeighbourInfo`s that are identical
+        /// but triggered by different messages are not filtered out.
         nonce: MessageHash,
     },
     /// User-facing message

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -678,17 +678,11 @@ impl Node {
                 _ => unreachable!(),
             },
             Stage::Approved(stage) => match msg.variant {
-                Variant::NeighbourInfo { elders_info, nonce } => {
+                Variant::NeighbourInfo { elders_info, .. } => {
                     // Ensure the src and dst are what we expect.
-                    let _: &Prefix<_> = msg.src.as_section()?;
+                    let src_key = *msg.src.as_section_key()?;
                     let _: &Prefix<_> = msg.dst.as_prefix()?;
-                    stage.handle_neighbour_info(
-                        elders_info,
-                        nonce,
-                        msg.src,
-                        msg.dst,
-                        msg.dst_key,
-                    )?;
+                    stage.handle_neighbour_info(elders_info, src_key)?;
                 }
                 Variant::GenesisUpdate(info) => {
                     let _: &Prefix<_> = msg.src.as_section()?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -684,7 +684,7 @@ impl Node {
                     // Ensure the src and dst are what we expect.
                     let _: &Prefix<_> = msg.src.as_section()?;
                     let _: &Prefix<_> = msg.dst.as_prefix()?;
-                    stage.handle_neighbour_info(elders_info, msg.src, msg.dst)?;
+                    stage.handle_neighbour_info(elders_info, msg.src, msg.dst, msg.dst_key)?;
                 }
                 Variant::AckMessage {
                     src_prefix,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -686,17 +686,6 @@ impl Node {
                     let _: &Prefix<_> = msg.dst.as_prefix()?;
                     stage.handle_neighbour_info(elders_info, msg.src, msg.dst, msg.dst_key)?;
                 }
-                Variant::AckMessage {
-                    src_prefix,
-                    ack_key,
-                } => {
-                    stage.handle_ack_message(
-                        src_prefix,
-                        ack_key,
-                        *msg.src.as_section()?,
-                        *msg.dst.as_section()?,
-                    )?;
-                }
                 Variant::GenesisUpdate(info) => {
                     let _: &Prefix<_> = msg.src.as_section()?;
                     stage.handle_genesis_update(&mut self.core, *info)?;
@@ -1094,6 +1083,13 @@ impl Node {
         self.stage
             .approved()
             .map(|stage| stage.shared_state.our_history.last_key())
+    }
+
+    /// Returns our section proof chain, or `None` if we are not joined yet.
+    pub fn our_history(&self) -> Option<&SectionProofChain> {
+        self.stage
+            .approved()
+            .map(|stage| &stage.shared_state.our_history)
     }
 
     fn shared_state(&self) -> Option<&SharedState> {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -619,7 +619,7 @@ impl Node {
 
     fn handle_message(&mut self, sender: Option<SocketAddr>, msg: Message) -> Result<()> {
         if let Stage::Approved(stage) = &mut self.stage {
-            stage.update_our_knowledge(&msg);
+            stage.update_section_knowledge(&msg);
         }
 
         self.core.msg_queue.push_back(msg.into_queued(sender));

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -335,7 +335,7 @@ impl Node {
         match &self.stage {
             Stage::Bootstrapping(_) | Stage::Joining(_) => match dst {
                 DstLocation::Node(name) => name == self.core.name(),
-                DstLocation::Section(_) | DstLocation::Prefix(_) => false,
+                DstLocation::Section(_) => false,
                 DstLocation::Direct => true,
             },
             Stage::Approved(stage) => {
@@ -681,7 +681,7 @@ impl Node {
                 Variant::NeighbourInfo { elders_info, .. } => {
                     // Ensure the src and dst are what we expect.
                     let src_key = *msg.src.as_section_key()?;
-                    let _: &Prefix<_> = msg.dst.as_prefix()?;
+                    let _: &XorName = msg.dst.as_section()?;
                     stage.handle_neighbour_info(elders_info, src_key)?;
                 }
                 Variant::GenesisUpdate(info) => {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -372,6 +372,8 @@ impl Node {
             return Err(RoutingError::BadLocation);
         }
 
+        let _log_ident = self.set_log_ident();
+
         match &mut self.stage {
             Stage::Bootstrapping(_) | Stage::Joining(_) | Stage::Terminated => {
                 Err(RoutingError::InvalidState)
@@ -634,11 +636,7 @@ impl Node {
     }
 
     fn dispatch_message(&mut self, sender: Option<SocketAddr>, msg: Message) -> Result<()> {
-        // Common messages
-        match msg.variant {
-            Variant::UserMessage(_) => (),
-            _ => trace!("Got {:?}", msg),
-        }
+        trace!("Got {:?}", msg);
 
         match &mut self.stage {
             Stage::Bootstrapping(stage) => match msg.variant {

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1860,10 +1860,11 @@ impl Approved {
         let content = PlainMessage {
             src: *self.shared_state.our_prefix(),
             dst,
+            dst_key,
             variant,
         };
 
-        AccumulatingMessage::new(content, sk_share, pk_set, proof, dst_key)
+        AccumulatingMessage::new(content, sk_share, pk_set, proof)
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -731,6 +731,8 @@ impl Approved {
         core: &mut Core,
         mut msg_with_bytes: MessageWithBytes,
     ) -> Result<()> {
+        trace!("accumulated message {:?}", msg_with_bytes);
+
         // TODO: this is almost the same as `Node::try_handle_message` - find a way
         // to avoid the duplication.
         self.try_relay_message(core, &msg_with_bytes)?;

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -311,11 +311,7 @@ impl Approved {
                 }
             }
             Variant::UserMessage(_) => {
-                if !self.should_handle_user_message(our_id, &msg.dst) {
-                    return Ok(MessageAction::Discard);
-                }
-
-                if self.verify_message(msg)? {
+                if self.should_handle_user_message(our_id, &msg.dst) && self.verify_message(msg)? {
                     Ok(MessageAction::Handle)
                 } else {
                     Ok(MessageAction::Bounce)

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -354,6 +354,7 @@ impl Approved {
         elders_info: EldersInfo,
         src: SrcAuthority,
         dst: DstLocation,
+        dst_key: Option<bls::PublicKey>,
     ) -> Result<()> {
         if self.shared_state.sections.is_new_neighbour(&elders_info) {
             let _ = self
@@ -366,6 +367,7 @@ impl Approved {
                     src,
                     dst,
                     variant: Variant::NeighbourInfo(elders_info.clone()),
+                    dst_key,
                 });
 
             self.vote_for_event(AccumulatingEvent::NeighbourInfo(elders_info));

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1935,6 +1935,11 @@ impl Approved {
         let proof = self.shared_state.prove(&dst, node_knowledge_override);
         let pk_set = self.section_keys_provider.public_key_set().clone();
         let sk_share = self.section_keys_provider.secret_key_share()?;
+        let dst_key = *self
+            .shared_state
+            .sections
+            .key_by_location(&dst)
+            .unwrap_or_else(|| self.shared_state.our_history.first_key());
 
         let content = PlainMessage {
             src: *self.shared_state.our_prefix(),
@@ -1942,7 +1947,7 @@ impl Approved {
             variant,
         };
 
-        AccumulatingMessage::new(content, sk_share, pk_set, proof)
+        AccumulatingMessage::new(content, sk_share, pk_set, proof, dst_key)
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1355,6 +1355,10 @@ impl Approved {
         core: &mut Core,
         dst: Prefix<XorName>,
     ) -> Result<()> {
+        if !self.is_our_elder(core.id()) {
+            return Ok(());
+        }
+
         self.send_routing_message(
             core,
             SrcLocation::Section(*self.shared_state.our_prefix()),

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -68,7 +68,7 @@ impl Bootstrapping {
                 Ok(MessageAction::Handle)
             }
 
-            Variant::NeighbourInfo(_)
+            Variant::NeighbourInfo { .. }
             | Variant::UserMessage(_)
             | Variant::NodeApproval(_)
             | Variant::GenesisUpdate(_)

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -67,7 +67,6 @@ impl Bootstrapping {
             Variant::NeighbourInfo(_)
             | Variant::UserMessage(_)
             | Variant::NodeApproval(_)
-            | Variant::AckMessage { .. }
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
             | Variant::MessageSignature(_)

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -84,7 +84,6 @@ impl Joining {
             | Variant::Bounce { .. } => true,
             Variant::NeighbourInfo(_)
             | Variant::UserMessage(_)
-            | Variant::AckMessage { .. }
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
             | Variant::MessageSignature(_)

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -100,7 +100,7 @@ impl Joining {
                 Ok(MessageAction::Handle)
             }
 
-            Variant::NeighbourInfo(_)
+            Variant::NeighbourInfo { .. }
             | Variant::UserMessage(_)
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -159,8 +159,9 @@ fn genesis_update_accumulating_message(
     let secret_key = sender.section_keys_provider.secret_key_share().unwrap();
     let public_key_set = sender.section_keys_provider.public_key_set().clone();
     let proof = sender.state.prove(&content.dst, None);
+    let dst_key = public_key_set.public_key();
 
-    AccumulatingMessage::new(content, secret_key, public_key_set, proof)
+    AccumulatingMessage::new(content, secret_key, public_key_set, proof, dst_key)
 }
 
 fn to_message_signature(sender_id: &FullId, msg: AccumulatingMessage) -> Result<Message> {

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -88,7 +88,7 @@ impl Env {
                 genesis_prefix_info.clone(),
             )?;
 
-            test_utils::handle_message(&mut self.subject, Some(elder.addr), msg)?;
+            test_utils::handle_message(&mut self.subject, elder.addr, msg)?;
         }
 
         Ok(())
@@ -213,7 +213,7 @@ fn genesis_update_message_successful_trust_check() {
     let msg =
         genesis_update_message_signature(&env.elders[0], *env.subject.name(), genesis_prefix_info)
             .unwrap();
-    test_utils::handle_message(&mut env.subject, Some(env.elders[0].addr), msg).unwrap();
+    test_utils::handle_message(&mut env.subject, env.elders[0].addr, msg).unwrap();
     assert_eq!(env.subject.parsec_last_version(), 1);
 }
 
@@ -227,5 +227,5 @@ fn genesis_update_message_failed_trust_check_proof_too_new() {
     let msg =
         genesis_update_message_signature(&env.elders[0], *env.subject.name(), genesis_prefix_info)
             .unwrap();
-    test_utils::handle_message(&mut env.subject, Some(env.elders[0].addr), msg).unwrap();
+    test_utils::handle_message(&mut env.subject, env.elders[0].addr, msg).unwrap();
 }

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -16,7 +16,7 @@ use crate::{
     network_params::NetworkParams,
     node::{Node, NodeConfig},
     rng::{self, MainRng},
-    section::{SectionKeyShare, SectionKeysProvider, SharedState},
+    section::{IndexedSecretKeyShare, SectionKeysProvider, SharedState},
     xor_space::{Prefix, XorName},
 };
 use mock_quic_p2p::Network;
@@ -121,11 +121,7 @@ fn create_elders(rng: &mut MainRng, network: &Network, version: u64) -> Vec<Elde
             );
             let section_keys_provider = SectionKeysProvider::new(
                 genesis_prefix_info.public_keys.clone(),
-                SectionKeyShare::new(
-                    Some(secret_key_set.secret_key_share(index)),
-                    full_id.public_id(),
-                    &genesis_prefix_info.elders_info,
-                ),
+                Some(IndexedSecretKeyShare::from_set(&secret_key_set, index)),
             );
 
             let addr = network.gen_addr();

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -150,18 +150,19 @@ fn genesis_update_accumulating_message(
     dst: XorName,
     genesis_prefix_info: GenesisPrefixInfo,
 ) -> Result<AccumulatingMessage> {
+    let secret_key = sender.section_keys_provider.secret_key_share().unwrap();
+    let public_key_set = sender.section_keys_provider.public_key_set().clone();
+
     let content = PlainMessage {
         src: Prefix::default(),
         dst: DstLocation::Node(dst),
+        dst_key: public_key_set.public_key(),
         variant: Variant::GenesisUpdate(Box::new(genesis_prefix_info)),
     };
 
-    let secret_key = sender.section_keys_provider.secret_key_share().unwrap();
-    let public_key_set = sender.section_keys_provider.public_key_set().clone();
     let proof = sender.state.prove(&content.dst, None);
-    let dst_key = public_key_set.public_key();
 
-    AccumulatingMessage::new(content, secret_key, public_key_set, proof, dst_key)
+    AccumulatingMessage::new(content, secret_key, public_key_set, proof)
 }
 
 fn to_message_signature(sender_id: &FullId, msg: AccumulatingMessage) -> Result<Message> {

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -468,7 +468,7 @@ fn handle_bootstrap() {
     let addr = new_node.our_connection_info();
     let msg = new_node.bootstrap_request().unwrap();
 
-    test_utils::handle_message(&mut env.subject, Some(addr), msg).unwrap();
+    test_utils::handle_message(&mut env.subject, addr, msg).unwrap();
     env.network.poll(&mut env.rng);
 
     let response = new_node.expect_bootstrap_response();
@@ -509,7 +509,7 @@ fn send_genesis_update() {
         parsec_version,
     });
     let msg = Message::single_src(&adult1.full_id, DstLocation::Direct, variant).unwrap();
-    test_utils::handle_message(&mut env.subject, Some(adult0.addr), msg).unwrap();
+    test_utils::handle_message(&mut env.subject, adult0.addr, msg).unwrap();
 
     // Create another `GenesisUpdate` and check the proof contains the updated version and does not
     // contain the previous version.

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -77,7 +77,7 @@ where
         .collect()
 }
 
-pub fn handle_message(node: &mut Node, sender: Option<SocketAddr>, msg: Message) -> Result<()> {
+pub fn handle_message(node: &mut Node, sender: SocketAddr, msg: Message) -> Result<()> {
     let msg = MessageWithBytes::new(msg)?;
     node.try_handle_message(sender, msg)?;
     node.handle_messages();

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -55,15 +55,6 @@ impl EldersInfo {
             >= quorum_count(self.elders.len())
     }
 
-    /// Returns `true` if the proofs are from all members of this section.
-    pub(crate) fn is_total_consensus(&self, proofs: &ProofSet) -> bool {
-        proofs
-            .ids()
-            .filter(|id| self.elders.contains_key(id.name()))
-            .count()
-            == self.elders.len()
-    }
-
     /// Returns whether this `EldersInfo` is compatible and newer than the other.
     pub(crate) fn is_newer(&self, other: &Self) -> bool {
         self.prefix.is_compatible(&other.prefix) && self.version > other.version

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -54,11 +54,6 @@ impl EldersInfo {
             .count()
             >= quorum_count(self.elders.len())
     }
-
-    /// Returns whether this `EldersInfo` is compatible and newer than the other.
-    pub(crate) fn is_newer(&self, other: &Self) -> bool {
-        self.prefix.is_compatible(&other.prefix) && self.version > other.version
-    }
 }
 
 impl Debug for EldersInfo {

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
     elders_info::{quorum_count, EldersInfo},
     member_info::{AgeCounter, MemberInfo, MemberState, MIN_AGE, MIN_AGE_COUNTER},
     network_stats::NetworkStats,
-    section_keys::{SectionKeyShare, SectionKeys, SectionKeysProvider},
+    section_keys::{IndexedSecretKeyShare, SectionKeys, SectionKeysProvider},
     section_map::SectionMap,
     section_members::SectionMembers,
     section_proof_chain::{SectionProofChain, TrustStatus},

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -26,6 +26,9 @@ pub use self::{
     shared_state::SharedState,
 };
 
+#[cfg(test)]
+pub use self::section_keys::gen_secret_key;
+
 use crate::consensus::AccumulatingProof;
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/section/section_keys.rs
+++ b/src/section/section_keys.rs
@@ -175,3 +175,12 @@ impl SectionKeysProvider {
             .ok_or(RoutingError::InvalidNewSectionInfo)
     }
 }
+
+// Generate random BLS `SecretKey`. For tests only.
+#[cfg(test)]
+pub fn gen_secret_key(rng: &mut crate::rng::MainRng) -> bls::SecretKey {
+    use crate::rng::RngCompat;
+    use rand_crypto::Rng;
+
+    RngCompat(rng).gen()
+}

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -112,7 +112,9 @@ impl SectionMap {
 
     /// Returns `true` if the `EldersInfo` isn't known to us yet.
     pub fn is_new(&self, elders_info: &EldersInfo) -> bool {
-        !self.all().any(|(_, info)| info.is_newer(elders_info))
+        self.all()
+            .filter(|(_, known_info)| known_info.prefix.is_compatible(&elders_info.prefix))
+            .all(|(_, known_info)| known_info.version < elders_info.version)
     }
 
     /// Returns `true` if the `EldersInfo` isn't known to us yet and is a neighbouring section.

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -110,6 +110,11 @@ impl SectionMap {
         self.all().map(|(prefix, _)| prefix)
     }
 
+    /// Returns whether the given name is in any of our neighbour sections.
+    pub fn is_in_neighbour(&self, name: &XorName) -> bool {
+        self.other.keys().any(|prefix| prefix.matches(name))
+    }
+
     /// Returns `true` if the `EldersInfo` isn't known to us yet.
     pub fn is_new(&self, elders_info: &EldersInfo) -> bool {
         self.all()

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -238,15 +238,16 @@ impl SectionMap {
     }
 
     /// Returns the latest known key for the prefix that matches `name`.
-    pub fn latest_compatible_key(&self, name: &XorName) -> Option<&bls::PublicKey> {
+    pub fn key_by_name(&self, name: &XorName) -> Option<&bls::PublicKey> {
         // `keys()` yields the keys from newest to oldest because it is a `chain` of `keys` and
         // `recent_keys` in that order, so in case of multiple compatible keys, the newest one
         // is returned.
         self.keys()
             .find(|(prefix, _)| prefix.matches(name))
-            .map(|(_, info)| info)
+            .map(|(_, key)| key)
     }
 
+    /// Returns the latest known key for the prefix that is compatible with `dst`.
     pub fn key_by_location(&self, dst: &DstLocation) -> Option<&bls::PublicKey> {
         self.keys
             .iter()

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -353,13 +353,15 @@ impl SectionMap {
         let _ = self.keys.insert(prefix, new_key);
     }
 
-    pub fn get_knowledge(&self, prefix: &Prefix<XorName>) -> Option<u64> {
-        self.knowledge.get(prefix).copied()
+    /// Returns the the index of the public key in our_history that will be trusted by the given
+    /// section.
+    pub fn knowledge_by_section(&self, prefix: &Prefix<XorName>) -> u64 {
+        self.knowledge.get(prefix).copied().unwrap_or(0)
     }
 
-    /// Returns the the index of the public key in our_history that will be trusted by the target
+    /// Returns the the index of the public key in our_history that will be trusted by the given
     /// location
-    pub fn trusted_key_index(&self, target: &DstLocation) -> u64 {
+    pub fn knowledge_by_location(&self, target: &DstLocation) -> u64 {
         let (prefix, &index) = if let Some(pair) = self
             .knowledge
             .iter()
@@ -667,7 +669,7 @@ mod tests {
             let dst_name = dst_name_prefix.substituted_in(rng.gen());
             let dst = DstLocation::Section(dst_name);
 
-            assert_eq!(map.trusted_key_index(&dst), expected_index);
+            assert_eq!(map.knowledge_by_location(&dst), expected_index);
         }
     }
 

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -32,8 +32,8 @@ pub struct SectionMap {
     // Note that after a split, the section's latest section info could be the one from the
     // pre-split parent section, so the value's prefix doesn't always match the key.
     other: BTreeMap<Prefix<XorName>, EldersInfo>,
-    // Other section infos that are not immediate successors of the ones we have. Stored here
-    // until we get the immediate successor, then moved to `other`.
+    // Other section infos that are not immediate successors of the ones we have. Stored here until
+    // we get the immediate successor, then moved to `other`.
     other_queued: VecDeque<EldersInfo>,
     // BLS public keys of known sections
     keys: BTreeMap<Prefix<XorName>, bls::PublicKey>,
@@ -107,11 +107,6 @@ impl SectionMap {
     /// Returns iterator over all known sections.
     pub fn all(&self) -> impl Iterator<Item = (&Prefix<XorName>, &EldersInfo)> + Clone {
         iter::once((&self.our.prefix, &self.our)).chain(&self.other)
-    }
-
-    /// Returns iterator over all known sections excluding ours.
-    pub fn other(&self) -> impl Iterator<Item = (&Prefix<XorName>, &EldersInfo)> {
-        self.other.iter()
     }
 
     /// Returns the known sections sorted by the distance from a given XorName.
@@ -455,6 +450,12 @@ impl SectionMap {
             total_elders,
             total_elders_exact,
         }
+    }
+
+    /// Returns iterator over all known sections excluding ours.
+    #[cfg(any(test, feature = "mock_base"))]
+    pub fn other(&self) -> impl Iterator<Item = (&Prefix<XorName>, &EldersInfo)> {
+        self.other.iter()
     }
 
     #[cfg(feature = "mock_base")]

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -302,6 +302,13 @@ impl SectionMap {
             .map(|(_, info)| info)
     }
 
+    pub fn key_by_location(&self, dst: &DstLocation) -> Option<&bls::PublicKey> {
+        self.keys
+            .iter()
+            .find(|(prefix, _)| dst.is_compatible(prefix))
+            .map(|(_, key)| key)
+    }
+
     /// Updates the entry in `keys` for `prefix` to the latest known key; if a split
     /// occurred in the meantime, the keys for sections covering the rest of the address space are
     /// initialised to the old key that was stored for their common ancestor

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -308,13 +308,13 @@ impl SectionMap {
         let _ = self.keys.insert(prefix, new_key);
     }
 
-    /// Returns the the index of the public key in our_history that will be trusted by the given
+    /// Returns the index of the public key in our_history that will be trusted by the given
     /// section.
     pub fn knowledge_by_section(&self, prefix: &Prefix<XorName>) -> u64 {
         self.knowledge.get(prefix).copied().unwrap_or(0)
     }
 
-    /// Returns the the index of the public key in our_history that will be trusted by the given
+    /// Returns the index of the public key in our_history that will be trusted by the given
     /// location
     pub fn knowledge_by_location(&self, target: &DstLocation) -> u64 {
         let (prefix, &index) = if let Some(pair) = self

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -180,8 +180,10 @@ impl Block {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rng::{self, MainRng, RngCompat};
-    use rand_crypto::Rng;
+    use crate::{
+        rng::{self, MainRng},
+        section::gen_secret_key,
+    };
 
     #[test]
     fn check_trust_trusted() {
@@ -237,11 +239,8 @@ mod tests {
     }
 
     fn gen_keys(rng: &mut MainRng) -> (bls::PublicKey, bls::SecretKey) {
-        let mut rng = RngCompat(rng);
-        let secret_key: bls::SecretKey = rng.gen();
-        let public_key = secret_key.public_key();
-
-        (public_key, secret_key)
+        let secret_key = gen_secret_key(rng);
+        (secret_key.public_key(), secret_key)
     }
 
     fn gen_block(

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -92,6 +92,11 @@ impl SectionProofChain {
         1 + self.tail.len()
     }
 
+    /// Index of the last key in the chain.
+    pub(crate) fn last_key_index(&self) -> u64 {
+        self.tail.len() as u64
+    }
+
     /// Check that all the blocks in the chain except the first one have valid signatures.
     /// The first one cannot be verified and requires matching against already trusted keys. Thus
     /// this function alone cannot be used to determine whether this chain is trusted. Use

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -13,7 +13,7 @@ use crate::{
     consensus::AccumulatingEvent,
     id::{P2pNode, PublicId},
     location::DstLocation,
-    messages::SrcAuthority,
+    messages::{MessageHash, SrcAuthority},
     network_params::NetworkParams,
     relocation::{self, RelocateDetails},
     xor_space::{Prefix, XorName, Xorable},
@@ -316,6 +316,7 @@ impl SharedState {
         &mut self,
         src: &SrcAuthority,
         dst_key: Option<&bls::PublicKey>,
+        hash: &MessageHash,
     ) -> Vec<AccumulatingEvent> {
         let (&prefix, new_key) = if let Some(pair) = src.section_prefix_and_key() {
             pair
@@ -360,8 +361,7 @@ impl SharedState {
         if vote_send_neighbour_info {
             events.push(AccumulatingEvent::SendNeighbourInfo {
                 dst: prefix,
-                dst_key: *new_key,
-                our_key_index: self.our_history.last_key_index(),
+                nonce: *hash,
             })
         }
 

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -326,6 +326,13 @@ impl SharedState {
 
         let is_neighbour = self.our_prefix().is_neighbour(&prefix);
 
+        // There will be at most two events returned because the only possible event combinations
+        // are these:
+        // - `[]`
+        // - `[TheirKeyInfo]`
+        // - `[TheirKeyInfo, TheirKnowledge]`
+        // - `[SendNeighbourInfo]`
+        // - `[SendNeighbourInfo, TheirKnowledge]`
         let mut events = Vec::with_capacity(2);
         let mut vote_send_neighbour_info = false;
 

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -106,7 +106,7 @@ impl SharedState {
         self.our_members
             .active()
             .map(|info| &info.p2p_node)
-            .chain(self.sections.other_elders())
+            .chain(self.sections.neighbour_elders())
     }
 
     /// Returns whether we know the given peer.
@@ -183,7 +183,7 @@ impl SharedState {
         if self.our_members.contains(name) {
             Some(self.sections.our())
         } else {
-            self.sections.find_other_by_elder(name)
+            self.sections.find_neighbour_by_elder(name)
         }
     }
 

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -318,7 +318,7 @@ impl SharedState {
         dst_key: Option<&bls::PublicKey>,
         hash: &MessageHash,
     ) -> Vec<AccumulatingEvent> {
-        let (&prefix, new_key) = if let Some(pair) = src.section_prefix_and_key() {
+        let (&prefix, new_key) = if let Ok(pair) = src.as_section_prefix_and_key() {
             pair
         } else {
             return vec![];

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -359,6 +359,9 @@ impl SharedState {
         }
 
         if vote_send_neighbour_info {
+            // TODO: if src has split, consider sending to all child prefixes that are still our
+            // neighbours.
+
             events.push(AccumulatingEvent::SendNeighbourInfo {
                 dst: prefix,
                 nonce: *hash,

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -297,7 +297,7 @@ impl SharedState {
     ) -> SectionProofChain {
         let index = match (target, node_knowledge_override) {
             (DstLocation::Node(_), Some(knowledge)) => knowledge,
-            _ => self.sections.trusted_key_index(target),
+            _ => self.sections.knowledge_by_location(target),
         };
 
         self.our_history.slice_from(index)
@@ -469,7 +469,7 @@ impl SharedState {
     // Return a relocating state of a node relocating now.
     // Ensure that node knows enough to trust node_knowledge proving index.
     fn create_relocating_state(&self) -> MemberState {
-        let node_knowledge = self.sections.get_knowledge(self.our_prefix()).unwrap_or(0);
+        let node_knowledge = self.sections.knowledge_by_section(self.our_prefix());
         MemberState::Relocating { node_knowledge }
     }
 }

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -363,7 +363,7 @@ impl SharedState {
             // neighbours.
 
             events.push(AccumulatingEvent::SendNeighbourInfo {
-                dst: prefix,
+                dst: prefix.name(),
                 nonce: *hash,
             })
         }

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -101,6 +101,7 @@ mod tests {
             let content = PlainMessage {
                 src: Prefix::default(),
                 dst: DstLocation::Section(rng.gen()),
+                dst_key: gen_secret_key(rng).public_key(),
                 variant: Variant::UserMessage(rng.sample_iter(Standard).take(3).collect()),
             };
 
@@ -111,14 +112,12 @@ mod tests {
             let other_ids = secret_ids.values().zip(secret_key_shares.values()).skip(1);
 
             let proof = SectionProofChain::new(pk_set.public_key());
-            let dst_key = gen_secret_key(rng).public_key();
 
             let signed_msg = AccumulatingMessage::new(
                 content.clone(),
                 msg_sender_secret_key_share,
                 pk_set.clone(),
                 proof.clone(),
-                dst_key,
             )
             .unwrap();
 
@@ -133,7 +132,6 @@ mod tests {
                                 bls_id,
                                 pk_set.clone(),
                                 proof.clone(),
-                                dst_key,
                             )
                             .unwrap(),
                         )),

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -79,7 +79,7 @@ mod tests {
         location::{DstLocation, SrcLocation},
         messages::{Message, PlainMessage, Variant},
         rng,
-        section::{SectionKeyShare, SectionProofChain},
+        section::{IndexedSecretKeyShare, SectionProofChain},
         unwrap, Prefix, XorName,
     };
     use itertools::Itertools;
@@ -94,7 +94,7 @@ mod tests {
     impl MessageAndSignatures {
         fn new(
             secret_ids: &BTreeMap<XorName, FullId>,
-            secret_bls_ids: &BTreeMap<XorName, SectionKeyShare>,
+            secret_bls_ids: &BTreeMap<XorName, IndexedSecretKeyShare>,
             pk_set: &bls::PublicKeySet,
         ) -> Self {
             let content = PlainMessage {
@@ -168,7 +168,7 @@ mod tests {
                 .keys()
                 .enumerate()
                 .map(|(idx, name)| {
-                    let share = SectionKeyShare::new_with_position(idx, keys.secret_key_share(idx));
+                    let share = IndexedSecretKeyShare::from_set(&keys, idx);
                     (*name, share)
                 })
                 .collect();

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{create_connected_nodes, gen_bytes, poll_all, sort_nodes_by_distance_to, TestNode};
+use super::utils::*;
 use rand::Rng;
 use routing::{
     event::Event, mock::Environment, DstLocation, NetworkParams, Prefix, SrcLocation, XorName,

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -719,7 +719,7 @@ fn setup_expectations(
     let index0 = gen_elder_index(rng, nodes);
     let index1 = gen_elder_index(rng, nodes);
 
-    let prefix: Prefix<XorName> = unwrap!(current_sections(nodes).choose(rng));
+    let prefix: Prefix<XorName> = current_sections(nodes).choose(rng).unwrap();
     let section_name = prefix.substituted_in(rng.gen());
 
     let src_n0 = SrcLocation::Node(*nodes[index0].name());

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -476,8 +476,8 @@ fn random_churn(
     (added_indices, dropped_names)
 }
 
-fn progress_and_verify<R: Rng>(
-    rng: &mut R,
+fn progress_and_verify(
+    rng: &mut MainRng,
     env: &Environment,
     nodes: &mut [TestNode],
     message_schedule: MessageSchedule,
@@ -712,8 +712,8 @@ fn is_expected_recipient(node: &TestNode, dst: &DstLocation) -> bool {
     node.inner.is_elder() && node.inner.in_dst_location(dst)
 }
 
-fn setup_expectations<R: Rng>(
-    rng: &mut R,
+fn setup_expectations(
+    rng: &mut MainRng,
     nodes: &mut [TestNode],
     elder_size: usize,
 ) -> Expectations {

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -592,7 +592,7 @@ impl Expectations {
             sent_count += 1;
         }
 
-        if src.is_multiple() {
+        if src.is_section() {
             assert!(
                 sent_count >= quorum_count(elder_size),
                 "sent_count: {}. elder_size: {}",
@@ -622,10 +622,10 @@ impl Expectations {
         self.prune_expected_recipients(nodes);
 
         for (key, recipients) in &self.messages {
-            let required = if key.dst.is_single() {
-                recipients.len().min(1)
-            } else {
+            let required = if key.dst.is_section() {
                 quorum_count(recipients.len())
+            } else {
+                recipients.len().min(1)
             };
 
             let received = recipients.values().filter(|&&r| r).count();

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -6,11 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    consensus_reached, count_sections, create_connected_nodes, create_connected_nodes_until_split,
-    current_sections, gen_elder_index, gen_range, gen_vec, node_joined, node_left, poll_until,
-    verify_invariants_for_nodes, TestNode,
-};
+use super::utils::*;
 use hex_fmt::HexFmt;
 use itertools::Itertools;
 use rand::{

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -114,7 +114,10 @@ fn remove_unresponsive_node() {
     let still_has_unresponsive_elder = nodes
         .iter()
         .map(|n| &n.inner)
-        .filter(|n| n.elders().any(|id| *id.name() == non_responsive_name))
+        .filter(|n| {
+            n.known_elders()
+                .any(|p2p_node| *p2p_node.name() == non_responsive_name)
+        })
         .map(|n| n.name())
         .collect_vec();
     assert_eq!(still_has_unresponsive_elder, Vec::<&XorName>::new());

--- a/tests/mock_network/churn.rs
+++ b/tests/mock_network/churn.rs
@@ -658,22 +658,24 @@ impl Expectations {
             DstLocation::Node(name) => assert_eq!(
                 node.name(),
                 name,
-                "unexpected recipient name of message {}: {}",
-                key,
+                "{}({:b}) unexpected recipient name of message {}",
                 node.name(),
-            ),
-            DstLocation::Section(name) => assert!(
-                node.our_prefix().matches(name),
-                "unexpected recipient prefix of message {}: {:b}",
-                key,
                 node.our_prefix(),
-            ),
-            DstLocation::Prefix(prefix) => assert!(
-                node.our_prefix().is_compatible(prefix),
-                "unexpected recipient prefix of message {}: {:b}",
                 key,
-                node.our_prefix(),
             ),
+            DstLocation::Section(name) => {
+                // Accepting both the current and the parent prefix in case the node went through
+                // a split in between the time it received the message and now.
+                let matches =
+                    node.our_prefix().matches(name) || node.our_prefix().popped().matches(name);
+                assert!(
+                    matches,
+                    "{}({:b}) unexpected recipient prefix of message {}",
+                    node.name(),
+                    node.our_prefix(),
+                    key,
+                )
+            }
             DstLocation::Direct => panic!("unexpected received direct message {}", key),
         }
 

--- a/tests/mock_network/drop.rs
+++ b/tests/mock_network/drop.rs
@@ -6,9 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    create_connected_nodes, node_left, poll_until, verify_invariants_for_nodes, LOWERED_ELDER_SIZE,
-};
+use super::utils::*;
 use rand::Rng;
 use routing::{mock::Environment, NetworkParams};
 

--- a/tests/mock_network/messages.rs
+++ b/tests/mock_network/messages.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{create_connected_nodes, gen_elder_index, gen_vec, poll_until, TestNode};
+use super::utils::*;
 use rand::Rng;
 use routing::{
     event::Event, mock::Environment, quorum_count, DstLocation, NetworkParams, SrcLocation,

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -376,7 +376,7 @@ fn check_close_names_for_elder_size_nodes() {
 }
 
 #[test]
-fn check_section_info_ack() {
+fn sibling_knowledge_update_after_split() {
     let elder_size = 8;
     let recommended_section_size = 8;
     let env = Environment::new(NetworkParams {

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -60,7 +60,7 @@ fn disconnect_on_rebootstrap() {
     // When retrying to bootstrap, we should have disconnected from the bootstrap node.
     assert!(!env.is_connected(&nodes[2].endpoint(), &nodes[1].endpoint()));
 
-    expect_next_event!(unwrap!(nodes.last_mut()), Event::Terminated);
+    expect_next_event!(nodes.last_mut().unwrap(), Event::Terminated);
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn simultaneous_joining_nodes(
                     compatible_proxies.shuffle(&mut rng);
 
                     TransportConfig::node()
-                        .with_hard_coded_contact(unwrap!(nodes.first_mut()).endpoint())
+                        .with_hard_coded_contact(nodes.first_mut().unwrap().endpoint())
                 };
 
                 let node = TestNode::builder(&env).transport_config(config).create();
@@ -327,8 +327,14 @@ fn simultaneous_joining_nodes_three_section_with_one_ready_to_split() {
 
     // The created sections
     let sections = current_sections(&nodes).collect_vec();
-    let small_prefix = *unwrap!(sections.iter().find(|prefix| prefix.bit_count() == 1));
-    let long_prefix_0 = *unwrap!(sections.iter().find(|prefix| prefix.bit_count() == 2));
+    let small_prefix = *sections
+        .iter()
+        .find(|prefix| prefix.bit_count() == 1)
+        .unwrap();
+    let long_prefix_0 = *sections
+        .iter()
+        .find(|prefix| prefix.bit_count() == 2)
+        .unwrap();
     let long_prefix_1 = long_prefix_0.sibling();
 
     // Setup the network so the small_prefix will split with one more node in small_prefix_to_add.

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -587,21 +587,3 @@ fn neighbour_update() {
         section_view_is_up_to_date(nodes, &prefix_a, &prefix_b)
     });
 }
-
-// Returns whether section A's view of section B is up to date.
-fn section_view_is_up_to_date(
-    nodes: &[TestNode],
-    a: &Prefix<XorName>,
-    b: &Prefix<XorName>,
-) -> bool {
-    for node_a in elders_with_prefix(nodes, a) {
-        for node_b in elders_with_prefix(nodes, b) {
-            if !node_a.inner.is_peer_elder(node_b.name()) {
-                trace!("Node {} doesn't know node {}", node_a.name(), node_b.name());
-                return false;
-            }
-        }
-    }
-
-    true
-}

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -598,6 +598,14 @@ fn neighbour_update() {
         poll_until(&env, &mut nodes, |nodes| node_left(nodes, &name));
     }
 
+    // Now A's knowledge of B is out of date.
+    assert!(!section_knowledge_is_up_to_date(
+        &nodes,
+        &prefix_a,
+        &prefix_b,
+        env.elder_size()
+    ));
+
     // Send a message from B to A to trigger the update request.
     send_user_message(&mut nodes, prefix_b, prefix_a, gen_vec(&mut rng, 10));
     poll_until(&env, &mut nodes, |nodes| {

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -12,9 +12,9 @@ mod drop;
 mod messages;
 mod node_ageing;
 mod secure_message_delivery;
-mod utils;
+pub mod utils;
 
-pub use self::utils::*;
+use self::utils::*;
 use fake_clock::FakeClock;
 use itertools::Itertools;
 use rand::{seq::SliceRandom, Rng};
@@ -23,9 +23,6 @@ use routing::{
     RelocationOverrides, TransportConfig, XorName,
 };
 use std::collections::BTreeMap;
-
-// The smallest number of elders which allows to reach consensus when one of them goes offline.
-pub const LOWERED_ELDER_SIZE: usize = 4;
 
 // -----  Miscellaneous tests below  -----
 

--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -576,7 +576,13 @@ fn neighbour_update() {
         env.elder_size()
     ));
 
-    let num_elders_to_remove = rng.gen_range(1, LOWERED_ELDER_SIZE + 1);
+    // Remove at most elder_size - 1 elders, so section A still knows at least one elder from B and
+    // so can still contact them.
+    let num_elders_to_remove = rng.gen_range(1, LOWERED_ELDER_SIZE);
+    info!(
+        "Removing {} elders from {:?}",
+        num_elders_to_remove, prefix_b
+    );
 
     // Add nodes that will replace the removed elders.
     for _ in 0..num_elders_to_remove {

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -318,7 +318,10 @@ fn churn_until_age_counter(
                 }
 
                 poll_until(env, nodes, |nodes| node_left(nodes, &removed_name));
-                update_neighbours_and_poll(env, nodes);
+
+                // Using threshold of 3 because removing one node can trigger another one to be
+                // relocated, but we still want to be left with at least one known node.
+                update_neighbours_and_poll(env, nodes, 3);
             }
         }
     }

--- a/tests/mock_network/node_ageing.rs
+++ b/tests/mock_network/node_ageing.rs
@@ -301,7 +301,7 @@ fn churn_until_age_counter(
                 // still online. If we picked such node for the bootstrap node, the bootstrapping
                 // would fail because the node would keep redirecting the joining node to
                 // non-existing peers. To avoid this and to keep things simple, we make sure we
-                // bootstrap off a node from the same section.
+                // bootstrap off a node from the same section that we are joining.
                 let bootstrap_index = indexed_nodes_with_prefix(nodes, prefix)
                     .choose(&mut rng)
                     .map(|(index, _)| index)

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -9,8 +9,8 @@
 use super::{create_connected_nodes_until_split, poll_all, TestNode, LOWERED_ELDER_SIZE};
 use routing::{
     generate_bls_threshold_secret_key, mock::Environment, rng::MainRng, AccumulatingMessage,
-    DstLocation, EldersInfo, FullId, Message, NetworkParams, P2pNode, PlainMessage, Prefix,
-    SectionKeyShare, SectionProofChain, Variant, XorName,
+    DstLocation, EldersInfo, FullId, IndexedSecretKeyShare, Message, NetworkParams, P2pNode,
+    PlainMessage, Prefix, SectionProofChain, Variant, XorName,
 };
 use std::{collections::BTreeMap, iter, net::SocketAddr};
 
@@ -63,7 +63,7 @@ fn message_with_invalid_security(fail_type: FailType) {
 
     let fake_full = FullId::gen(&mut env.new_rng());
     let bls_keys = generate_bls_threshold_secret_key(&mut rng, 1);
-    let bls_secret_key_share = SectionKeyShare::new_with_position(0, bls_keys.secret_key_share(0));
+    let bls_secret_key_share = IndexedSecretKeyShare::from_set(&bls_keys, 0);
 
     let socket_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
     let members: BTreeMap<_, _> = iter::once((

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -57,6 +57,7 @@ fn message_with_invalid_security(fail_type: FailType) {
 
     let their_node_pos = 0;
     let their_prefix = get_prefix(&nodes[their_node_pos]);
+    let their_key = *nodes[their_node_pos].inner.section_key().unwrap();
 
     let our_node_pos = get_position_with_other_prefix(&nodes, &their_prefix);
     let our_prefix = get_prefix(&nodes[our_node_pos]);
@@ -91,7 +92,9 @@ fn message_with_invalid_security(fail_type: FailType) {
         };
         let pk_set = bls_keys.public_keys();
 
-        let msg = AccumulatingMessage::new(content, &bls_secret_key_share, pk_set, proof).unwrap();
+        let msg =
+            AccumulatingMessage::new(content, &bls_secret_key_share, pk_set, proof, their_key)
+                .unwrap();
         msg.combine_signatures().unwrap()
     };
 

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -77,6 +77,7 @@ fn message_with_invalid_security(fail_type: FailType) {
     let content = PlainMessage {
         src: our_prefix,
         dst: DstLocation::Prefix(their_prefix),
+        dst_key: their_key,
         variant: Variant::NeighbourInfo(new_info),
     };
 
@@ -92,9 +93,7 @@ fn message_with_invalid_security(fail_type: FailType) {
         };
         let pk_set = bls_keys.public_keys();
 
-        let msg =
-            AccumulatingMessage::new(content, &bls_secret_key_share, pk_set, proof, their_key)
-                .unwrap();
+        let msg = AccumulatingMessage::new(content, &bls_secret_key_share, pk_set, proof).unwrap();
         msg.combine_signatures().unwrap()
     };
 

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -9,8 +9,8 @@
 use super::{create_connected_nodes_until_split, poll_all, TestNode, LOWERED_ELDER_SIZE};
 use routing::{
     generate_bls_threshold_secret_key, mock::Environment, rng::MainRng, AccumulatingMessage,
-    DstLocation, EldersInfo, FullId, IndexedSecretKeyShare, Message, NetworkParams, P2pNode,
-    PlainMessage, Prefix, SectionProofChain, Variant, XorName,
+    DstLocation, EldersInfo, FullId, IndexedSecretKeyShare, Message, MessageHash, NetworkParams,
+    P2pNode, PlainMessage, Prefix, SectionProofChain, Variant, XorName,
 };
 use std::{collections::BTreeMap, iter, net::SocketAddr};
 
@@ -78,7 +78,10 @@ fn message_with_invalid_security(fail_type: FailType) {
         src: our_prefix,
         dst: DstLocation::Prefix(their_prefix),
         dst_key: their_key,
-        variant: Variant::NeighbourInfo(new_info),
+        variant: Variant::NeighbourInfo {
+            elders_info: new_info,
+            nonce: MessageHash::from_bytes(b"hello"),
+        },
     };
 
     let message = {

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -76,7 +76,7 @@ fn message_with_invalid_security(fail_type: FailType) {
 
     let content = PlainMessage {
         src: our_prefix,
-        dst: DstLocation::Prefix(their_prefix),
+        dst: DstLocation::Section(their_prefix.name()),
         dst_key: their_key,
         variant: Variant::NeighbourInfo {
             elders_info: new_info,
@@ -88,7 +88,7 @@ fn message_with_invalid_security(fail_type: FailType) {
         let proof = match fail_type {
             FailType::TrustedProofInvalidSig => nodes[our_node_pos]
                 .inner
-                .prove(&DstLocation::Prefix(their_prefix))
+                .prove(&DstLocation::Section(their_prefix.name()))
                 .unwrap(),
             FailType::UntrustedProofValidSig => {
                 create_invalid_proof_chain(&mut rng, bls_keys.public_keys().public_key())

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -24,6 +24,9 @@ use std::{
     cmp, collections::BTreeSet, convert::TryInto, iter, net::SocketAddr, ops::Range, time::Duration,
 };
 
+// The smallest number of elders which allows to reach consensus when one of them goes offline.
+pub const LOWERED_ELDER_SIZE: usize = 4;
+
 // Maximum number of iterations of the `poll_until` function. This is several orders higher than
 // the anticipated upper limit for any test, and if hit is likely to indicate an infinite loop.
 const MAX_POLL_UNTIL_ITERATIONS: usize = 2000;
@@ -769,9 +772,10 @@ pub fn send_user_message(
     let dst_location = DstLocation::Prefix(dst);
 
     trace!(
-        "sending user message {:?} -> {:?}",
+        "sending user message {:?} -> {:?}: {:?}",
         src_location,
-        dst_location
+        dst_location,
+        hex_fmt::HexFmt(&content)
     );
 
     for node in elders_with_prefix_mut(nodes, &src) {

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -882,7 +882,6 @@ fn neighbours_with_outdated_knowledge<'a>(
             !section_knowledge_is_up_to_date(nodes, a, b, threshold)
                 || !section_knowledge_is_up_to_date(nodes, b, a, threshold)
         })
-        .map(|(a, b)| if a < b { (a, b) } else { (b, a) })
 }
 
 // Generate a vector of random T of the given length.

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -796,13 +796,24 @@ pub fn gen_bytes(rng: &mut MainRng, size: usize) -> Vec<u8> {
 
 // Create new node in the given section.
 pub fn add_node_to_section(env: &Environment, nodes: &mut Vec<TestNode>, prefix: &Prefix<XorName>) {
+    add_node_to_section_using_bootstrap_node(env, nodes, prefix, 0)
+}
+
+// Create new node in the given section, bootstrapping it off the node at the given index.
+pub fn add_node_to_section_using_bootstrap_node(
+    env: &Environment,
+    nodes: &mut Vec<TestNode>,
+    prefix: &Prefix<XorName>,
+    bootstrap_node_index: usize,
+) {
     let mut rng = env.new_rng();
     let full_id = FullId::within_range(&mut rng, &prefix.range_inclusive());
 
     let node = if nodes.is_empty() {
         TestNode::builder(env).first().full_id(full_id).create()
     } else {
-        let config = TransportConfig::node().with_hard_coded_contact(nodes[0].endpoint());
+        let bootstrap_contact = nodes[bootstrap_node_index].endpoint();
+        let config = TransportConfig::node().with_hard_coded_contact(bootstrap_contact);
         TestNode::builder(env)
             .transport_config(config)
             .full_id(full_id)

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -556,7 +556,7 @@ pub fn add_mature_nodes(
         let removed_id =
             remove_elder_from_section_in_range(nodes, &prefix, 0..nodes.len() - count0 - count1);
         poll_until(env, nodes, |nodes| node_left(nodes, &removed_id));
-        update_neighbours_and_poll(env, nodes);
+        update_neighbours_and_poll(env, nodes, 2);
     }
 
     // Count the number of nodes in each sub-prefix and verify they are as expected.
@@ -837,11 +837,9 @@ pub fn send_user_message(
 }
 
 // Poll until all sections have up-to-date knowledge of their neighbour sections.
-pub fn update_neighbours_and_poll(env: &Environment, nodes: &mut [TestNode]) {
-    // We want each node to know at least 2 online nodes from the neighbour section. If it knows
-    // less than that and the neighbour section would lose more nodes, the node risks being unable
-    // to communicate with it.
-    let threshold = 2;
+// We consider section A's knowledge of its neighbour section B as up-to-date if every elder from A
+// knows at least `threshold` online nodes from B.
+pub fn update_neighbours_and_poll(env: &Environment, nodes: &mut [TestNode], threshold: usize) {
     let outdated: Vec<_> = neighbours_with_outdated_knowledge(nodes, threshold).collect();
     if outdated.is_empty() {
         return;

--- a/tests/mock_network/utils.rs
+++ b/tests/mock_network/utils.rs
@@ -810,13 +810,13 @@ pub fn send_user_message(
     content: Vec<u8>,
 ) {
     let src_location = SrcLocation::Section(src);
-    let dst_location = DstLocation::Prefix(dst);
+    let dst_location = DstLocation::Section(dst.name());
 
     trace!(
         "send_user_message: {:?} -> {:?}: {:?}",
         src_location,
         dst_location,
-        hex_fmt::HexFmt(&content)
+        hex_fmt::HexFmt(&content),
     );
 
     for node in elders_with_prefix_mut(nodes, &src) {


### PR DESCRIPTION
This PR changes the mechanism by which sections get updated about the elders of other sections. Previously a section would send ("push") a `NeighbourInfo` message to all its neighbours every time its elder set changed. This PR changes that to a "pull" model:

- Every message now contains a `dst_key` field which contains the latest section key of the destination that the source knows about.
- On receiving a message, we compare the destination section key we know with the latest key of the message proof and if they differ, it means our knowledge of the destination section is out of date.
- We also compare our latest section key with the `dst_key` field of the message and if they differ it means their knowledge of us is out of date
- If either knowledge is out of date, we send them a `NeighbourInfo` message containing the current elder set of our section
- On receiving the message, the destination section updates its knowledge of us (if they were out of date) and/or sends a `NeighbourInfo` of their own to us (if we were out of date).

Currently sending a section message needs to be synchronized via parsec which means to send a `NeighbourInfo` message we must first accumulate a `SendNeighbourInfo` vote. This synchronization requirement will be relaxed in the future.

Additional changes:

- For neighbour sections, we now always update their keys and their elder sets together - that is - we never store their key unless we also have their elders set corresponding to that key. This simplifies some flows.
-  It's no longer necessary for the `NeighbourInfo` message to be successfully delivered on the first try (because it will be sent again as per the flow described above) which allows us to remove some complexity of resending the message to the sibling section in case of split.
- The `DstLocation::Prefix` variant is removed. A message is now always sent to a `XorName` which simplifies the routing logic.

Changes to tests:

- We now need to explicitly send some messages every now and then to trigger the `NeighbourInfo` exchanges as it doesn't happen implicitly. Not doing that would result in some sections knowledge to become so out of date that they would not be able to communicate with each other. This reflects  how the real network will behave which will have constant message traffic driven by the clients.
- We also relax some checks reflecting the fact that the knowledge of other sections might nor necessarily be up-to-date all the time.