### PR TITLE
fix/approved: sending DKG message to the participants directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", optional = true 
 parsec = { git = "https://github.com/maidsafe/parsec" }
 quic-p2p = { version = "~0.7.0", features = ["upnp"] }
 rand = "~0.7.3"
-# rand in the versions used by the threshold-crypto crate
 rand_core = "~0.5.1"
 rand_os = "~0.2.2"
 rand_xorshift = "~0.2.0"


### PR DESCRIPTION
The previous broadcasting DKG messages by send_routing_message
will send DKG messages to elders multiple times un-necessarily.
Also could send to non-participants elder during split.
This commit reduce the duplication of messages by sending to
participants directly. Also fixed a bug that DKG messages between
two non-elder participants not get transmitted previously.