### PR TITLE
chore(deps): use updated crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rand = "~0.7.3"
 rand_core = "~0.5.1"
 rand_os = "~0.2.2"
 rand_xorshift = "~0.2.0"
-safe-network-signature-aggregator = { git = "https://github.com/maidsafe/safe-network-signature-aggregator" }
+bls-signature-aggregator = { git = "https://github.com/maidsafe/bls-signature-aggregator" }
 serde = { version = "1.0.111", features = ["derive" ,"rc"] }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 xor_name = "1"
@@ -53,6 +53,6 @@ mock_base = [
     "lazy_static",
     "bls/use-insecure-test-only-mock-crypto",
     "env_logger",
-    "safe-network-signature-aggregator/mock_timer"
+    "bls-signature-aggregator/mock_timer"
 ]
 mock = ["mock_base"]

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
     proven::Proven,
     vote::{Vote, VoteAccumulator},
 };
-pub use safe_network_signature_aggregator::{
+pub use bls_signature_aggregator::{
     AccumulationError, Proof, ProofShare, SignatureAggregator,
 };
 


### PR DESCRIPTION
Must only be merged once PR [here](https://github.com/maidsafe/safe-network-signature-aggregator/pull/7) updating signature aggregator crate name has been merged, and that repo's name has been updated.

