### PR TITLE
chore(ci): Print CI machine disk space stats on failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -91,3 +91,9 @@ jobs:
       # Run tests.
       - shell: bash
         run: ./scripts/tests
+
+      # Print CI machine disk space stats if the tests fail
+      - name: Print CI Machine df Stats on Failure 
+        if: failure()
+        run: df -Ph
+        shell: bash


### PR DESCRIPTION
We have had a couple of unexplained CI failures recently and would
like to rule out low disk space being the cause.