### PR TITLE
fix/approved: remove unnessary send_neighbour

### DIFF
--- a/src/section/section_map.rs
+++ b/src/section/section_map.rs
@@ -276,6 +276,7 @@ impl SectionMap {
     }
 
     /// Returns iterator over all neighbours sections.
+    #[cfg(any(test, feature = "mock_base"))]
     pub fn neighbours(&self) -> impl Iterator<Item = &EldersInfo> {
         self.neighbours.iter().map(|info| &info.value)
     }


### PR DESCRIPTION
also only vote their_knowledge for sibling section when being a
newly promoted elder during split