### PR TITLE
fix/testing: reduce memory usage for integration tests

### DIFF
--- a/tests/mock_network/mod.rs
+++ b/tests/mock_network/mod.rs
@@ -379,11 +379,9 @@ fn check_close_names_for_elder_size_nodes() {
 
 #[test]
 fn sibling_knowledge_update_after_split() {
-    let elder_size = 8;
-    let recommended_section_size = 8;
     let env = Environment::new(NetworkParams {
-        elder_size,
-        recommended_section_size,
+        elder_size: MIN_ELDER_SIZE,
+        recommended_section_size: MIN_ELDER_SIZE,
     });
 
     let mut nodes = create_connected_nodes_until_split(&env, &[1, 1]);


### PR DESCRIPTION
Occasionally, CI encounters `Over Buffer` issue.
It's noticed that each time such error happens, the `sibling_knowledge_update_after_split` test is running over time.
It turned out that test is the only test running with 8 elders (normally are 4) AND multiple sections.