### PR TITLE
Fix incorrect section key assigned to non-elders

### DIFF
--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -682,7 +682,12 @@ impl Approved {
         }
     }
 
-    pub fn handle_elders_update(&mut self, core: &mut Core, payload: EldersUpdate) -> Result<()> {
+    pub fn handle_elders_update(
+        &mut self,
+        core: &mut Core,
+        section_key: bls::PublicKey,
+        payload: EldersUpdate,
+    ) -> Result<()> {
         info!("Received {:?}", payload);
 
         // Receiving an old EldersUpdate or we are going to be promoted soon.
@@ -697,7 +702,7 @@ impl Approved {
 
         core.msg_filter.reset();
 
-        self.shared_state = SharedState::new(payload.elders_info);
+        self.shared_state = SharedState::new(section_key, payload.elders_info);
         self.section_keys_provider = SectionKeysProvider::new(None);
         self.reset_parsec(core, payload.parsec_version)
     }
@@ -2490,7 +2495,7 @@ fn create_first_shared_state(
     sk_share: &bls::SecretKeyShare,
     elders_info: Proven<EldersInfo>,
 ) -> Result<SharedState> {
-    let mut shared_state = SharedState::new(elders_info);
+    let mut shared_state = SharedState::new(elders_info.proof.public_key, elders_info);
 
     for p2p_node in shared_state.sections.our().elders.values() {
         let proof = create_first_proof(

--- a/src/node/tests/adult.rs
+++ b/src/node/tests/adult.rs
@@ -48,7 +48,8 @@ impl Env {
         let sk_set = consensus::generate_secret_key_set(&mut rng, ELDER_SIZE);
 
         let proven_elders_info = test_utils::create_proven(&sk_set, elders_info.clone());
-        let shared_state = SharedState::new(proven_elders_info);
+        let shared_state =
+            SharedState::new(proven_elders_info.proof.public_key, proven_elders_info);
 
         let (subject, ..) = Node::approved(
             NodeConfig {

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -68,7 +68,8 @@ impl Env {
         let (full_id, secret_key_share) = full_and_bls_ids.remove(0);
         let other_ids = full_and_bls_ids;
 
-        let mut shared_state = SharedState::new(proven_elders_info);
+        let mut shared_state =
+            SharedState::new(proven_elders_info.proof.public_key, proven_elders_info);
         for p2p_node in elders_info.elders.values() {
             let proof = test_utils::create_proof(
                 &sk_set,


### PR DESCRIPTION
When creating the new `SharedState` (on `EldersUpdate` or `NodeApproval`), we incorrectly used the previous section key instead of the latest one for the section chain. This made every `EldersUpdate` message bounce back as untrusted.