### PR TITLE
Remove Genesis event handling

### DIFF
--- a/src/consensus/event_accumulator.rs
+++ b/src/consensus/event_accumulator.rs
@@ -115,13 +115,6 @@ impl EventAccumulator {
         proof_share: ProofShare,
         elders_info: &EldersInfo,
     ) -> Result<(AccumulatingEvent, Proof), AccumulationError> {
-        if let AccumulatingEvent::Genesis { .. } = event {
-            panic!(
-                "invalid event inserted into the event accumulator: {:?}",
-                event
-            );
-        }
-
         if self.accumulated_events.contains(&event) {
             self.vote_statuses.add_vote(&event, &voter_name);
             return Err(AccumulationError::AlreadyAccumulated);

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -57,11 +57,10 @@ impl ConsensusEngine {
         rng: &mut MainRng,
         full_id: FullId,
         elders_info: &EldersInfo,
-        serialised_state: Vec<u8>,
         parsec_version: u64,
     ) -> Self {
         let mut parsec_map = ParsecMap::default();
-        parsec_map.init(rng, full_id, elders_info, serialised_state, parsec_version);
+        parsec_map.init(rng, full_id, elders_info, parsec_version);
 
         Self {
             parsec_map,
@@ -87,26 +86,14 @@ impl ConsensusEngine {
     ) -> Option<(AccumulatingEvent, Option<Proof>)> {
         // TODO: implement Block::into_payload in parsec to avoid cloning.
         match block.payload() {
-            Observation::Genesis {
-                group,
-                related_info,
-            } => {
-                // FIXME: Validate with Chain info.
-
+            Observation::Genesis { group, .. } => {
                 trace!(
-                    "Parsec Genesis v{}: group: {:?}, related_info: {}",
+                    "Parsec Genesis v{}: group: {:?}",
                     self.parsec_map.last_version(),
                     group,
-                    related_info.len()
                 );
 
-                Some((
-                    AccumulatingEvent::Genesis {
-                        group: group.clone(),
-                        related_info: related_info.clone(),
-                    },
-                    None,
-                ))
+                Some((AccumulatingEvent::Genesis, None))
             }
             Observation::OpaquePayload(event) => {
                 let voter_name = *block.proofs().iter().next()?.public_id().name();
@@ -215,11 +202,10 @@ impl ConsensusEngine {
         rng: &mut MainRng,
         full_id: FullId,
         elders_info: &EldersInfo,
-        serialised_state: Vec<u8>,
         parsec_version: u64,
     ) {
         self.parsec_map
-            .init(rng, full_id, elders_info, serialised_state, parsec_version)
+            .init(rng, full_id, elders_info, parsec_version)
     }
 
     pub fn detect_unresponsive(&self, elders_info: &EldersInfo) -> BTreeSet<PublicId> {

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -214,10 +214,6 @@ impl ConsensusEngine {
         self.parsec_map.vote_for(event)
     }
 
-    pub fn add_force_gossip_peer(&mut self, peer_id: &PublicId) {
-        self.parsec_map.add_force_gossip_peer(peer_id)
-    }
-
     pub fn create_gossip(
         &mut self,
         version: u64,

--- a/src/consensus/network_event.rs
+++ b/src/consensus/network_event.rs
@@ -17,10 +17,7 @@ use crate::{
 };
 use hex_fmt::HexFmt;
 use serde::Serialize;
-use std::{
-    collections::BTreeSet,
-    fmt::{self, Debug, Formatter},
-};
+use std::fmt::{self, Debug, Formatter};
 
 /// Routing Network events
 // TODO: Box `SectionInfo`?
@@ -28,10 +25,7 @@ use std::{
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum AccumulatingEvent {
     /// Genesis event. This is output-only unsigned event.
-    Genesis {
-        group: BTreeSet<PublicId>,
-        related_info: Vec<u8>,
-    },
+    Genesis,
 
     /// Voted for node that is about to join our section
     Online {
@@ -161,15 +155,7 @@ impl AccumulatingEvent {
 impl Debug for AccumulatingEvent {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            Self::Genesis {
-                group,
-                related_info,
-            } => write!(
-                formatter,
-                "Genesis {{ group: {:?}, related_info: {:10} }}",
-                group,
-                HexFmt(related_info)
-            ),
+            Self::Genesis => write!(formatter, "Genesis"),
             Self::Online {
                 p2p_node,
                 previous_name,

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -236,12 +236,6 @@ impl ParsecMap {
         }
     }
 
-    pub fn add_force_gossip_peer(&mut self, peer_id: &PublicId) {
-        if let Some(ref mut parsec) = self.map.values_mut().last() {
-            parsec.add_force_gossip_peer(peer_id)
-        }
-    }
-
     pub fn gossip_recipients(&self) -> Vec<&PublicId> {
         self.map
             .values()

--- a/src/consensus/parsec.rs
+++ b/src/consensus/parsec.rs
@@ -122,10 +122,9 @@ impl ParsecMap {
         rng: &mut MainRng,
         full_id: FullId,
         elders_info: &EldersInfo,
-        serialised_state: Vec<u8>,
         parsec_version: u64,
     ) {
-        self.add_new(rng, full_id, elders_info, serialised_state, parsec_version);
+        self.add_new(rng, full_id, elders_info, parsec_version);
         self.remove_old();
     }
 
@@ -325,17 +324,10 @@ impl ParsecMap {
         rng: &mut MainRng,
         full_id: FullId,
         elders_info: &EldersInfo,
-        serialised_state: Vec<u8>,
         parsec_version: u64,
     ) {
         if let Entry::Vacant(entry) = self.map.entry(parsec_version) {
-            let _ = entry.insert(create(
-                rng,
-                full_id,
-                elders_info,
-                serialised_state,
-                parsec_version,
-            ));
+            let _ = entry.insert(create(rng, full_id, elders_info, parsec_version));
             self.size_counter = ParsecSizeCounter::default();
             info!("Init new Parsec v{}", parsec_version);
         }
@@ -357,7 +349,6 @@ fn create(
     rng: &mut MainRng,
     full_id: FullId,
     elders_info: &EldersInfo,
-    serialised_state: Vec<u8>,
     #[cfg_attr(not(feature = "mock"), allow(unused))] parsec_version: u64,
 ) -> Parsec {
     #[cfg(feature = "mock")]
@@ -372,7 +363,7 @@ fn create(
             hash,
             full_id,
             &elders_info.elder_ids().copied().collect(),
-            serialised_state,
+            vec![],
             ConsensusMode::Single,
             Box::new(rng::new_from(rng)),
         )
@@ -458,7 +449,7 @@ mod tests {
             })
             .collect();
         let elders_info = EldersInfo::new(members, Prefix::default());
-        parsec_map.init(rng, full_ids[0].clone(), &elders_info, vec![], version);
+        parsec_map.init(rng, full_ids[0].clone(), &elders_info, version);
     }
 
     fn create_parsec_map(rng: &mut MainRng, size: u64) -> ParsecMap {

--- a/src/mock/parsec/mod.rs
+++ b/src/mock/parsec/mod.rs
@@ -102,6 +102,7 @@ where
         }
     }
 
+    #[cfg(test)]
     pub fn our_pub_id(&self) -> &S::PublicId {
         self.our_id.public_id()
     }
@@ -130,16 +131,6 @@ where
                 ObservationHolder::new(observation, vote_id.public_id(), self.consensus_mode);
             let _ = state.vote(vote_id, holder);
         });
-    }
-
-    /// Add a gossip peer by force
-    pub fn add_force_gossip_peer(&mut self, peer_id: &S::PublicId) {
-        debug!(
-            "{:?}: adding a new gossip_peer {:?} by force.",
-            self.our_pub_id(),
-            peer_id
-        );
-        let _ = self.peer_list.insert(peer_id.clone());
     }
 
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &S::PublicId> {

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -94,12 +94,10 @@ impl Approved {
         parsec_version: u64,
         section_key_share: Option<SectionKeyShare>,
     ) -> Result<Self> {
-        let serialised_state = bincode::serialize(&shared_state)?;
         let consensus_engine = ConsensusEngine::new(
             &mut core.rng,
             core.full_id.clone(),
             shared_state.sections.our(),
-            serialised_state,
             parsec_version,
         );
 
@@ -727,6 +725,8 @@ impl Approved {
             return Ok(());
         }
 
+        info!("Promoted To Elder");
+
         core.msg_filter.reset();
 
         // TODO: verify `shared_state` !
@@ -734,8 +734,6 @@ impl Approved {
 
         self.reset_parsec(core, parsec_version)?;
         self.gossip_timer_token = Some(core.timer.schedule(self.consensus_engine.gossip_period()));
-
-        info!("Promoted To Elder");
 
         match self
             .section_keys_provider
@@ -790,6 +788,8 @@ impl Approved {
             debug!("ignore lagging notification - our key is ahead");
             return Ok(());
         }
+
+        trace!("Handle NotifyLagging");
 
         // TODO: verify `shared_state` !
         self.shared_state.update(shared_state)?;
@@ -1369,10 +1369,7 @@ impl Approved {
         debug!("Handle consensus on {:?}", event);
 
         match event {
-            AccumulatingEvent::Genesis {
-                group,
-                related_info,
-            } => self.handle_genesis_event(&group, &related_info)?,
+            AccumulatingEvent::Genesis { .. } => self.handle_genesis_event(),
             AccumulatingEvent::Online {
                 p2p_node,
                 previous_name,
@@ -1472,16 +1469,10 @@ impl Approved {
     //
     // The related_info is the serialized shared state that will be the starting
     // point when processing parsec data.
-    fn handle_genesis_event(
-        &mut self,
-        _group: &BTreeSet<PublicId>,
-        related_info: &[u8],
-    ) -> Result<()> {
-        let new_state = bincode::deserialize(related_info)?;
-
+    fn handle_genesis_event(&mut self) {
         // On split membership may need to be checked again.
         self.members_changed = true;
-        self.shared_state.update(new_state)
+        self.shared_state.handled_genesis_event = true;
     }
 
     fn handle_online_event(
@@ -2007,17 +1998,10 @@ impl Approved {
         let events = self.consensus_engine.prepare_reset(core.name());
         let events = self.filter_events_to_revote(events);
 
-        let serialised_state = if is_elder {
-            bincode::serialize(&self.shared_state)?
-        } else {
-            vec![]
-        };
-
         self.consensus_engine.finalise_reset(
             &mut core.rng,
             core.full_id.clone(),
             self.shared_state.our_info(),
-            serialised_state,
             new_parsec_version,
         );
 

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1824,27 +1824,11 @@ impl Approved {
         Ok(())
     }
 
-    fn add_force_gossip_peer(
-        &mut self,
-        elders_info: &EldersInfo,
-        old_prefix: Prefix,
-        was_elder: bool,
-    ) {
-        if was_elder
-            && (elders_info.prefix == old_prefix || elders_info.prefix.is_extension_of(&old_prefix))
-        {
-            for id in elders_info.elders.values() {
-                self.consensus_engine.add_force_gossip_peer(id.public_id());
-            }
-        }
-    }
-
     fn update_our_section(&mut self, core: &mut Core, details: SectionUpdateDetails) -> Result<()> {
         trace!("update our section with {:?}", details);
         info!("handle SectionInfo: {:?}", details.our.info.value);
 
         let old_prefix = *self.shared_state.our_prefix();
-        let was_elder = self.is_our_elder(core.id());
         let sibling_prefix = details.sibling.as_ref().map(|sibling| sibling.key.value.0);
 
         let mut old_shared_state = self.shared_state.clone();
@@ -1861,11 +1845,9 @@ impl Approved {
             .cloned()
             .collect();
 
-        self.add_force_gossip_peer(&details.our.info.value, old_prefix, was_elder);
         self.update_our_key_and_info(core, details.our.key, details.our.info.clone())?;
 
         if let Some(sibling) = details.sibling {
-            self.add_force_gossip_peer(&sibling.info.value, old_prefix, was_elder);
             self.shared_state.sections.update_keys(sibling.key);
             self.update_neighbour_info(core, sibling.info.clone());
 

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1216,7 +1216,7 @@ impl Approved {
 
     // Can we perform an action right now that can result in churn?
     fn is_ready_to_churn(&self) -> bool {
-        self.shared_state.handled_genesis_event && !self.churn_in_progress
+        !self.churn_in_progress
     }
 
     // Generate a new section info based on the current set of members and vote for it if it
@@ -1472,7 +1472,6 @@ impl Approved {
     fn handle_genesis_event(&mut self) {
         // On split membership may need to be checked again.
         self.members_changed = true;
-        self.shared_state.handled_genesis_event = true;
     }
 
     fn handle_online_event(
@@ -1828,7 +1827,6 @@ impl Approved {
         info!("handle ParsecPrune");
 
         self.reset_parsec(core, self.consensus_engine.parsec_version() + 1)?;
-        self.shared_state.handled_genesis_event = false;
         self.send_elders_update(core)?;
 
         Ok(())

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -143,22 +143,18 @@ impl Env {
 
         for event in events {
             for (full_id, secret_key_share) in self.other_ids.iter().take(count) {
-                let event = if event.needs_signature() {
-                    let index = self
-                        .elders_info
-                        .position(full_id.public_id().name())
-                        .unwrap();
-                    event
-                        .clone()
-                        .into_signed_network_event(&SectionKeyShare {
-                            public_key_set: self.public_key_set.clone(),
-                            index,
-                            secret_key_share: secret_key_share.clone(),
-                        })
-                        .unwrap()
-                } else {
-                    event.clone().into_unsigned_network_event()
-                };
+                let index = self
+                    .elders_info
+                    .position(full_id.public_id().name())
+                    .unwrap();
+                let event = event
+                    .clone()
+                    .into_network_event(&SectionKeyShare {
+                        public_key_set: self.public_key_set.clone(),
+                        index,
+                        secret_key_share: secret_key_share.clone(),
+                    })
+                    .unwrap();
 
                 info!("Vote as {:?} for event {:?}", full_id.public_id(), event);
                 parsec.vote_for_as(event.into_obs(), full_id);

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -53,6 +53,7 @@ impl SharedState {
         }
     }
 
+    // TODO: merge the new state into the old, don't replace it.
     pub fn update(&mut self, new: Self) -> Result<(), RoutingError> {
         if self.handled_genesis_event {
             error!("shared state update - genesis event already handled",);


### PR DESCRIPTION
This PR removes the logic around handling of the `Genesis` parsec event which isn't needed now we have the `Promote` message. This should have been part of the PR to address https://github.com/maidsafe/routing/issues/2126, but it must have been missed. 

Also remove the explicit gossip peer adding which isn't needed either, because now only elders participate in parsec gossip. 

