### PR TITLE
Untrusted and unknown messages handling

### DIFF
--- a/src/consensus/event_accumulator.rs
+++ b/src/consensus/event_accumulator.rs
@@ -302,7 +302,7 @@ mod test {
     }
 
     fn empty_elders_info() -> EldersInfo {
-        EldersInfo::new(Default::default(), Default::default(), Default::default())
+        EldersInfo::new(Default::default(), Default::default())
     }
 
     fn random_section_info_sig_share(

--- a/src/consensus/genesis_prefix_info.rs
+++ b/src/consensus/genesis_prefix_info.rs
@@ -21,8 +21,8 @@ impl Debug for GenesisPrefixInfo {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "GenesisPrefixInfo({:?}, elders_version: {}, parsec_version: {})",
-            self.elders_info.prefix, self.elders_info.version, self.parsec_version,
+            "GenesisPrefixInfo({:?}, parsec_version: {})",
+            self.elders_info.prefix, self.parsec_version,
         )
     }
 }

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -393,7 +393,7 @@ fn create(
 ) -> Parsec {
     #[cfg(feature = "mock")]
     let hash = {
-        let fields = (elders_info.prefix, elders_info.version, parsec_version);
+        let fields = (elders_info.prefix, parsec_version);
         crypto::sha3_256(&bincode::serialize(&fields).unwrap())
     };
 
@@ -491,7 +491,7 @@ mod tests {
                 )
             })
             .collect();
-        let elders_info = EldersInfo::new(members, Prefix::<XorName>::default(), version);
+        let elders_info = EldersInfo::new(members, Prefix::<XorName>::default());
         parsec_map.init(rng, full_ids[0].clone(), &elders_info, vec![], version);
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -111,6 +111,11 @@ impl Core {
             .send_message_to_targets(conn_infos, delivery_group_size, msg)
     }
 
+    pub fn send_message_to_target(&mut self, recipient: &SocketAddr, msg: Bytes) {
+        self.transport
+            .send_message_to_targets(slice::from_ref(recipient), 1, msg)
+    }
+
     pub fn send_direct_message(&mut self, recipient: &SocketAddr, variant: Variant) {
         let message = match Message::single_src(&self.full_id, DstLocation::Direct, None, variant) {
             Ok(message) => message,
@@ -128,7 +133,7 @@ impl Core {
             }
         };
 
-        self.send_message_to_targets(slice::from_ref(recipient), 1, bytes)
+        self.send_message_to_target(recipient, bytes)
     }
 
     pub fn handle_unsent_message(

--- a/src/core.rs
+++ b/src/core.rs
@@ -17,7 +17,6 @@ use crate::{
     node::NodeConfig,
     quic_p2p::{EventSenders, OurType, Token},
     rng::{self, MainRng},
-    time::Duration,
     timer::Timer,
     transport::{PeerStatus, Transport},
     xor_space::XorName,
@@ -110,16 +109,6 @@ impl Core {
     ) {
         self.transport
             .send_message_to_targets(conn_infos, delivery_group_size, msg)
-    }
-
-    pub fn send_message_to_target_later(
-        &mut self,
-        dst: &SocketAddr,
-        message: Bytes,
-        delay: Duration,
-    ) {
-        self.transport
-            .send_message_to_target_later(dst, message, &self.timer, delay)
     }
 
     pub fn send_direct_message(&mut self, recipient: &SocketAddr, variant: Variant) {

--- a/src/core.rs
+++ b/src/core.rs
@@ -112,7 +112,7 @@ impl Core {
     }
 
     pub fn send_direct_message(&mut self, recipient: &SocketAddr, variant: Variant) {
-        let message = match Message::single_src(&self.full_id, DstLocation::Direct, variant) {
+        let message = match Message::single_src(&self.full_id, DstLocation::Direct, None, variant) {
             Ok(message) => message,
             Err(error) => {
                 error!("Failed to create message: {:?}", error);

--- a/src/location.rs
+++ b/src/location.rs
@@ -37,6 +37,14 @@ impl SrcLocation {
             SrcLocation::Section(self_prefix) => self_prefix.matches(name),
         }
     }
+
+    /// Returns this location as `DstLocation`
+    pub(crate) fn to_dst(&self) -> DstLocation {
+        match self {
+            Self::Node(name) => DstLocation::Node(*name),
+            Self::Section(prefix) => DstLocation::Section(prefix.name()),
+        }
+    }
 }
 
 /// Message destination location.

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -158,14 +158,17 @@ where
     )
 }
 
-/// What to do with an incomming message.
-pub enum MessageAction {
-    /// Message will be handled
-    Handle,
-    /// Message will be bounced back to the sender
-    Bounce,
-    /// Message will be discarded
-    Discard,
+/// Status of an incomming message.
+pub enum MessageStatus {
+    /// Message is useful and should be handled.
+    Useful,
+    /// Message is useless and should be discarded.
+    Useless,
+    /// Message trust can't be established.
+    Untrusted,
+    /// We don't know how to handle the message because we are not in the right state (e.g. it
+    /// needs elder but we are not)
+    Unknown,
 }
 
 fn serialize_for_section_signing(

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -73,8 +73,14 @@ impl Message {
     }
 
     /// Creates a message from single node.
-    pub(crate) fn single_src(src: &FullId, dst: DstLocation, variant: Variant) -> Result<Self> {
-        let serialized = serialize_for_node_signing(src.public_id(), &dst, None, &variant)?;
+    pub(crate) fn single_src(
+        src: &FullId,
+        dst: DstLocation,
+        dst_key: Option<bls::PublicKey>,
+        variant: Variant,
+    ) -> Result<Self> {
+        let serialized =
+            serialize_for_node_signing(src.public_id(), &dst, dst_key.as_ref(), &variant)?;
         let signature = src.sign(&serialized);
 
         Ok(Self {
@@ -84,7 +90,7 @@ impl Message {
                 signature,
             },
             variant,
-            dst_key: None,
+            dst_key,
         })
     }
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     accumulating_message::{AccumulatingMessage, PlainMessage},
     hash::MessageHash,
     src_authority::SrcAuthority,
-    variant::{BootstrapResponse, JoinRequest, MemberKnowledge, Variant},
+    variant::{BootstrapResponse, JoinRequest, Variant},
     with_bytes::MessageWithBytes,
 };
 use crate::{

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -119,4 +119,52 @@ impl SrcAuthority {
 
         Ok(VerifyStatus::Full)
     }
+
+    // Extend the current message proof so it starts at `new_first_key` while keeping the last key
+    // (and therefore the signature) intact.
+    #[cfg_attr(feature = "mock_base", allow(clippy::trivially_copy_pass_by_ref))]
+    pub fn extend_proof(
+        &mut self,
+        new_first_key: &bls::PublicKey,
+        section_proof_chain: &SectionProofChain,
+    ) -> Result<(), ExtendProofError> {
+        let proof = match self {
+            Self::Section { proof, .. } => proof,
+            Self::Node { .. } => return Err(ExtendProofError::MustBeSection),
+        };
+
+        if proof.has_key(new_first_key) {
+            return Err(ExtendProofError::ProofAlreadySufficient);
+        }
+
+        let index_from = if let Some(index) = section_proof_chain.index_of(new_first_key) {
+            index
+        } else {
+            return Err(ExtendProofError::InvalidFirstKey);
+        };
+
+        let index_to = if let Some(index) = section_proof_chain.index_of(proof.last_key()) {
+            index
+        } else {
+            return Err(ExtendProofError::InvalidLastKey);
+        };
+
+        *proof = section_proof_chain.slice(index_from..=index_to);
+
+        Ok(())
+    }
+}
+
+/// Error returned from `SrcAuthority::extend_proof`.
+#[derive(Debug)]
+pub enum ExtendProofError {
+    /// Only SecAuthority::Section supports proof extension.
+    MustBeSection,
+    /// The new first key is invalid/unknown
+    InvalidFirstKey,
+    /// The last key of the current proof is invalid/unknown. Perhaps the message was not created
+    /// by our section?
+    InvalidLastKey,
+    /// The proof already contains the new first key and so doesn't need to be extended.
+    ProofAlreadySufficient,
 }

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -39,10 +39,15 @@ impl SrcAuthority {
     }
 
     pub fn check_is_section(&self) -> Result<()> {
-        match self {
-            Self::Section { .. } => Ok(()),
-            Self::Node { .. } => Err(RoutingError::BadLocation),
+        if self.is_section() {
+            Ok(())
+        } else {
+            Err(RoutingError::BadLocation)
         }
+    }
+
+    pub fn is_section(&self) -> bool {
+        matches!(self, Self::Section { .. })
     }
 
     pub fn as_node(&self) -> Result<&PublicId> {

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -154,12 +154,3 @@ pub struct MemberKnowledge {
     pub section_key: bls::PublicKey,
     pub parsec_version: u64,
 }
-
-impl MemberKnowledge {
-    pub fn update(&mut self, other: &MemberKnowledge) {
-        if other.parsec_version > self.parsec_version {
-            self.section_key = other.section_key;
-            self.parsec_version = other.parsec_version;
-        }
-    }
-}

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -116,8 +116,11 @@ impl Debug for Variant {
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, Hash)]
 pub enum BootstrapResponse {
     /// This response means that the new peer is clear to join the section. The connection infos of
-    /// the section elders and the section prefix are provided.
-    Join(EldersInfo),
+    /// the section elders and the section key are provided.
+    Join {
+        elders_info: EldersInfo,
+        section_key: bls::PublicKey,
+    },
     /// The new peer should retry bootstrapping with another section. The set of connection infos
     /// of the members of that section is provided.
     Rebootstrap(Vec<SocketAddr>),
@@ -126,8 +129,8 @@ pub enum BootstrapResponse {
 /// Request to join a section
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct JoinRequest {
-    /// The section version to join
-    pub elders_version: u64,
+    /// The public key of the section to join
+    pub section_key: bls::PublicKey,
     /// If the peer is being relocated, contains `RelocatePayload`. Otherwise contains `None`.
     pub relocate_payload: Option<RelocatePayload>,
 }
@@ -136,7 +139,7 @@ impl Debug for JoinRequest {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         formatter
             .debug_struct("JoinRequest")
-            .field("elders_version", &self.elders_version)
+            .field("section_key", &self.section_key)
             .field(
                 "relocate_payload",
                 &self

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 /// Message variant
 pub enum Variant {
     /// Inform neighbours about our new section.
@@ -37,11 +38,11 @@ pub enum Variant {
     UserMessage(Vec<u8>),
     /// Approves the joining node as a routing node.
     /// Section X -> Node joining X
-    NodeApproval(Box<GenesisPrefixInfo>),
+    NodeApproval(GenesisPrefixInfo),
     /// Update sent to Adults and Infants by Elders
-    GenesisUpdate(Box<GenesisPrefixInfo>),
+    GenesisUpdate(GenesisPrefixInfo),
     /// Send from a section to the node being relocated.
-    Relocate(Box<RelocateDetails>),
+    Relocate(RelocateDetails),
     /// Sent from members of a section message's source location to the first hop. The
     /// message will only be relayed once enough signatures have been accumulated.
     MessageSignature(Box<AccumulatingMessage>),

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -54,9 +54,9 @@ pub enum Variant {
     /// Sent from a bootstrapping peer to the section that responded with a
     /// `BootstrapResponse::Join` to its `BootstrapRequest`.
     JoinRequest(Box<JoinRequest>),
-    /// Sent from Adults and Infants to Elders. Updates Elders about the sender's knowledge of its
-    /// own section.
-    MemberKnowledge(MemberKnowledge),
+    /// Sent from Adults and Infants to Elders. Used to "poke" the elders to trigger them to send
+    /// ParsecRequest back.
+    ParsecPoke(u64),
     /// Parsec request message
     ParsecRequest(u64, ParsecRequest),
     /// Parsec response message
@@ -92,7 +92,7 @@ impl Debug for Variant {
             Self::BootstrapRequest(payload) => write!(f, "BootstrapRequest({})", payload),
             Self::BootstrapResponse(payload) => write!(f, "BootstrapResponse({:?})", payload),
             Self::JoinRequest(payload) => write!(f, "JoinRequest({:?})", payload),
-            Self::MemberKnowledge(payload) => write!(f, "MemberKnowledge({:?})", payload),
+            Self::ParsecPoke(version) => write!(f, "ParsecPoke({})", version),
             Self::ParsecRequest(version, _) => write!(f, "ParsecRequest({}, ..)", version),
             Self::ParsecResponse(version, _) => write!(f, "ParsecResponse({}, ..)", version),
             Self::Ping => write!(f, "Ping"),
@@ -146,11 +146,4 @@ impl Debug for JoinRequest {
             )
             .finish()
     }
-}
-
-/// Node's knowledge about its own section.
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Debug, Hash)]
-pub struct MemberKnowledge {
-    pub section_key: bls::PublicKey,
-    pub parsec_version: u64,
 }

--- a/src/messages/with_bytes.rs
+++ b/src/messages/with_bytes.rs
@@ -107,7 +107,7 @@ mod tests {
 
         let dst = DstLocation::Section(rng.gen());
         let variant = Variant::UserMessage(rng.sample_iter(Standard).take(6).collect());
-        let msg = Message::single_src(&full_id, dst, variant).unwrap();
+        let msg = Message::single_src(&full_id, dst, None, variant).unwrap();
 
         let msg_with_bytes = MessageWithBytes::new(msg.clone()).unwrap();
         let bytes = msg_with_bytes.full_bytes();

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1034,7 +1034,7 @@ impl Node {
             .map(|stage| &stage.shared_state.our_history)
     }
 
-    fn shared_state(&self) -> Option<&SharedState> {
+    pub(crate) fn shared_state(&self) -> Option<&SharedState> {
         self.stage.approved().map(|stage| &stage.shared_state)
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -840,23 +840,28 @@ impl Node {
             Stage::Bootstrapping(_) => write!(buffer, "{}(?) ", self.name()),
             Stage::Joining(stage) => write!(
                 buffer,
-                "{}({:b}v{}?) ",
+                "{}({:b}?) ",
                 self.name(),
                 stage.target_section_elders_info().prefix,
-                stage.target_section_elders_info().version,
             ),
-            Stage::Approved(stage) => write!(
-                buffer,
-                "{}({:b}v{}{}) ",
-                self.core.name(),
-                stage.shared_state.our_prefix(),
-                stage.shared_state.our_info().version,
+            Stage::Approved(stage) => {
                 if stage.is_our_elder(self.core.id()) {
-                    "!"
+                    write!(
+                        buffer,
+                        "{}({:b}v{}!) ",
+                        self.core.name(),
+                        stage.shared_state.our_prefix(),
+                        stage.shared_state.our_history.last_key_index()
+                    )
                 } else {
-                    ""
-                },
-            ),
+                    write!(
+                        buffer,
+                        "{}({:b}) ",
+                        self.core.name(),
+                        stage.shared_state.our_prefix()
+                    )
+                }
+            }
             Stage::Terminated => write!(buffer, "[terminated]"),
         })
     }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -932,15 +932,6 @@ impl Node {
             .unwrap_or_default()
     }
 
-    /// Returns the elder info version of a section with the given prefix.
-    /// Prefix must be either our prefix or of one of our neighbours.
-    /// Returns `None` otherwise.
-    pub fn section_elder_info_version(&self, prefix: &Prefix<XorName>) -> Option<u64> {
-        self.shared_state()
-            .and_then(|state| state.sections.get(prefix))
-            .map(|info| info.version)
-    }
-
     /// Returns the elders in our and neighbouring sections.
     pub fn known_elders(&self) -> impl Iterator<Item = &P2pNode> {
         self.shared_state()

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -596,7 +596,7 @@ impl Node {
                 self.send_bounce(&sender, msg.full_bytes().clone());
                 Ok(())
             }
-            Stage::Approved(stage) => stage.send_signed_message(&mut self.core, msg),
+            Stage::Approved(stage) => stage.relay_message(&mut self.core, msg),
             Stage::Terminated => unreachable!(),
         }
     }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -759,7 +759,7 @@ impl Node {
             Stage::Bootstrapping(stage) => stage.handle_unknown_message(sender, msg),
             Stage::Joining(stage) => stage.handle_unknown_message(sender, msg),
             Stage::Approved(stage) => {
-                stage.handle_unknown_message(&mut self.core, sender, msg_bytes)?
+                stage.handle_unknown_message(&mut self.core, Some(sender), msg_bytes)?
             }
             Stage::Terminated => (),
         }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -40,10 +40,7 @@ use crossbeam_channel::{Receiver, RecvError, Select};
 use std::net::SocketAddr;
 
 #[cfg(all(test, feature = "mock"))]
-use crate::{
-    consensus::{AccumulatingEvent, ConsensusEngine},
-    messages::AccumulatingMessage,
-};
+use crate::{consensus::ConsensusEngine, messages::AccumulatingMessage};
 #[cfg(feature = "mock_base")]
 use {
     crate::section::{EldersInfo, SectionProofChain, SharedState},
@@ -1079,15 +1076,6 @@ impl Node {
     pub(crate) fn consensus_engine_mut(&mut self) -> Result<&mut ConsensusEngine> {
         if let Some(stage) = self.stage.approved_mut() {
             Ok(&mut stage.consensus_engine)
-        } else {
-            Err(RoutingError::InvalidState)
-        }
-    }
-
-    pub(crate) fn vote_for_event(&mut self, event: AccumulatingEvent) -> Result<()> {
-        if let Some(stage) = self.stage.approved_mut() {
-            stage.vote_for_event(event);
-            Ok(())
         } else {
             Err(RoutingError::InvalidState)
         }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -648,12 +648,15 @@ impl Node {
                 _ => unreachable!(),
             },
             Stage::Joining(stage) => match msg.variant {
-                Variant::BootstrapResponse(BootstrapResponse::Join(elders_info)) => stage
-                    .handle_bootstrap_response(
-                        &mut self.core,
-                        msg.src.to_sender_node(sender)?,
-                        elders_info,
-                    )?,
+                Variant::BootstrapResponse(BootstrapResponse::Join {
+                    elders_info,
+                    section_key,
+                }) => stage.handle_bootstrap_response(
+                    &mut self.core,
+                    msg.src.to_sender_node(sender)?,
+                    elders_info,
+                    section_key,
+                )?,
                 Variant::NodeApproval(genesis_prefix_info) => {
                     let connect_type = stage.connect_type();
                     let msg_backlog = stage.take_message_backlog();
@@ -780,6 +783,7 @@ impl Node {
     fn join(&mut self, params: JoinParams) {
         let JoinParams {
             elders_info,
+            section_key,
             relocate_payload,
             msg_backlog,
         } = params;
@@ -787,6 +791,7 @@ impl Node {
         self.stage = Stage::Joining(Joining::new(
             &mut self.core,
             elders_info,
+            section_key,
             relocate_payload,
             msg_backlog,
         ));

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -660,7 +660,7 @@ impl Node {
                 Variant::NodeApproval(genesis_prefix_info) => {
                     let connect_type = stage.connect_type();
                     let msg_backlog = stage.take_message_backlog();
-                    self.approve(connect_type, *genesis_prefix_info, msg_backlog)?
+                    self.approve(connect_type, genesis_prefix_info, msg_backlog)?
                 }
                 _ => unreachable!(),
             },
@@ -672,7 +672,7 @@ impl Node {
                 }
                 Variant::GenesisUpdate(info) => {
                     msg.src.check_is_section()?;
-                    stage.handle_genesis_update(&mut self.core, *info)?;
+                    stage.handle_genesis_update(&mut self.core, info)?;
                 }
                 Variant::Relocate(_) => {
                     msg.src.check_is_section()?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -518,11 +518,7 @@ impl Node {
 
         match &mut self.stage {
             Stage::Bootstrapping(stage) => stage.handle_timeout(&mut self.core, token),
-            Stage::Joining(stage) => {
-                if stage.handle_timeout(&mut self.core, token) {
-                    self.rebootstrap()
-                }
-            }
+            Stage::Joining(stage) => stage.handle_timeout(&mut self.core, token),
             Stage::Approved(stage) => stage.handle_timeout(&mut self.core, token),
             Stage::Terminated => {}
         }
@@ -864,14 +860,6 @@ impl Node {
         }
 
         self.stage = Stage::Bootstrapping(stage);
-    }
-
-    // Transition from Joining to Bootstrapping on join failure
-    fn rebootstrap(&mut self) {
-        // TODO: preserve relocation details
-        self.stage = Stage::Bootstrapping(Bootstrapping::new(None));
-        self.core.full_id = FullId::gen(&mut self.core.rng);
-        self.core.transport.bootstrap();
     }
 
     fn set_log_ident(&self) -> log_utils::Guard {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -699,10 +699,10 @@ impl Node {
                     msg.src.to_sender_node(sender)?,
                     *join_request,
                 ),
-                Variant::MemberKnowledge(payload) => stage.handle_member_knowledge(
+                Variant::ParsecPoke(version) => stage.handle_parsec_poke(
                     &mut self.core,
                     msg.src.to_sender_node(sender)?,
-                    payload,
+                    version,
                 ),
                 Variant::ParsecRequest(version, request) => {
                     stage.handle_parsec_request(

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -404,6 +404,15 @@ impl Approved {
         })
     }
 
+    pub fn handle_unknown_message(&self, core: &mut Core, sender: SocketAddr, msg_bytes: Bytes) {
+        let variant = Variant::Bounce {
+            elders_version: Some(self.shared_state.our_info().version),
+            message: msg_bytes,
+        };
+
+        core.send_direct_message(&sender, variant)
+    }
+
     pub fn handle_neighbour_info(
         &mut self,
         elders_info: EldersInfo,
@@ -1663,13 +1672,6 @@ impl Approved {
 
             trace!("Send {:?} to {:?}", payload, recipient);
             core.send_direct_message(recipient.peer_addr(), Variant::MemberKnowledge(payload))
-        }
-    }
-
-    pub fn create_bounce(&self, msg_bytes: Bytes) -> Variant {
-        Variant::Bounce {
-            elders_version: Some(self.shared_state.our_info().version),
-            message: msg_bytes,
         }
     }
 

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1981,5 +1981,5 @@ pub struct RelocateParams {
 fn create_first_elders_info(p2p_node: P2pNode) -> EldersInfo {
     let name = *p2p_node.name();
     let node = (name, p2p_node);
-    EldersInfo::new(iter::once(node).collect(), Prefix::default(), 0)
+    EldersInfo::new(iter::once(node).collect(), Prefix::default())
 }

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1233,7 +1233,7 @@ impl Approved {
 
         let src = SrcLocation::Section(*self.shared_state.our_prefix());
         let dst = DstLocation::Node(*details.pub_id.name());
-        let content = Variant::Relocate(Box::new(details));
+        let content = Variant::Relocate(details);
 
         self.send_routing_message(core, src, dst, content, Some(knowledge_index))
     }
@@ -1668,7 +1668,7 @@ impl Approved {
         let src = SrcLocation::Section(self.genesis_prefix_info.elders_info.prefix);
         let dst = DstLocation::Node(*p2p_node.name());
 
-        let variant = Variant::NodeApproval(Box::new(self.genesis_prefix_info.clone()));
+        let variant = Variant::NodeApproval(self.genesis_prefix_info.clone());
         let their_knowledge =
             their_knowledge.and_then(|key| self.shared_state.our_history.index_of(&key));
 
@@ -1699,7 +1699,7 @@ impl Approved {
             .adults_and_infants_p2p_nodes()
             .cloned()
             .filter_map(|recipient| {
-                let variant = Variant::GenesisUpdate(Box::new(self.genesis_prefix_info.clone()));
+                let variant = Variant::GenesisUpdate(self.genesis_prefix_info.clone());
                 let dst = DstLocation::Node(*recipient.name());
                 let proof_start_index = self
                     .shared_state

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -562,7 +562,7 @@ impl Approved {
         elders_info: EldersInfo,
         src_key: bls::PublicKey,
     ) -> Result<()> {
-        if self.shared_state.sections.is_new_neighbour(&elders_info) {
+        if !self.shared_state.sections.has_key(&src_key) {
             self.vote_for_event(AccumulatingEvent::NeighbourInfo(elders_info, src_key));
         } else {
             trace!("Ignore not new neighbour neighbour_info: {:?}", elders_info);

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -539,6 +539,7 @@ impl Approved {
                 MessageHash::from_bytes(&bounced_msg_bytes),
                 sender
             );
+            return;
         }
 
         trace!(
@@ -548,7 +549,7 @@ impl Approved {
             sender,
         );
 
-        // First send parsec gossip to update the peer, the resend the message itself. If the
+        // First send parsec gossip to update the peer, then resend the message itself. If the
         // messages arrive in the same order they were sent, the gossip should update the peer so
         // they will then be able to handle the resent message. If not, the peer will bounce the
         // message again.

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -10,7 +10,7 @@ use crate::{
     core::Core,
     error::Result,
     id::{FullId, P2pNode},
-    messages::{BootstrapResponse, Message, MessageAction, Variant, VerifyStatus},
+    messages::{BootstrapResponse, Message, MessageStatus, Variant, VerifyStatus},
     relocation::{RelocatePayload, SignedRelocateDetails},
     section::EldersInfo,
     time::Duration,
@@ -61,14 +61,14 @@ impl Bootstrapping {
         }
     }
 
-    pub fn decide_message_action(&self, msg: &Message) -> Result<MessageAction> {
+    pub fn decide_message_status(&self, msg: &Message) -> Result<MessageStatus> {
         match msg.variant {
             Variant::BootstrapResponse(_) | Variant::Bounce { .. } => {
                 verify_message(msg)?;
-                Ok(MessageAction::Handle)
+                Ok(MessageStatus::Useful)
             }
 
-            Variant::NeighbourInfo { .. } | Variant::UserMessage(_) => Ok(MessageAction::Bounce),
+            Variant::NeighbourInfo { .. } | Variant::UserMessage(_) => Ok(MessageStatus::Unknown),
 
             Variant::NodeApproval(_)
             | Variant::GenesisUpdate(_)
@@ -79,7 +79,7 @@ impl Bootstrapping {
             | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
-            | Variant::Ping => Ok(MessageAction::Discard),
+            | Variant::Ping => Ok(MessageStatus::Useless),
         }
     }
 

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -79,7 +79,7 @@ impl Bootstrapping {
             | Variant::MessageSignature(_)
             | Variant::BootstrapRequest(_)
             | Variant::JoinRequest(_)
-            | Variant::MemberKnowledge { .. }
+            | Variant::ParsecPoke(_)
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
             | Variant::Ping

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -64,7 +64,7 @@ impl Bootstrapping {
 
     pub fn decide_message_status(&self, msg: &Message) -> Result<MessageStatus> {
         match msg.variant {
-            Variant::BootstrapResponse(_) | Variant::Bounce { .. } => {
+            Variant::BootstrapResponse(_) => {
                 verify_message(msg)?;
                 Ok(MessageStatus::Useful)
             }
@@ -80,7 +80,8 @@ impl Bootstrapping {
             | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
-            | Variant::Ping => Ok(MessageStatus::Useless),
+            | Variant::Ping
+            | Variant::BouncedUnknownMessage { .. } => Ok(MessageStatus::Useless),
         }
     }
 

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -108,7 +108,10 @@ impl Bootstrapping {
         }
 
         match response {
-            BootstrapResponse::Join(elders_info) => {
+            BootstrapResponse::Join {
+                elders_info,
+                section_key,
+            } => {
                 info!(
                     "Joining a section {:?} (given by {:?})",
                     elders_info, sender
@@ -117,6 +120,7 @@ impl Bootstrapping {
                 let relocate_payload = self.join_section(core, &elders_info)?;
                 Ok(Some(JoinParams {
                     elders_info,
+                    section_key,
                     relocate_payload,
                     msg_backlog: mem::take(&mut self.msg_backlog),
                 }))
@@ -197,6 +201,7 @@ impl Bootstrapping {
 
 pub struct JoinParams {
     pub elders_info: EldersInfo,
+    pub section_key: bls::PublicKey,
     pub relocate_payload: Option<RelocatePayload>,
     pub msg_backlog: Vec<QueuedMessage>,
 }

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -69,7 +69,9 @@ impl Bootstrapping {
                 Ok(MessageStatus::Useful)
             }
 
-            Variant::NeighbourInfo { .. } | Variant::UserMessage(_) => Ok(MessageStatus::Unknown),
+            Variant::NeighbourInfo { .. }
+            | Variant::UserMessage(_)
+            | Variant::BouncedUntrustedMessage(_) => Ok(MessageStatus::Unknown),
 
             Variant::NodeApproval(_)
             | Variant::GenesisUpdate(_)

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -68,16 +68,15 @@ impl Bootstrapping {
                 Ok(MessageAction::Handle)
             }
 
-            Variant::NeighbourInfo { .. }
-            | Variant::UserMessage(_)
-            | Variant::NodeApproval(_)
+            Variant::NeighbourInfo { .. } | Variant::UserMessage(_) => Ok(MessageAction::Bounce),
+
+            Variant::NodeApproval(_)
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
             | Variant::MessageSignature(_)
             | Variant::BootstrapRequest(_)
-            | Variant::JoinRequest(_) => Ok(MessageAction::Bounce),
-
-            Variant::MemberKnowledge { .. }
+            | Variant::JoinRequest(_)
+            | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
             | Variant::Ping => Ok(MessageAction::Discard),

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -84,7 +84,7 @@ impl Joining {
                 Ok(MessageStatus::Useful)
             }
 
-            Variant::BootstrapResponse(BootstrapResponse::Join(_)) | Variant::Bounce { .. } => {
+            Variant::BootstrapResponse(BootstrapResponse::Join(_)) => {
                 verify_message(msg, None)?;
                 Ok(MessageStatus::Useful)
             }
@@ -93,7 +93,8 @@ impl Joining {
             | Variant::UserMessage(_)
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
-            | Variant::MessageSignature(_) => Ok(MessageStatus::Unknown),
+            | Variant::MessageSignature(_)
+            | Variant::BouncedUnknownMessage { .. } => Ok(MessageStatus::Unknown),
 
             Variant::BootstrapRequest(_)
             | Variant::BootstrapResponse(_)

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -94,6 +94,7 @@ impl Joining {
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
             | Variant::MessageSignature(_)
+            | Variant::BouncedUntrustedMessage(_)
             | Variant::BouncedUnknownMessage { .. } => Ok(MessageStatus::Unknown),
 
             Variant::BootstrapRequest(_)

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -89,12 +89,12 @@ impl Joining {
             | Variant::UserMessage(_)
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
-            | Variant::MessageSignature(_)
-            | Variant::BootstrapRequest(_)
-            | Variant::BootstrapResponse(_)
-            | Variant::JoinRequest(_) => Ok(MessageAction::Bounce),
+            | Variant::MessageSignature(_) => Ok(MessageAction::Bounce),
 
-            Variant::MemberKnowledge { .. }
+            Variant::BootstrapRequest(_)
+            | Variant::BootstrapResponse(_)
+            | Variant::JoinRequest(_)
+            | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
             | Variant::Ping => Ok(MessageAction::Discard),

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -100,7 +100,7 @@ impl Joining {
             Variant::BootstrapRequest(_)
             | Variant::BootstrapResponse(_)
             | Variant::JoinRequest(_)
-            | Variant::MemberKnowledge { .. }
+            | Variant::ParsecPoke(_)
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
             | Variant::Ping => Ok(MessageStatus::Useless),

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -12,7 +12,7 @@ use crate::{
     event::Connected,
     id::P2pNode,
     messages::{
-        self, BootstrapResponse, JoinRequest, Message, MessageAction, Variant, VerifyStatus,
+        self, BootstrapResponse, JoinRequest, Message, MessageStatus, Variant, VerifyStatus,
     },
     relocation::RelocatePayload,
     section::EldersInfo,
@@ -64,7 +64,7 @@ impl Joining {
         }
     }
 
-    pub fn decide_message_action(&self, msg: &Message) -> Result<MessageAction> {
+    pub fn decide_message_status(&self, msg: &Message) -> Result<MessageStatus> {
         match msg.variant {
             Variant::NodeApproval(_) => {
                 match &self.join_type {
@@ -77,19 +77,19 @@ impl Joining {
                         // handle it.
                     }
                 }
-                Ok(MessageAction::Handle)
+                Ok(MessageStatus::Useful)
             }
 
             Variant::BootstrapResponse(BootstrapResponse::Join(_)) | Variant::Bounce { .. } => {
                 verify_message(msg, None)?;
-                Ok(MessageAction::Handle)
+                Ok(MessageStatus::Useful)
             }
 
             Variant::NeighbourInfo { .. }
             | Variant::UserMessage(_)
             | Variant::GenesisUpdate(_)
             | Variant::Relocate(_)
-            | Variant::MessageSignature(_) => Ok(MessageAction::Bounce),
+            | Variant::MessageSignature(_) => Ok(MessageStatus::Unknown),
 
             Variant::BootstrapRequest(_)
             | Variant::BootstrapResponse(_)
@@ -97,7 +97,7 @@ impl Joining {
             | Variant::MemberKnowledge { .. }
             | Variant::ParsecRequest(..)
             | Variant::ParsecResponse(..)
-            | Variant::Ping => Ok(MessageAction::Discard),
+            | Variant::Ping => Ok(MessageStatus::Useless),
         }
     }
 

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -19,7 +19,6 @@ use crate::{
     section::{EldersInfo, IndexedSecretKeyShare, SectionKeysProvider, SharedState},
     xor_space::{Prefix, XorName},
 };
-use itertools::Itertools;
 use mock_quic_p2p::Network;
 use rand::Rng;
 use std::{collections::BTreeMap, net::SocketAddr};
@@ -125,16 +124,11 @@ impl Env {
     }
 
     fn accumulate_message(&self, content: PlainMessage) -> Message {
-        self.elders
-            .iter()
-            .map(|elder| to_accumulating_message(elder, content.clone()).unwrap())
-            .fold1(|mut msg0, msg1| {
-                msg0.add_signature_shares(msg1);
-                msg0
-            })
-            .expect("there are no messages to accumulate")
-            .combine_signatures()
-            .expect("failed to combine signatures")
+        test_utils::accumulate_messages(
+            self.elders
+                .iter()
+                .map(|elder| to_accumulating_message(elder, content.clone()).unwrap()),
+        )
     }
 }
 

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -42,7 +42,7 @@ impl Env {
         let network = Network::new();
 
         let (elders_info, full_ids) =
-            test_utils::create_elders_info(&mut rng, &network, ELDER_SIZE, 0);
+            test_utils::create_elders_info(&mut rng, &network, ELDER_SIZE);
         let elders = create_elders(&mut rng, elders_info.clone(), full_ids);
 
         let public_key_set = elders[0].section_keys_provider.public_key_set().clone();
@@ -82,11 +82,7 @@ impl Env {
     }
 
     fn perform_elders_change(&mut self) {
-        let elders_info = EldersInfo::new(
-            self.elders[0].state.our_info().elders.clone(),
-            self.elders[0].state.our_info().prefix,
-            self.elders[0].state.our_info().version + 1,
-        );
+        let elders_info = self.elders[0].state.our_info().clone();
         let full_ids = self
             .elders
             .drain(..)

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -166,7 +166,7 @@ fn genesis_update_accumulating_message(
 
 fn to_message_signature(sender_id: &FullId, msg: AccumulatingMessage) -> Result<Message> {
     let variant = Variant::MessageSignature(Box::new(msg));
-    Message::single_src(sender_id, DstLocation::Direct, variant)
+    Message::single_src(sender_id, DstLocation::Direct, None, variant)
 }
 
 #[test]

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -204,7 +204,7 @@ fn create_genesis_update_accumulating_message(
         src: Prefix::default(),
         dst: DstLocation::Node(dst),
         dst_key: sender.section_keys_provider.public_key_set().public_key(),
-        variant: Variant::GenesisUpdate(Box::new(genesis_prefix_info)),
+        variant: Variant::GenesisUpdate(genesis_prefix_info),
     };
 
     to_accumulating_message(sender, content)

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -287,33 +287,15 @@ fn handle_genesis_update_allow_skipped_versions() {
 }
 
 #[test]
-fn genesis_update_message_successful_trust_check() {
-    let mut env = Env::new();
-    let genesis_prefix_info = env.genesis_prefix_info(1);
-    let msg = create_genesis_update_message_signature(
-        &env.elders[0],
-        *env.subject.name(),
-        genesis_prefix_info,
-    )
-    .unwrap();
-    test_utils::handle_message(&mut env.subject, env.elders[0].addr(), msg).unwrap();
-    assert_eq!(env.subject.parsec_last_version(), 1);
-}
-
-#[test]
-#[should_panic(expected = "Untrusted")]
-fn genesis_update_message_failed_trust_check_proof_too_new() {
+fn genesis_update_message_proof_too_new() {
     let mut env = Env::new();
     env.perform_elders_change();
 
     let genesis_prefix_info = env.genesis_prefix_info(1);
-    let msg = create_genesis_update_message_signature(
-        &env.elders[0],
-        *env.subject.name(),
-        genesis_prefix_info,
-    )
-    .unwrap();
-    test_utils::handle_message(&mut env.subject, env.elders[0].addr(), msg).unwrap();
+    env.handle_genesis_update(genesis_prefix_info).unwrap();
+
+    // The GenesisUpdate message is bounced so nothing is updated yet.
+    assert_eq!(env.subject.parsec_last_version(), 0);
 }
 
 #[test]
@@ -338,7 +320,6 @@ fn receive_unknown_message() {
 }
 
 #[test]
-#[ignore] // FIXME: there is a bug in Approved::verify_message that causes this test to fail
 fn receive_untrusted_message() {
     let mut env = Env::new();
 

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -264,14 +264,10 @@ impl Env {
                 .subject
                 .our_history()
                 .expect("subject is not approved")
-                .len() as u64
-                - 1,
+                .last_key_index(),
         };
 
-        // This event needs total consensus.
-        // FIXME: it doesn't anymore.
-        self.subject.vote_for_event(event.clone()).unwrap();
-        let _ = self.n_vote_for_gossipped(self.other_ids.len(), iter::once(event));
+        let _ = self.n_vote_for_gossipped(ACCUMULATE_VOTE_COUNT, iter::once(event));
     }
 
     // Accumulate `ParsecPrune` which should result in the parsec version increase.

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -157,6 +157,7 @@ impl Env {
         let message = Message::single_src(
             other_full_id,
             DstLocation::Direct,
+            None,
             Variant::ParsecRequest(parsec_version, request),
         )
         .unwrap();
@@ -511,7 +512,7 @@ fn send_genesis_update() {
         section_key: *env.subject.section_key().expect("subject is not approved"),
         parsec_version,
     });
-    let msg = Message::single_src(&adult1.full_id, DstLocation::Direct, variant).unwrap();
+    let msg = Message::single_src(&adult1.full_id, DstLocation::Direct, None, variant).unwrap();
     test_utils::handle_message(&mut env.subject, adult0.addr, msg).unwrap();
 
     // Create another `GenesisUpdate` and check the proof contains the updated version and does not
@@ -554,7 +555,7 @@ impl JoiningPeer {
 
     fn bootstrap_request(&self) -> Result<Message> {
         let variant = Variant::BootstrapRequest(*self.public_id().name());
-        Message::single_src(&self.full_id, DstLocation::Direct, variant)
+        Message::single_src(&self.full_id, DstLocation::Direct, None, variant)
     }
 
     fn expect_bootstrap_response(&self) -> BootstrapResponse {

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -539,7 +539,7 @@ fn handle_bootstrap() {
 
     let response = new_node.expect_bootstrap_response();
     match response {
-        BootstrapResponse::Join(elders_info) => assert_eq!(elders_info, env.elders_info),
+        BootstrapResponse::Join { elders_info, .. } => assert_eq!(elders_info, env.elders_info),
         BootstrapResponse::Rebootstrap(_) => panic!("Unexpected Rebootstrap response"),
     }
 }

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -53,8 +53,7 @@ impl Env {
         let mut rng = rng::new();
         let network = Network::new();
 
-        let (elders_info, full_ids) =
-            test_utils::create_elders_info(&mut rng, &network, sec_size, 0);
+        let (elders_info, full_ids) = test_utils::create_elders_info(&mut rng, &network, sec_size);
         let secret_key_set = generate_bls_threshold_secret_key(&mut rng, full_ids.len());
         let genesis_prefix_info = test_utils::create_genesis_prefix_info(
             elders_info.clone(),
@@ -294,7 +293,6 @@ impl Env {
                 .map(|node| (*node.public_id().name(), node.clone()))
                 .collect(),
             self.elders_info.prefix,
-            self.elders_info.version + 1,
         );
 
         self.updated_other_ids(new_elder_info)
@@ -305,7 +303,6 @@ impl Env {
         let new_elder_info = EldersInfo::new(
             self.elders_info.elders.clone(),
             old_info.new_elders_info.prefix,
-            old_info.new_elders_info.version + 1,
         );
         self.updated_other_ids(new_elder_info)
     }
@@ -336,11 +333,7 @@ impl Env {
             )))
             .collect();
 
-        let new_elders_info = EldersInfo::new(
-            new_member_map,
-            self.elders_info.prefix,
-            self.elders_info.version + 1,
-        );
+        let new_elders_info = EldersInfo::new(new_member_map, self.elders_info.prefix);
         self.updated_other_ids(new_elders_info)
     }
 

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -34,7 +34,6 @@ pub fn create_elders_info(
     rng: &mut MainRng,
     network: &Network,
     elder_size: usize,
-    version: u64,
 ) -> (EldersInfo, BTreeMap<XorName, FullId>) {
     let full_ids: BTreeMap<_, _> = (0..elder_size)
         .map(|_| {
@@ -51,7 +50,7 @@ pub fn create_elders_info(
         })
         .collect();
 
-    let elders_info = EldersInfo::new(members_map, Prefix::default(), version);
+    let elders_info = EldersInfo::new(members_map, Prefix::default());
     (elders_info, full_ids)
 }
 

--- a/src/node/tests/utils.rs
+++ b/src/node/tests/utils.rs
@@ -35,8 +35,7 @@ pub fn create_elders_info(
     let full_ids: BTreeMap<_, _> = (0..elder_size)
         .map(|_| {
             let id = FullId::gen(rng);
-            let name = *id.public_id().name();
-            (name, id)
+            (*id.public_id().name(), id)
         })
         .collect();
 

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -54,7 +54,7 @@ impl SignedRelocateDetails {
 
     pub fn relocate_details(&self) -> &RelocateDetails {
         if let Variant::Relocate(details) = &self.signed_msg.variant {
-            &**details
+            details
         } else {
             panic!("SignedRelocateDetails always contain Variant::Relocate")
         }

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -25,21 +25,14 @@ use std::{
 pub struct EldersInfo {
     /// The section's complete set of elders as a map from their name to a `P2pNode`.
     pub elders: BTreeMap<XorName, P2pNode>,
-    /// The section version. This increases monotonically whenever the set of elders changes.
-    /// Thus `EldersInfo`s with compatible prefixes always have different versions.
-    pub version: u64,
     /// The section prefix. It matches all the members' names.
     pub prefix: Prefix<XorName>,
 }
 
 impl EldersInfo {
     /// Creates a new `EldersInfo` with the given members, prefix and version.
-    pub fn new(elders: BTreeMap<XorName, P2pNode>, prefix: Prefix<XorName>, version: u64) -> Self {
-        Self {
-            elders,
-            version,
-            prefix,
-        }
+    pub fn new(elders: BTreeMap<XorName, P2pNode>, prefix: Prefix<XorName>) -> Self {
+        Self { elders, prefix }
     }
 
     pub(crate) fn elder_ids(&self) -> impl Iterator<Item = &PublicId> {
@@ -60,9 +53,8 @@ impl Debug for EldersInfo {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "EldersInfo {{ prefix: ({:b}), version: {}, elders: {{{}}} }}",
+            "EldersInfo {{ prefix: ({:b}), elders: {{{}}} }}",
             self.prefix,
-            self.version,
             self.elders.values().format(", "),
         )
     }

--- a/src/section/member_info.rs
+++ b/src/section/member_info.rs
@@ -101,10 +101,7 @@ impl MemberInfo {
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 pub enum MemberState {
     Joined,
-    Relocating {
-        // The latest index of our section key that this node knows about.
-        node_knowledge: u64,
-    },
+    Relocating,
     // TODO: we should track how long the node has been away. If longer than some limit, remove it
     // from the list. Otherwise we allow it to return.
     Left,

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -98,22 +98,6 @@ impl SectionMap {
         self.neighbours.keys().any(|prefix| prefix.matches(name))
     }
 
-    /// Returns `true` if the `EldersInfo` isn't known to us yet.
-    pub fn is_new(&self, elders_info: &EldersInfo) -> bool {
-        self.all()
-            .filter(|(_, known_info)| known_info.prefix.is_compatible(&elders_info.prefix))
-            .all(|(_, known_info)| known_info.version < elders_info.version)
-    }
-
-    /// Returns `true` if the `EldersInfo` isn't known to us yet and is a neighbouring section.
-    pub fn is_new_neighbour(&self, elders_info: &EldersInfo) -> bool {
-        let our_prefix = &self.our().prefix;
-        let other_prefix = &elders_info.prefix;
-
-        (our_prefix.is_neighbour(other_prefix) || other_prefix.is_extension_of(our_prefix))
-            && self.is_new(elders_info)
-    }
-
     /// Returns all elders from all known sections.
     pub fn elders(&self) -> impl Iterator<Item = &P2pNode> {
         self.all().flat_map(|(_, info)| info.elders.values())
@@ -226,8 +210,7 @@ impl SectionMap {
 
     #[cfg_attr(feature = "mock_base", allow(clippy::trivially_copy_pass_by_ref))]
     pub fn has_key(&self, key: &bls::PublicKey) -> bool {
-        // TODO: should we use `self.keys()` instead of `self.keys` ?
-        self.keys.values().any(|known_key| known_key == key)
+        self.keys().any(|(_, known_key)| known_key == key)
     }
 
     /// Returns the latest known key for the prefix that matches `name`.

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -58,15 +58,6 @@ impl SectionMap {
         &self.our
     }
 
-    /// Get `EldersInfo` of a known section with the given prefix.
-    pub fn get(&self, prefix: &Prefix<XorName>) -> Option<&EldersInfo> {
-        if *prefix == self.our.prefix {
-            Some(&self.our)
-        } else {
-            self.neighbours.get(prefix)
-        }
-    }
-
     /// Find neighbour section containing the given elder.
     pub fn find_neighbour_by_elder(&self, elder_name: &XorName) -> Option<&EldersInfo> {
         self.neighbours
@@ -409,6 +400,16 @@ impl SectionMap {
             known_elders: self.elders().count() as u64,
             total_elders,
             total_elders_exact,
+        }
+    }
+
+    /// Get `EldersInfo` of a known section with the given prefix.
+    #[cfg(any(test, feature = "mock_base"))]
+    pub fn get(&self, prefix: &Prefix<XorName>) -> Option<&EldersInfo> {
+        if *prefix == self.our.prefix {
+            Some(&self.our)
+        } else {
+            self.neighbours.get(prefix)
         }
     }
 

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -234,6 +234,7 @@ impl SectionMap {
 
     #[cfg_attr(feature = "mock_base", allow(clippy::trivially_copy_pass_by_ref))]
     pub fn has_key(&self, key: &bls::PublicKey) -> bool {
+        // TODO: should we use `self.keys()` instead of `self.keys` ?
         self.keys.values().any(|known_key| known_key == key)
     }
 
@@ -249,6 +250,7 @@ impl SectionMap {
 
     /// Returns the latest known key for the prefix that is compatible with `dst`.
     pub fn key_by_location(&self, dst: &DstLocation) -> Option<&bls::PublicKey> {
+        // TODO: should we use `self.keys()` instead of `self.keys` ?
         self.keys
             .iter()
             .find(|(prefix, _)| dst.is_compatible(prefix))

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -346,7 +346,7 @@ impl SectionMap {
     }
 
     /// Get `EldersInfo` of a known section with the given prefix.
-    #[cfg(any(test, feature = "mock_base"))]
+    #[cfg(test)]
     pub fn get(&self, prefix: &Prefix<XorName>) -> Option<&EldersInfo> {
         if *prefix == self.our.prefix {
             Some(&self.our)
@@ -610,9 +610,8 @@ mod tests {
                 )
             })
             .collect();
-        let version = 101;
 
-        EldersInfo::new(members, prefix, version)
+        EldersInfo::new(members, prefix)
     }
 
     fn gen_key(rng: &mut MainRng) -> bls::PublicKey {

--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -58,14 +58,6 @@ impl SectionMap {
         &self.our
     }
 
-    /// Find neighbour section containing the given elder.
-    pub fn find_neighbour_by_elder(&self, elder_name: &XorName) -> Option<&EldersInfo> {
-        self.neighbours
-            .iter()
-            .find(|(_, info)| info.elders.contains_key(elder_name))
-            .map(|(_, info)| info)
-    }
-
     /// Returns the known section that is closest to the given name, regardless of whether `name`
     /// belongs in that section or not.
     pub fn closest(&self, name: &XorName) -> (&Prefix<XorName>, &EldersInfo) {

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -285,7 +285,7 @@ impl SharedState {
             _ => self.sections.knowledge_by_location(target),
         };
 
-        self.our_history.slice_from(index)
+        self.our_history.slice(index..)
     }
 
     /// Check if we know this node but have not yet processed it.

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -176,15 +176,6 @@ impl SharedState {
         self.our_members.remove(pub_id.name())
     }
 
-    /// Find section which has member with the given id
-    pub fn find_section_by_member(&self, name: &XorName) -> Option<&EldersInfo> {
-        if self.our_members.contains(name) {
-            Some(self.sections.our())
-        } else {
-            self.sections.find_neighbour_by_elder(name)
-        }
-    }
-
     /// Returns the `P2pNode` of all non-elders in the section
     pub fn adults_and_infants_p2p_nodes(&self) -> impl Iterator<Item = &P2pNode> {
         self.our_members

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -462,7 +462,6 @@ impl SharedState {
             return;
         }
 
-        let relocating_state = self.create_relocating_state();
         let first_key = self.our_history.first_key();
 
         for member_info in self.our_members.joined_mut() {
@@ -498,7 +497,7 @@ impl SharedState {
                 "Change state to Relocating {}",
                 member_info.p2p_node.public_id()
             );
-            member_info.state = relocating_state;
+            member_info.state = MemberState::Relocating;
 
             let destination_key = *self.sections.key_by_name(&destination).unwrap_or(first_key);
             let details = RelocateDetails {
@@ -513,13 +512,6 @@ impl SharedState {
         }
 
         trace!("increment_age_counters: {:?}", self.our_members);
-    }
-
-    // Return a relocating state of a node relocating now.
-    // Ensure that node knows enough to trust node_knowledge proving index.
-    fn create_relocating_state(&self) -> MemberState {
-        let node_knowledge = self.sections.knowledge_by_section(self.our_prefix());
-        MemberState::Relocating { node_knowledge }
     }
 }
 

--- a/src/signature_accumulator.rs
+++ b/src/signature_accumulator.rs
@@ -126,6 +126,7 @@ mod tests {
                     Message::single_src(
                         id,
                         DstLocation::Direct,
+                        None,
                         Variant::MessageSignature(Box::new(
                             AccumulatingMessage::new(
                                 content.clone(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use bytes::Bytes;
 use hex_fmt::HexFmt;
-use std::{collections::HashMap, net::SocketAddr, slice};
+use std::{collections::HashMap, net::SocketAddr};
 
 use sending_targets_cache::SendingTargetsCache;
 
@@ -80,18 +80,6 @@ impl Transport {
 
         self.cache
             .insert_message(token, conn_infos, delivery_group_size);
-    }
-
-    pub fn send_message_to_target_later(
-        &mut self,
-        target: &SocketAddr,
-        content: Bytes,
-        timer: &Timer,
-        delay: Duration,
-    ) {
-        let token = self.next_msg_token();
-        self.send_later(*target, content, token, timer, delay);
-        self.cache.insert_message(token, slice::from_ref(target), 1);
     }
 
     pub fn send_message_to_client(&mut self, target: SocketAddr, msg: Bytes, token: Token) {

--- a/tests/mock_network/secure_message_delivery.rs
+++ b/tests/mock_network/secure_message_delivery.rs
@@ -72,7 +72,7 @@ fn message_with_invalid_security(fail_type: FailType) {
         P2pNode::new(*fake_full.public_id(), socket_addr),
     ))
     .collect();
-    let new_info = EldersInfo::new(members, our_prefix, 10001);
+    let new_info = EldersInfo::new(members, our_prefix);
 
     let content = PlainMessage {
         src: our_prefix,


### PR DESCRIPTION
This PR introduces the distinction between untrusted and unknown messages and implement their handling logic:

- **untrusted** message is a message which is otherwise valid but whose proof cannot be trusted by the recipient because none of the keys in it is known by them
- **unknown** message is a message that cannot be handled by the recipient in its present state. For example a message is meant to be handled by elders but the recipient is adult or infant.

When receiving untrusted message from section X, the node will wrap it in `Variant::BouncedUntrustedMessage`, set the `dst_key` field to the latest known key of X and send it back to X. Then X will extend the proof so that it starts at the given `dst_key` and send the message back.

When receiving unknown message, the handling differs by which stage the node is in:

- When in `Bootstrapping` or `Joining`, the message is put into backlog. Then when transitioning to `Approved`, all the backlogged messages are taken out and processed as if they were just received. This is OK, because these stages are only temporary and so messages will always remain in the backlog for only finite time (usually short).
- When in `Approved`, the node will wrap the message in `Variant::BouncedUnknownMessage`, include its current known parsec version and sent it to **its elders**. The elders then compare that parsec version with their parsec version to decide whether the node is lagging behind. If it is, they send it a parsec gossip and the original message itself, otherwise they do nothing. The idea is that the parsec gossip should cause the node to catch up and be able to process the message. This process might need to be repeated multiple times in case the node is lagging more than one parsec version behind or if the messages get reordered in flight, but those cases should be relatively rare and the process should always eventually terminate.

This PR also removes the remaining instances of the use of elders version.

Closes #2008 