### PR TITLE
chore(deps): use updated bls_dkg crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.2.1"
 bls = { package = "threshold_crypto", version = "~0.4.0" }
-bls_dkg = { git = "https://github.com/maidsafe/BLS-DKG" }
+bls_dkg = "~0.1.0"
 bytes = "~0.5.4"
 crossbeam-channel = "~0.4.2"
 ctrlc = { version = "3", optional = true, features = ["termination"] }


### PR DESCRIPTION
Must first publish the [bls_dkg crate](https://crates.io/crates/bls_dkg) before merging this PR 

UPDATE: bls_dkg now published so was able to run CI - clippy errors are found, though they seem unrelated to anything changed in this PR. Attempted to resolve but suggested fixes are leading to further clippy errors so IMO it's best to leave a fix for a Rust dev working on this crate.
The 3 `Test` CI jobs have passed - merging